### PR TITLE
Cheese scheduler: include frozen bucket in startInventory

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -884,10 +884,18 @@ export function scheduleCheese({
     });
   });
 
-  // Starting inventory = effective cf for cheese (cheese_done credits live
-  // here too — same convention as dough). Frozen is unused for cheese
-  // (it's refrigerated, not frozen).
-  const startInventory = (inventoryReport?.effective?.coldFerment?.[CHEESE_SKU_KEY]) || 0;
+  // Starting inventory = effective cf + fr for cheese.
+  //   - cheese_done log entries credit `cf` (the dough convention we
+  //     reused for batches-on-hand).
+  //   - The Stock tab's manual count writes to BOTH `cf` and `fr` from a
+  //     single user-entered "on hand" number; for items without a real
+  //     dough/baking lifecycle (cheese, bulk dip, etc.) the value lands
+  //     in `fr`. Sum both so a manual stock count reflects in the
+  //     scheduler — otherwise scheduleCheese sees 0 and force-overdues
+  //     every upcoming batch even when the fridge is full.
+  const cfStart = inventoryReport?.effective?.coldFerment?.[CHEESE_SKU_KEY] || 0;
+  const frStart = inventoryReport?.effective?.frozen?.[CHEESE_SKU_KEY] || 0;
+  const startInventory = cfStart + frStart;
 
   // Walk forward. Track running stock. When stock would go negative on day i,
   // schedule a batch on the latest valid day inside the [i-MAX_LEAD, i-MIN_LEAD]


### PR DESCRIPTION
## The bug

Manager entered 220 dips of cheese on-hand via the Stock tab today. iCal feed still showed every upcoming cheese batch as **overdue**. Investigation: Stock-tab snapshots write the user-entered count to the `frozen` bucket for items without a real dough/baking lifecycle (cheese, bulk dip). `scheduleCheese` was only reading `coldFerment` → saw `startInventory = 0` → forced an overdue batch on every day with demand.

## The fix

One block in `scripts/inventory.js`: sum `cf + fr` for cheese inventory.

```js
const cfStart = inventoryReport?.effective?.coldFerment?.[CHEESE_SKU_KEY] || 0;
const frStart = inventoryReport?.effective?.frozen?.[CHEESE_SKU_KEY] || 0;
const startInventory = cfStart + frStart;
```

## Verified live

Worker already deployed (the iCal feed runs on the worker). Before/after on `/foh-cal.ics`:

- **Before:** 12 cheese events, 6 marked overdue
- **After:** 12 cheese events, **2 marked overdue**

The 2 remaining overdues are correct alerts:
- **5/7 (today):** TF needs 192 dips on 5/8. Optimal window for that batch was 5/3 → 5/6 — already past. Today is the late-but-still-doable backstop.
- **5/10:** Big demand spike on 5/11 (TF 96 + Fisher 240 + 32 FOH = 368). Needs 3 batches in the 5/8 → 5/9 window plus catch-up batches falling on 5/10.

## Test plan

- [ ] Merge → AEM auto-deploys static site (production app + planner pick up fix)
- [ ] After merge, refresh production app's Cheese tab — same overdue counts as iCal feed (2)
- [ ] On the FOH tablet, wait for myecalendar's next sync poll — 'overdue!' tag drops from 10 of 12 events

Generated with [Claude Code](https://claude.com/claude-code)