### PR TITLE
Add combined receiving entry and history page

### DIFF
--- a/static/deliveries/index.html
+++ b/static/deliveries/index.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Delivery History | Dangerous Pretzel Co.</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700;800&family=Paytone+One&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    [hidden] { display: none !important; }
+    body { font-family: 'Manrope', sans-serif; color: #1A1A1A; background: #1A1A1A; -webkit-font-smoothing: antialiased; }
+    a { color: inherit; text-decoration: none; }
+
+    /* ── Nav ── */
+    .site-nav { background: #1A1A1A; padding: 14px 5%; position: sticky; top: 0; z-index: 9999; border-bottom: 1px solid #333; }
+    .nav-wrap { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; }
+    .nav-logo { height: 46px; }
+    .nav-links { display: flex; align-items: center; gap: 20px; }
+    .nav-links a { color: #fff; font: 400 15px/1 'Manrope', sans-serif; transition: color 0.2s; }
+    .nav-links a:hover { color: #C41E1E; }
+
+    /* ── Hero ── */
+    .hero { background: #1A1A1A; text-align: center; padding: clamp(30px, 4vw, 50px) 5% clamp(16px, 3vw, 28px); }
+    .hero h1 { font: 900 italic clamp(32px, 5vw, 52px)/1.05 Georgia, serif; color: #fff; margin: 0; }
+
+    /* ── Layout ── */
+    .section-cream { background: #F5F0E8; padding: clamp(24px, 4vw, 48px) 5%; min-height: calc(100vh - 200px); }
+    .max-1000 { max-width: 1000px; margin: 0 auto; }
+
+    /* ── Filter bar ── */
+    .filter-card {
+      background: #fff;
+      border-radius: 10px;
+      padding: 20px 24px;
+      margin-bottom: 24px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+    }
+    .filter-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 14px;
+      margin-bottom: 14px;
+    }
+    .filter-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr auto;
+      gap: 14px;
+      align-items: end;
+    }
+    .field-group { display: flex; flex-direction: column; gap: 5px; }
+    .field-group label { font: 700 11px 'Manrope', sans-serif; color: #888; letter-spacing: 0.8px; text-transform: uppercase; }
+    .field-group input,
+    .field-group select {
+      font: 400 14px 'Manrope', sans-serif;
+      padding: 9px 12px;
+      border: 2px solid #e8e0d5;
+      border-radius: 6px;
+      background: #fff;
+      color: #1A1A1A;
+      outline: none;
+      transition: border-color 0.2s;
+      width: 100%;
+    }
+    .field-group input:focus,
+    .field-group select:focus { border-color: #C41E1E; }
+
+    .date-range { display: flex; align-items: center; gap: 8px; }
+    .date-range input { flex: 1; }
+    .date-range span { font: 400 12px 'Manrope', sans-serif; color: #aaa; flex-shrink: 0; }
+
+    .btn-clear {
+      background: #F5F0E8;
+      color: #888;
+      font: 700 13px 'Manrope', sans-serif;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      padding: 9px 18px;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: background 0.2s, color 0.2s;
+      height: fit-content;
+    }
+    .btn-clear:hover { background: #ece5d8; color: #1A1A1A; }
+
+    .results-meta {
+      font: 400 13px 'Manrope', sans-serif;
+      color: #888;
+      margin-bottom: 16px;
+    }
+    .results-meta strong { color: #1A1A1A; font-weight: 700; }
+
+    /* ── Status message ── */
+    .status-msg { font: 400 14px 'Manrope', sans-serif; color: #aaa; padding: 40px 0; text-align: center; }
+    .status-msg.error { color: #C41E1E; font-weight: 700; }
+
+    /* ── Delivery cards ── */
+    .delivery-card {
+      background: #fff;
+      border-radius: 10px;
+      padding: 0;
+      margin-bottom: 12px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+      overflow: hidden;
+      border-left: 4px solid #ddd;
+    }
+    .delivery-card.status-scheduled  { border-left-color: #C41E1E; }
+    .delivery-card.status-delivered  { border-left-color: #2a7a2a; }
+    .delivery-card.status-picked_up  { border-left-color: #2a7a2a; }
+    .delivery-card.status-cancelled  { border-left-color: #bbb; opacity: 0.65; }
+
+    /* Card header — always visible, click to expand */
+    .card-summary {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 16px 20px;
+      cursor: pointer;
+      user-select: none;
+    }
+    .card-summary:hover { background: #fafafa; }
+    .summary-customer { font: 700 15px 'Manrope', sans-serif; color: #1A1A1A; flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .summary-date { font: 400 13px 'Manrope', sans-serif; color: #888; white-space: nowrap; }
+    .summary-badges { display: flex; gap: 6px; flex-shrink: 0; }
+
+    .badge {
+      font: 700 11px 'Manrope', sans-serif;
+      padding: 3px 9px;
+      border-radius: 20px;
+      white-space: nowrap;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+    }
+    .badge-type { background: #F5F0E8; color: #555; }
+    .badge-status-scheduled { background: #fde8e8; color: #C41E1E; }
+    .badge-status-delivered  { background: #e6f4e6; color: #2a7a2a; }
+    .badge-status-picked_up  { background: #e6f4e6; color: #2a7a2a; }
+    .badge-status-cancelled  { background: #eee;    color: #999; }
+
+    .expand-icon {
+      color: #ccc;
+      font-size: 18px;
+      line-height: 1;
+      transition: transform 0.25s;
+      flex-shrink: 0;
+    }
+    .delivery-card.open .expand-icon { transform: rotate(180deg); }
+
+    /* Card body — expanded details */
+    .card-body {
+      border-top: 1px solid #f0f0f0;
+      padding: 16px 20px;
+      display: none;
+    }
+    .delivery-card.open .card-body { display: block; }
+
+    .detail-section { margin-bottom: 16px; }
+    .detail-section:last-child { margin-bottom: 0; }
+    .detail-label {
+      font: 700 11px 'Manrope', sans-serif;
+      color: #bbb;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      margin-bottom: 8px;
+    }
+
+    /* Line items */
+    .line-items { display: flex; flex-direction: column; gap: 4px; }
+    .line-item { font: 400 14px 'Manrope', sans-serif; color: #1A1A1A; display: flex; gap: 8px; }
+    .line-item .qty { color: #aaa; }
+    .line-item.empty { color: #ccc; font-style: italic; }
+
+    /* Barcodes */
+    .barcode-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+    .barcode-chip {
+      font-family: 'Courier New', monospace;
+      font-size: 12px;
+      background: #F5F0E8;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      padding: 3px 8px;
+      color: #555;
+    }
+    .empty-value { font: 400 13px 'Manrope', sans-serif; color: #ccc; font-style: italic; }
+
+    /* Confirmation */
+    .confirm-row { font: 400 13px 'Manrope', sans-serif; color: #555; margin-bottom: 4px; }
+    .confirm-row strong { color: #1A1A1A; }
+
+    /* No results */
+    .no-results {
+      text-align: center;
+      padding: 60px 20px;
+      font: 400 15px 'Manrope', sans-serif;
+      color: #aaa;
+    }
+    .no-results strong { color: #1A1A1A; display: block; font-size: 18px; margin-bottom: 8px; }
+
+    @media (max-width: 640px) {
+      .filter-grid { grid-template-columns: 1fr; }
+      .filter-row { grid-template-columns: 1fr; }
+      .summary-badges { display: none; }
+    }
+  </style>
+</head>
+<body>
+
+  <nav class="site-nav">
+    <div class="nav-wrap">
+      <a href="../v2/index.html"><img src="https://www.dangerouspretzel.com/images/logos/svg-logo.svg" alt="Dangerous Pretzel Co." class="nav-logo"></a>
+      <div class="nav-links">
+        <a href="../v2/menu.html">Menu</a>
+        <a href="../v2/catering.html">Catering</a>
+        <a href="../v2/index.html">Home</a>
+        <a href="../delivery-planner/index.html">Delivery Planner</a>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>DELIVERY HISTORY.</h1>
+  </section>
+
+  <div class="section-cream">
+    <div class="max-1000">
+
+      <!-- Filter bar -->
+      <div class="filter-card">
+        <div class="filter-grid">
+          <div class="field-group">
+            <label for="filter-customer">Customer</label>
+            <input type="text" id="filter-customer" placeholder="Search by name…" autocomplete="off">
+          </div>
+          <div class="field-group">
+            <label for="filter-status">Status</label>
+            <select id="filter-status">
+              <option value="">All statuses</option>
+              <option value="scheduled">Scheduled</option>
+              <option value="delivered">Delivered</option>
+              <option value="picked_up">Picked Up</option>
+              <option value="cancelled">Cancelled</option>
+            </select>
+          </div>
+          <div class="field-group">
+            <label for="filter-sku">Item / SKU</label>
+            <input type="text" id="filter-sku" placeholder="Search by product…" autocomplete="off">
+          </div>
+        </div>
+        <div class="filter-row">
+          <div class="field-group">
+            <label>From Date</label>
+            <input type="date" id="filter-date-from">
+          </div>
+          <div class="field-group">
+            <label>To Date</label>
+            <input type="date" id="filter-date-to">
+          </div>
+          <button class="btn-clear" id="clear-btn">Clear Filters</button>
+        </div>
+      </div>
+
+      <!-- Results count -->
+      <div id="results-meta" class="results-meta" hidden></div>
+
+      <!-- Status / loading -->
+      <div id="status-msg" class="status-msg">Loading deliveries…</div>
+
+      <!-- Results -->
+      <div id="results"></div>
+
+    </div>
+  </div>
+
+  <script type="module">
+    import { fetchLog } from '../../scripts/sheet-logger.js';
+
+    const LOG_PATH = '/dangpretz/delivery-planner';
+
+    // ── Delivery resolver (handles barcodes — copied from delivery planner) ──
+    function resolveDeliveriesFromLogs(logs) {
+      const byId = {};
+      if (!Array.isArray(logs)) return [];
+      logs.forEach((row, idx) => {
+        const id = row.deliveryId || `legacy-${row.timeStamp || idx}`;
+        if (row.action === 'delete') { delete byId[id]; return; }
+        if (row.action === 'barcodes') {
+          if (byId[id]) {
+            try { byId[id].barcodes = JSON.parse(row.barcodes || '[]'); } catch (_) { byId[id].barcodes = []; }
+          }
+          return;
+        }
+        if (row.action === 'confirm') {
+          if (byId[id]) {
+            byId[id].confirmation = {
+              confirmedBy:      row.confirmedBy || '',
+              confirmNote:      row.confirmNote || '',
+              confirmTimestamp: row.confirmTimestamp || row.timeStamp || '',
+            };
+            const t = (byId[id].type || 'delivery').toLowerCase();
+            byId[id].status = t === 'pickup' ? 'picked_up' : 'delivered';
+          }
+          return;
+        }
+        if (row.action === 'status') {
+          if (byId[id]) {
+            let s = row.status || 'scheduled';
+            if (s === 'ready_deliver' || s === 'ready_pickup') s = 'scheduled';
+            byId[id].status = s;
+          }
+          return;
+        }
+        if (row.action === 'update') {
+          const prevBarcodes     = byId[id] ? byId[id].barcodes     : undefined;
+          const prevConfirmation = byId[id] ? byId[id].confirmation : undefined;
+          byId[id] = { ...row, deliveryId: id };
+          if (prevBarcodes)     byId[id].barcodes     = prevBarcodes;
+          if (prevConfirmation) byId[id].confirmation = prevConfirmation;
+          let s = row.status || 'scheduled';
+          if (s === 'ready_deliver' || s === 'ready_pickup') s = 'scheduled';
+          byId[id].status = s;
+          return;
+        }
+        const prevBarcodes     = byId[id] ? byId[id].barcodes     : undefined;
+        const prevConfirmation = byId[id] ? byId[id].confirmation : undefined;
+        byId[id] = { ...row, deliveryId: id };
+        if (prevBarcodes)     byId[id].barcodes     = prevBarcodes;
+        if (prevConfirmation) byId[id].confirmation = prevConfirmation;
+        let s = byId[id].status || 'scheduled';
+        if (s === 'ready_deliver' || s === 'ready_pickup') s = 'scheduled';
+        byId[id].status = s;
+      });
+      // Sort newest first
+      return Object.values(byId).sort((a, b) => {
+        const d = (b.date || '').localeCompare(a.date || '');
+        return d !== 0 ? d : (b.timeStamp || '').localeCompare(a.timeStamp || '');
+      });
+    }
+
+    // ── State ────────────────────────────────────────────────────
+    let allDeliveries = [];
+
+    // ── DOM refs ─────────────────────────────────────────────────
+    const filterCustomer  = document.getElementById('filter-customer');
+    const filterStatus    = document.getElementById('filter-status');
+    const filterSku       = document.getElementById('filter-sku');
+    const filterDateFrom  = document.getElementById('filter-date-from');
+    const filterDateTo    = document.getElementById('filter-date-to');
+    const clearBtn        = document.getElementById('clear-btn');
+    const statusMsg       = document.getElementById('status-msg');
+    const resultsMeta     = document.getElementById('results-meta');
+    const resultsEl       = document.getElementById('results');
+
+    // ── Wire filters ─────────────────────────────────────────────
+    [filterCustomer, filterSku].forEach((el) => {
+      let t;
+      el.addEventListener('input', () => { clearTimeout(t); t = setTimeout(applyFilters, 250); });
+    });
+    [filterStatus, filterDateFrom, filterDateTo].forEach((el) => {
+      el.addEventListener('change', applyFilters);
+    });
+    clearBtn.addEventListener('click', () => {
+      filterCustomer.value = '';
+      filterStatus.value   = '';
+      filterSku.value      = '';
+      filterDateFrom.value = '';
+      filterDateTo.value   = '';
+      applyFilters();
+    });
+
+    // ── Load ─────────────────────────────────────────────────────
+    async function init() {
+      try {
+        const logs = await fetchLog(LOG_PATH);
+        allDeliveries = resolveDeliveriesFromLogs(logs);
+        statusMsg.hidden = true;
+        applyFilters();
+      } catch (err) {
+        statusMsg.className = 'status-msg error';
+        statusMsg.textContent = 'Failed to load deliveries: ' + (err.message || 'unknown error');
+      }
+    }
+
+    // ── Filter ───────────────────────────────────────────────────
+    function applyFilters() {
+      const customer  = filterCustomer.value.trim().toLowerCase();
+      const status    = filterStatus.value;
+      const sku       = filterSku.value.trim().toLowerCase();
+      const dateFrom  = filterDateFrom.value;
+      const dateTo    = filterDateTo.value;
+
+      const filtered = allDeliveries.filter((d) => {
+        if (customer) {
+          const name = (d.customer || d.location || '').toLowerCase();
+          if (!name.includes(customer)) return false;
+        }
+        if (status && d.status !== status) return false;
+        if (dateFrom && (d.date || '') < dateFrom) return false;
+        if (dateTo   && (d.date || '') > dateTo)   return false;
+        if (sku) {
+          let items = [];
+          try { items = JSON.parse(d.lineItems || '[]'); } catch (_) {}
+          const match = items.some((it) => (it.sku || '').toLowerCase().includes(sku));
+          if (!match) return false;
+        }
+        return true;
+      });
+
+      const total = allDeliveries.length;
+      const shown = filtered.length;
+      resultsMeta.hidden = false;
+      resultsMeta.innerHTML = `Showing <strong>${shown}</strong> of <strong>${total}</strong> deliveries`;
+
+      renderResults(filtered);
+    }
+
+    // ── Render ───────────────────────────────────────────────────
+    function renderResults(deliveries) {
+      if (deliveries.length === 0) {
+        resultsEl.innerHTML = `
+          <div class="no-results">
+            <strong>No deliveries found</strong>
+            Try adjusting your filters.
+          </div>`;
+        return;
+      }
+      resultsEl.innerHTML = deliveries.map((d) => renderCard(d)).join('');
+
+      // Wire expand/collapse
+      resultsEl.querySelectorAll('.card-summary').forEach((summary) => {
+        summary.addEventListener('click', () => {
+          summary.closest('.delivery-card').classList.toggle('open');
+        });
+      });
+    }
+
+    function renderCard(d) {
+      const customer  = escapeHtml(d.customer || d.location || '—');
+      const date      = escapeHtml(d.date || '—');
+      const type      = (d.type || 'delivery').toLowerCase();
+      const typeLabel = type === 'pickup' ? 'Pickup' : 'Delivery';
+      const status    = d.status || 'scheduled';
+      const statusLabels = { scheduled: 'Scheduled', delivered: 'Delivered', picked_up: 'Picked Up', cancelled: 'Cancelled' };
+      const statusLabel  = escapeHtml(statusLabels[status] || status);
+
+      // Line items
+      let items = [];
+      try { items = JSON.parse(d.lineItems || '[]'); } catch (_) {}
+      const itemsHtml = items.length
+        ? items.map((it) => `<div class="line-item"><span class="sku">${escapeHtml(it.sku || '—')}</span><span class="qty">× ${escapeHtml(String(it.quantity ?? '?'))}</span></div>`).join('')
+        : '<div class="line-item empty">No line items</div>';
+
+      // Barcodes
+      const barcodes = Array.isArray(d.barcodes) ? d.barcodes : [];
+      const barcodesHtml = barcodes.length
+        ? barcodes.map((b) => `<code class="barcode-chip">${escapeHtml(b)}</code>`).join('')
+        : '<span class="empty-value">None recorded</span>';
+
+      // Confirmation
+      let confirmHtml = '<span class="empty-value">Not yet confirmed</span>';
+      if (d.confirmation && d.confirmation.confirmedBy) {
+        const ts = d.confirmation.confirmTimestamp
+          ? new Date(d.confirmation.confirmTimestamp).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })
+          : '—';
+        confirmHtml = `
+          <div class="confirm-row"><strong>Confirmed by:</strong> ${escapeHtml(d.confirmation.confirmedBy)}</div>
+          <div class="confirm-row"><strong>At:</strong> ${escapeHtml(ts)}</div>
+          ${d.confirmation.confirmNote ? `<div class="confirm-row"><strong>Note:</strong> ${escapeHtml(d.confirmation.confirmNote)}</div>` : ''}`;
+      }
+
+      return `
+        <div class="delivery-card status-${escapeHtml(status)}">
+          <div class="card-summary">
+            <span class="summary-customer">${customer}</span>
+            <span class="summary-date">${date}</span>
+            <div class="summary-badges">
+              <span class="badge badge-type">${escapeHtml(typeLabel)}</span>
+              <span class="badge badge-status-${escapeHtml(status)}">${statusLabel}</span>
+            </div>
+            <span class="expand-icon">&#8964;</span>
+          </div>
+          <div class="card-body">
+            <div class="detail-section">
+              <div class="detail-label">Order Items</div>
+              <div class="line-items">${itemsHtml}</div>
+            </div>
+            <div class="detail-section">
+              <div class="detail-label">Barcodes</div>
+              <div class="barcode-chips">${barcodesHtml}</div>
+            </div>
+            <div class="detail-section">
+              <div class="detail-label">Confirmation</div>
+              ${confirmHtml}
+            </div>
+          </div>
+        </div>`;
+    }
+
+    // ── Utilities ─────────────────────────────────────────────────
+    function escapeHtml(s) {
+      return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/static/deliveries/index.html
+++ b/static/deliveries/index.html
@@ -549,7 +549,7 @@
       PRODUCTS.push(newProduct);
       try { await appendLog(LOG_PATH, { action: 'new_product', usFoodsCode: code, productName: name, packSize, requiresTemp: String(reqTemp), timeStamp: new Date().toISOString(), addedBy: nameInput.value.trim() }); } catch (_) {}
       newProductForm.hidden = true;
-      showToast('Product added — remember to add it to the code!', 'success');
+      showToast('Product saved and available for future sessions', 'success');
       showProductCard(newProduct);
     });
 
@@ -660,6 +660,20 @@
     }
 
     function buildSessions(logs) {
+      // Re-load any products added via the unknown-product form in past sessions
+      logs.filter((r) => r.action === 'new_product').forEach((r) => {
+        const exists = PRODUCTS.some((p) => p.usFoodsCode === r.usFoodsCode);
+        if (!exists && r.usFoodsCode && r.productName) {
+          PRODUCTS.push({
+            id:           `new-${r.usFoodsCode}`,
+            name:         r.productName,
+            packSize:     r.packSize    || '',
+            requiresTemp: r.requiresTemp === 'true',
+            usFoodsCode:  r.usFoodsCode,
+          });
+        }
+      });
+
       const map = {};
       logs.filter((r) => r.action === 'receive').forEach((r) => {
         const sid = r.sessionId || `legacy-${r.timeStamp}`;

--- a/static/deliveries/index.html
+++ b/static/deliveries/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Delivery History | Dangerous Pretzel Co.</title>
+  <title>Receiving History | Dangerous Pretzel Co.</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700;800&family=Paytone+One&display=swap" rel="stylesheet">
@@ -13,7 +13,6 @@
     body { font-family: 'Manrope', sans-serif; color: #1A1A1A; background: #1A1A1A; -webkit-font-smoothing: antialiased; }
     a { color: inherit; text-decoration: none; }
 
-    /* ── Nav ── */
     .site-nav { background: #1A1A1A; padding: 14px 5%; position: sticky; top: 0; z-index: 9999; border-bottom: 1px solid #333; }
     .nav-wrap { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; }
     .nav-logo { height: 46px; }
@@ -21,11 +20,9 @@
     .nav-links a { color: #fff; font: 400 15px/1 'Manrope', sans-serif; transition: color 0.2s; }
     .nav-links a:hover { color: #C41E1E; }
 
-    /* ── Hero ── */
     .hero { background: #1A1A1A; text-align: center; padding: clamp(30px, 4vw, 50px) 5% clamp(16px, 3vw, 28px); }
     .hero h1 { font: 900 italic clamp(32px, 5vw, 52px)/1.05 Georgia, serif; color: #fff; margin: 0; }
 
-    /* ── Layout ── */
     .section-cream { background: #F5F0E8; padding: clamp(24px, 4vw, 48px) 5%; min-height: calc(100vh - 200px); }
     .max-1000 { max-width: 1000px; margin: 0 auto; }
 
@@ -66,10 +63,6 @@
     .field-group input:focus,
     .field-group select:focus { border-color: #C41E1E; }
 
-    .date-range { display: flex; align-items: center; gap: 8px; }
-    .date-range input { flex: 1; }
-    .date-range span { font: 400 12px 'Manrope', sans-serif; color: #aaa; flex-shrink: 0; }
-
     .btn-clear {
       background: #F5F0E8;
       color: #888;
@@ -84,123 +77,100 @@
     }
     .btn-clear:hover { background: #ece5d8; color: #1A1A1A; }
 
-    .results-meta {
-      font: 400 13px 'Manrope', sans-serif;
-      color: #888;
-      margin-bottom: 16px;
-    }
+    .results-meta { font: 400 13px 'Manrope', sans-serif; color: #888; margin-bottom: 16px; }
     .results-meta strong { color: #1A1A1A; font-weight: 700; }
 
-    /* ── Status message ── */
     .status-msg { font: 400 14px 'Manrope', sans-serif; color: #aaa; padding: 40px 0; text-align: center; }
     .status-msg.error { color: #C41E1E; font-weight: 700; }
 
-    /* ── Delivery cards ── */
-    .delivery-card {
+    /* ── Session cards ── */
+    .session-card {
       background: #fff;
       border-radius: 10px;
-      padding: 0;
       margin-bottom: 12px;
       box-shadow: 0 1px 4px rgba(0,0,0,0.06);
       overflow: hidden;
-      border-left: 4px solid #ddd;
     }
-    .delivery-card.status-scheduled  { border-left-color: #C41E1E; }
-    .delivery-card.status-delivered  { border-left-color: #2a7a2a; }
-    .delivery-card.status-picked_up  { border-left-color: #2a7a2a; }
-    .delivery-card.status-cancelled  { border-left-color: #bbb; opacity: 0.65; }
 
-    /* Card header — always visible, click to expand */
-    .card-summary {
+    .session-summary {
       display: flex;
       align-items: center;
-      gap: 12px;
+      gap: 14px;
       padding: 16px 20px;
       cursor: pointer;
       user-select: none;
     }
-    .card-summary:hover { background: #fafafa; }
-    .summary-customer { font: 700 15px 'Manrope', sans-serif; color: #1A1A1A; flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .summary-date { font: 400 13px 'Manrope', sans-serif; color: #888; white-space: nowrap; }
-    .summary-badges { display: flex; gap: 6px; flex-shrink: 0; }
+    .session-summary:hover { background: #fafafa; }
 
+    .session-info { flex: 1; min-width: 0; }
+    .session-date { font: 700 15px 'Manrope', sans-serif; color: #1A1A1A; }
+    .session-meta { font: 400 12px 'Manrope', sans-serif; color: #888; margin-top: 2px; }
+
+    .session-badges { display: flex; gap: 6px; flex-shrink: 0; align-items: center; }
     .badge {
       font: 700 11px 'Manrope', sans-serif;
-      padding: 3px 9px;
+      padding: 3px 10px;
       border-radius: 20px;
       white-space: nowrap;
       text-transform: uppercase;
       letter-spacing: 0.3px;
     }
-    .badge-type { background: #F5F0E8; color: #555; }
-    .badge-status-scheduled { background: #fde8e8; color: #C41E1E; }
-    .badge-status-delivered  { background: #e6f4e6; color: #2a7a2a; }
-    .badge-status-picked_up  { background: #e6f4e6; color: #2a7a2a; }
-    .badge-status-cancelled  { background: #eee;    color: #999; }
+    .badge-supplier { background: #F5F0E8; color: #555; }
+    .badge-fail     { background: #fde8e8; color: #C41E1E; }
 
-    .expand-icon {
-      color: #ccc;
-      font-size: 18px;
-      line-height: 1;
-      transition: transform 0.25s;
-      flex-shrink: 0;
+    .item-count { font: 700 13px 'Manrope', sans-serif; color: #aaa; white-space: nowrap; }
+    .expand-icon { color: #ccc; font-size: 18px; line-height: 1; transition: transform 0.25s; flex-shrink: 0; }
+    .session-card.open .expand-icon { transform: rotate(180deg); }
+
+    /* ── Session body ── */
+    .session-body { border-top: 1px solid #f0f0f0; display: none; }
+    .session-card.open .session-body { display: block; }
+
+    .received-by-row {
+      padding: 10px 20px;
+      font: 400 13px 'Manrope', sans-serif;
+      color: #888;
+      border-bottom: 1px solid #f5f5f5;
+      background: #fafafa;
     }
-    .delivery-card.open .expand-icon { transform: rotate(180deg); }
+    .received-by-row strong { color: #555; }
 
-    /* Card body — expanded details */
-    .card-body {
-      border-top: 1px solid #f0f0f0;
-      padding: 16px 20px;
-      display: none;
+    /* ── Item rows ── */
+    .item-row {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 12px 20px;
+      border-bottom: 1px solid #f5f5f5;
     }
-    .delivery-card.open .card-body { display: block; }
+    .item-row:last-child { border-bottom: none; }
+    .item-row.temp-fail { background: #fffaf9; }
 
-    .detail-section { margin-bottom: 16px; }
-    .detail-section:last-child { margin-bottom: 0; }
-    .detail-label {
+    .item-name-wrap { flex: 1; min-width: 0; }
+    .item-name { font: 600 14px 'Manrope', sans-serif; color: #1A1A1A; }
+    .item-pack { font: 400 12px 'Manrope', sans-serif; color: #aaa; margin-top: 1px; }
+
+    .item-temp { font: 600 13px 'Manrope', sans-serif; white-space: nowrap; }
+    .item-temp.no-temp { color: #ccc; font-weight: 400; font-style: italic; }
+
+    .temp-badge {
+      display: inline-block;
       font: 700 11px 'Manrope', sans-serif;
-      color: #bbb;
-      letter-spacing: 1px;
-      text-transform: uppercase;
-      margin-bottom: 8px;
+      padding: 2px 8px;
+      border-radius: 10px;
+      margin-left: 5px;
     }
+    .temp-badge.pass { background: #e6f4e6; color: #2a7a2a; }
+    .temp-badge.fail { background: #fde8e8; color: #C41E1E; }
 
-    /* Line items */
-    .line-items { display: flex; flex-direction: column; gap: 4px; }
-    .line-item { font: 400 14px 'Manrope', sans-serif; color: #1A1A1A; display: flex; gap: 8px; }
-    .line-item .qty { color: #aaa; }
-    .line-item.empty { color: #ccc; font-style: italic; }
-
-    /* Barcodes */
-    .barcode-chips { display: flex; flex-wrap: wrap; gap: 6px; }
-    .barcode-chip {
-      font-family: 'Courier New', monospace;
-      font-size: 12px;
-      background: #F5F0E8;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      padding: 3px 8px;
-      color: #555;
-    }
-    .empty-value { font: 400 13px 'Manrope', sans-serif; color: #ccc; font-style: italic; }
-
-    /* Confirmation */
-    .confirm-row { font: 400 13px 'Manrope', sans-serif; color: #555; margin-bottom: 4px; }
-    .confirm-row strong { color: #1A1A1A; }
-
-    /* No results */
-    .no-results {
-      text-align: center;
-      padding: 60px 20px;
-      font: 400 15px 'Manrope', sans-serif;
-      color: #aaa;
-    }
+    /* ── No results ── */
+    .no-results { text-align: center; padding: 60px 20px; font: 400 15px 'Manrope', sans-serif; color: #aaa; }
     .no-results strong { color: #1A1A1A; display: block; font-size: 18px; margin-bottom: 8px; }
 
     @media (max-width: 640px) {
       .filter-grid { grid-template-columns: 1fr; }
-      .filter-row { grid-template-columns: 1fr; }
-      .summary-badges { display: none; }
+      .filter-row  { grid-template-columns: 1fr; }
+      .session-badges { display: none; }
     }
   </style>
 </head>
@@ -219,32 +189,34 @@
   </nav>
 
   <section class="hero">
-    <h1>DELIVERY HISTORY.</h1>
+    <h1>RECEIVING HISTORY.</h1>
   </section>
 
   <div class="section-cream">
     <div class="max-1000">
 
-      <!-- Filter bar -->
       <div class="filter-card">
         <div class="filter-grid">
           <div class="field-group">
-            <label for="filter-customer">Customer</label>
-            <input type="text" id="filter-customer" placeholder="Search by name…" autocomplete="off">
+            <label for="filter-product">Product</label>
+            <input type="text" id="filter-product" placeholder="Search by product name…" autocomplete="off">
           </div>
           <div class="field-group">
-            <label for="filter-status">Status</label>
-            <select id="filter-status">
-              <option value="">All statuses</option>
-              <option value="scheduled">Scheduled</option>
-              <option value="delivered">Delivered</option>
-              <option value="picked_up">Picked Up</option>
-              <option value="cancelled">Cancelled</option>
+            <label for="filter-supplier">Supplier</label>
+            <select id="filter-supplier">
+              <option value="">All suppliers</option>
+              <option value="usfoods">US Foods</option>
+              <option value="sysco">Sysco</option>
             </select>
           </div>
           <div class="field-group">
-            <label for="filter-sku">Item / SKU</label>
-            <input type="text" id="filter-sku" placeholder="Search by product…" autocomplete="off">
+            <label for="filter-temp">Temperature</label>
+            <select id="filter-temp">
+              <option value="">All results</option>
+              <option value="pass">Pass only</option>
+              <option value="fail">Fail only</option>
+              <option value="checked">Temp checked</option>
+            </select>
           </div>
         </div>
         <div class="filter-row">
@@ -260,13 +232,8 @@
         </div>
       </div>
 
-      <!-- Results count -->
       <div id="results-meta" class="results-meta" hidden></div>
-
-      <!-- Status / loading -->
-      <div id="status-msg" class="status-msg">Loading deliveries…</div>
-
-      <!-- Results -->
+      <div id="status-msg" class="status-msg">Loading receiving records…</div>
       <div id="results"></div>
 
     </div>
@@ -275,94 +242,31 @@
   <script type="module">
     import { fetchLog } from '../../scripts/sheet-logger.js';
 
-    const LOG_PATH = '/dangpretz/delivery-planner';
+    const LOG_PATH = '/dangpretz/receiving';
 
-    // ── Delivery resolver (handles barcodes — copied from delivery planner) ──
-    function resolveDeliveriesFromLogs(logs) {
-      const byId = {};
-      if (!Array.isArray(logs)) return [];
-      logs.forEach((row, idx) => {
-        const id = row.deliveryId || `legacy-${row.timeStamp || idx}`;
-        if (row.action === 'delete') { delete byId[id]; return; }
-        if (row.action === 'barcodes') {
-          if (byId[id]) {
-            try { byId[id].barcodes = JSON.parse(row.barcodes || '[]'); } catch (_) { byId[id].barcodes = []; }
-          }
-          return;
-        }
-        if (row.action === 'confirm') {
-          if (byId[id]) {
-            byId[id].confirmation = {
-              confirmedBy:      row.confirmedBy || '',
-              confirmNote:      row.confirmNote || '',
-              confirmTimestamp: row.confirmTimestamp || row.timeStamp || '',
-            };
-            const t = (byId[id].type || 'delivery').toLowerCase();
-            byId[id].status = t === 'pickup' ? 'picked_up' : 'delivered';
-          }
-          return;
-        }
-        if (row.action === 'status') {
-          if (byId[id]) {
-            let s = row.status || 'scheduled';
-            if (s === 'ready_deliver' || s === 'ready_pickup') s = 'scheduled';
-            byId[id].status = s;
-          }
-          return;
-        }
-        if (row.action === 'update') {
-          const prevBarcodes     = byId[id] ? byId[id].barcodes     : undefined;
-          const prevConfirmation = byId[id] ? byId[id].confirmation : undefined;
-          byId[id] = { ...row, deliveryId: id };
-          if (prevBarcodes)     byId[id].barcodes     = prevBarcodes;
-          if (prevConfirmation) byId[id].confirmation = prevConfirmation;
-          let s = row.status || 'scheduled';
-          if (s === 'ready_deliver' || s === 'ready_pickup') s = 'scheduled';
-          byId[id].status = s;
-          return;
-        }
-        const prevBarcodes     = byId[id] ? byId[id].barcodes     : undefined;
-        const prevConfirmation = byId[id] ? byId[id].confirmation : undefined;
-        byId[id] = { ...row, deliveryId: id };
-        if (prevBarcodes)     byId[id].barcodes     = prevBarcodes;
-        if (prevConfirmation) byId[id].confirmation = prevConfirmation;
-        let s = byId[id].status || 'scheduled';
-        if (s === 'ready_deliver' || s === 'ready_pickup') s = 'scheduled';
-        byId[id].status = s;
-      });
-      // Sort newest first
-      return Object.values(byId).sort((a, b) => {
-        const d = (b.date || '').localeCompare(a.date || '');
-        return d !== 0 ? d : (b.timeStamp || '').localeCompare(a.timeStamp || '');
-      });
-    }
+    let allSessions = [];   // array of { sessionId, date, supplier, receivedBy, items[] }
+    let allItems    = [];   // flat list for filtering
 
-    // ── State ────────────────────────────────────────────────────
-    let allDeliveries = [];
-
-    // ── DOM refs ─────────────────────────────────────────────────
-    const filterCustomer  = document.getElementById('filter-customer');
-    const filterStatus    = document.getElementById('filter-status');
-    const filterSku       = document.getElementById('filter-sku');
-    const filterDateFrom  = document.getElementById('filter-date-from');
-    const filterDateTo    = document.getElementById('filter-date-to');
-    const clearBtn        = document.getElementById('clear-btn');
-    const statusMsg       = document.getElementById('status-msg');
-    const resultsMeta     = document.getElementById('results-meta');
-    const resultsEl       = document.getElementById('results');
+    const filterProduct  = document.getElementById('filter-product');
+    const filterSupplier = document.getElementById('filter-supplier');
+    const filterTemp     = document.getElementById('filter-temp');
+    const filterDateFrom = document.getElementById('filter-date-from');
+    const filterDateTo   = document.getElementById('filter-date-to');
+    const clearBtn       = document.getElementById('clear-btn');
+    const statusMsg      = document.getElementById('status-msg');
+    const resultsMeta    = document.getElementById('results-meta');
+    const resultsEl      = document.getElementById('results');
 
     // ── Wire filters ─────────────────────────────────────────────
-    [filterCustomer, filterSku].forEach((el) => {
-      let t;
-      el.addEventListener('input', () => { clearTimeout(t); t = setTimeout(applyFilters, 250); });
-    });
-    [filterStatus, filterDateFrom, filterDateTo].forEach((el) => {
+    let debounce;
+    filterProduct.addEventListener('input', () => { clearTimeout(debounce); debounce = setTimeout(applyFilters, 250); });
+    [filterSupplier, filterTemp, filterDateFrom, filterDateTo].forEach((el) => {
       el.addEventListener('change', applyFilters);
     });
     clearBtn.addEventListener('click', () => {
-      filterCustomer.value = '';
-      filterStatus.value   = '';
-      filterSku.value      = '';
+      filterProduct.value  = '';
+      filterSupplier.value = '';
+      filterTemp.value     = '';
       filterDateFrom.value = '';
       filterDateTo.value   = '';
       applyFilters();
@@ -372,131 +276,147 @@
     async function init() {
       try {
         const logs = await fetchLog(LOG_PATH);
-        allDeliveries = resolveDeliveriesFromLogs(logs);
+        buildSessions(Array.isArray(logs) ? logs : []);
         statusMsg.hidden = true;
         applyFilters();
       } catch (err) {
         statusMsg.className = 'status-msg error';
-        statusMsg.textContent = 'Failed to load deliveries: ' + (err.message || 'unknown error');
+        statusMsg.textContent = 'Failed to load records: ' + (err.message || 'unknown error');
       }
+    }
+
+    // Group log rows into sessions by sessionId, newest first
+    function buildSessions(logs) {
+      const sessionMap = {};
+      logs
+        .filter((r) => r.action === 'receive')
+        .forEach((r) => {
+          const sid = r.sessionId || `legacy-${r.timeStamp}`;
+          if (!sessionMap[sid]) {
+            sessionMap[sid] = {
+              sessionId:  sid,
+              date:       r.date || '',
+              supplier:   r.supplier || '',
+              receivedBy: r.receivedBy || '',
+              items:      [],
+            };
+          }
+          sessionMap[sid].items.push({
+            productName:  r.productName || '—',
+            packSize:     r.packSize    || '',
+            requiresTemp: r.requiresTemp === 'true',
+            temperature:  r.temperature !== '' ? parseFloat(r.temperature) : null,
+            tempPass:     r.tempPass === 'true' ? true : r.tempPass === 'false' ? false : null,
+            barcode:      r.barcode || '',
+          });
+          allItems.push({ ...r, sessionId: sid });
+        });
+
+      allSessions = Object.values(sessionMap).sort((a, b) => b.date.localeCompare(a.date) || b.sessionId.localeCompare(a.sessionId));
     }
 
     // ── Filter ───────────────────────────────────────────────────
     function applyFilters() {
-      const customer  = filterCustomer.value.trim().toLowerCase();
-      const status    = filterStatus.value;
-      const sku       = filterSku.value.trim().toLowerCase();
-      const dateFrom  = filterDateFrom.value;
-      const dateTo    = filterDateTo.value;
+      const product  = filterProduct.value.trim().toLowerCase();
+      const supplier = filterSupplier.value.toLowerCase();
+      const temp     = filterTemp.value;
+      const dateFrom = filterDateFrom.value;
+      const dateTo   = filterDateTo.value;
 
-      const filtered = allDeliveries.filter((d) => {
-        if (customer) {
-          const name = (d.customer || d.location || '').toLowerCase();
-          if (!name.includes(customer)) return false;
-        }
-        if (status && d.status !== status) return false;
-        if (dateFrom && (d.date || '') < dateFrom) return false;
-        if (dateTo   && (d.date || '') > dateTo)   return false;
-        if (sku) {
-          let items = [];
-          try { items = JSON.parse(d.lineItems || '[]'); } catch (_) {}
-          const match = items.some((it) => (it.sku || '').toLowerCase().includes(sku));
-          if (!match) return false;
-        }
-        return true;
-      });
+      // Filter at the item level, then rebuild sessions from matching items
+      const filteredSessions = allSessions
+        .filter((s) => {
+          if (supplier && s.supplier.toLowerCase() !== supplier) return false;
+          if (dateFrom && s.date < dateFrom) return false;
+          if (dateTo   && s.date > dateTo)   return false;
+          return true;
+        })
+        .map((s) => {
+          const filteredItems = s.items.filter((item) => {
+            if (product && !item.productName.toLowerCase().includes(product)) return false;
+            if (temp === 'pass')    return item.tempPass === true;
+            if (temp === 'fail')    return item.tempPass === false;
+            if (temp === 'checked') return item.requiresTemp;
+            return true;
+          });
+          return { ...s, items: filteredItems };
+        })
+        .filter((s) => s.items.length > 0);
 
-      const total = allDeliveries.length;
-      const shown = filtered.length;
+      const totalItems   = allSessions.reduce((n, s) => n + s.items.length, 0);
+      const shownItems   = filteredSessions.reduce((n, s) => n + s.items.length, 0);
       resultsMeta.hidden = false;
-      resultsMeta.innerHTML = `Showing <strong>${shown}</strong> of <strong>${total}</strong> deliveries`;
+      resultsMeta.innerHTML = `Showing <strong>${shownItems}</strong> of <strong>${totalItems}</strong> received items across <strong>${filteredSessions.length}</strong> session${filteredSessions.length !== 1 ? 's' : ''}`;
 
-      renderResults(filtered);
+      renderResults(filteredSessions);
     }
 
     // ── Render ───────────────────────────────────────────────────
-    function renderResults(deliveries) {
-      if (deliveries.length === 0) {
-        resultsEl.innerHTML = `
-          <div class="no-results">
-            <strong>No deliveries found</strong>
-            Try adjusting your filters.
-          </div>`;
+    function renderResults(sessions) {
+      if (sessions.length === 0) {
+        resultsEl.innerHTML = `<div class="no-results"><strong>No records found</strong>Try adjusting your filters.</div>`;
         return;
       }
-      resultsEl.innerHTML = deliveries.map((d) => renderCard(d)).join('');
 
-      // Wire expand/collapse
-      resultsEl.querySelectorAll('.card-summary').forEach((summary) => {
-        summary.addEventListener('click', () => {
-          summary.closest('.delivery-card').classList.toggle('open');
-        });
+      resultsEl.innerHTML = sessions.map((s) => renderSession(s)).join('');
+
+      resultsEl.querySelectorAll('.session-summary').forEach((el) => {
+        el.addEventListener('click', () => el.closest('.session-card').classList.toggle('open'));
       });
     }
 
-    function renderCard(d) {
-      const customer  = escapeHtml(d.customer || d.location || '—');
-      const date      = escapeHtml(d.date || '—');
-      const type      = (d.type || 'delivery').toLowerCase();
-      const typeLabel = type === 'pickup' ? 'Pickup' : 'Delivery';
-      const status    = d.status || 'scheduled';
-      const statusLabels = { scheduled: 'Scheduled', delivered: 'Delivered', picked_up: 'Picked Up', cancelled: 'Cancelled' };
-      const statusLabel  = escapeHtml(statusLabels[status] || status);
+    function renderSession(s) {
+      const dateLabel    = s.date ? new Date(s.date + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' }) : '—';
+      const supplierLabel = supplierName(s.supplier);
+      const hasFail      = s.items.some((i) => i.tempPass === false);
+      const itemCount    = s.items.length;
 
-      // Line items
-      let items = [];
-      try { items = JSON.parse(d.lineItems || '[]'); } catch (_) {}
-      const itemsHtml = items.length
-        ? items.map((it) => `<div class="line-item"><span class="sku">${escapeHtml(it.sku || '—')}</span><span class="qty">× ${escapeHtml(String(it.quantity ?? '?'))}</span></div>`).join('')
-        : '<div class="line-item empty">No line items</div>';
-
-      // Barcodes
-      const barcodes = Array.isArray(d.barcodes) ? d.barcodes : [];
-      const barcodesHtml = barcodes.length
-        ? barcodes.map((b) => `<code class="barcode-chip">${escapeHtml(b)}</code>`).join('')
-        : '<span class="empty-value">None recorded</span>';
-
-      // Confirmation
-      let confirmHtml = '<span class="empty-value">Not yet confirmed</span>';
-      if (d.confirmation && d.confirmation.confirmedBy) {
-        const ts = d.confirmation.confirmTimestamp
-          ? new Date(d.confirmation.confirmTimestamp).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })
-          : '—';
-        confirmHtml = `
-          <div class="confirm-row"><strong>Confirmed by:</strong> ${escapeHtml(d.confirmation.confirmedBy)}</div>
-          <div class="confirm-row"><strong>At:</strong> ${escapeHtml(ts)}</div>
-          ${d.confirmation.confirmNote ? `<div class="confirm-row"><strong>Note:</strong> ${escapeHtml(d.confirmation.confirmNote)}</div>` : ''}`;
-      }
+      const itemsHtml = s.items.map((item) => {
+        const tempHtml = item.requiresTemp && item.temperature !== null
+          ? `<span class="item-temp">${item.temperature}°F<span class="temp-badge ${item.tempPass ? 'pass' : 'fail'}">${item.tempPass ? '✓ Pass' : '✗ Fail'}</span></span>`
+          : `<span class="item-temp no-temp">No temp req.</span>`;
+        return `
+          <div class="item-row${item.tempPass === false ? ' temp-fail' : ''}">
+            <div class="item-name-wrap">
+              <div class="item-name">${escapeHtml(item.productName)}</div>
+              ${item.packSize ? `<div class="item-pack">${escapeHtml(item.packSize)}</div>` : ''}
+            </div>
+            ${tempHtml}
+          </div>`;
+      }).join('');
 
       return `
-        <div class="delivery-card status-${escapeHtml(status)}">
-          <div class="card-summary">
-            <span class="summary-customer">${customer}</span>
-            <span class="summary-date">${date}</span>
-            <div class="summary-badges">
-              <span class="badge badge-type">${escapeHtml(typeLabel)}</span>
-              <span class="badge badge-status-${escapeHtml(status)}">${statusLabel}</span>
+        <div class="session-card">
+          <div class="session-summary">
+            <div class="session-info">
+              <div class="session-date">${escapeHtml(dateLabel)}</div>
+              <div class="session-meta">Received by ${escapeHtml(s.receivedBy || '—')}</div>
             </div>
+            <div class="session-badges">
+              <span class="badge badge-supplier">${escapeHtml(supplierLabel)}</span>
+              ${hasFail ? '<span class="badge badge-fail">Temp Fail</span>' : ''}
+            </div>
+            <span class="item-count">${itemCount} item${itemCount !== 1 ? 's' : ''}</span>
             <span class="expand-icon">&#8964;</span>
           </div>
-          <div class="card-body">
-            <div class="detail-section">
-              <div class="detail-label">Order Items</div>
-              <div class="line-items">${itemsHtml}</div>
+          <div class="session-body">
+            <div class="received-by-row">
+              <strong>Supplier:</strong> ${escapeHtml(supplierLabel)} &nbsp;·&nbsp;
+              <strong>Received by:</strong> ${escapeHtml(s.receivedBy || '—')} &nbsp;·&nbsp;
+              <strong>Date:</strong> ${escapeHtml(s.date || '—')}
             </div>
-            <div class="detail-section">
-              <div class="detail-label">Barcodes</div>
-              <div class="barcode-chips">${barcodesHtml}</div>
-            </div>
-            <div class="detail-section">
-              <div class="detail-label">Confirmation</div>
-              ${confirmHtml}
-            </div>
+            ${itemsHtml}
           </div>
         </div>`;
     }
 
-    // ── Utilities ─────────────────────────────────────────────────
+    function supplierName(val) {
+      if (!val) return '—';
+      if (val === 'usfoods') return 'US Foods';
+      if (val === 'sysco')   return 'Sysco';
+      return val;
+    }
+
     function escapeHtml(s) {
       return String(s)
         .replace(/&/g, '&amp;')

--- a/static/deliveries/index.html
+++ b/static/deliveries/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Receiving History | Dangerous Pretzel Co.</title>
+  <title>Receiving | Dangerous Pretzel Co.</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700;800&family=Paytone+One&display=swap" rel="stylesheet">
@@ -13,6 +13,7 @@
     body { font-family: 'Manrope', sans-serif; color: #1A1A1A; background: #1A1A1A; -webkit-font-smoothing: antialiased; }
     a { color: inherit; text-decoration: none; }
 
+    /* ── Nav ── */
     .site-nav { background: #1A1A1A; padding: 14px 5%; position: sticky; top: 0; z-index: 9999; border-bottom: 1px solid #333; }
     .nav-wrap { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; }
     .nav-logo { height: 46px; }
@@ -20,32 +21,22 @@
     .nav-links a { color: #fff; font: 400 15px/1 'Manrope', sans-serif; transition: color 0.2s; }
     .nav-links a:hover { color: #C41E1E; }
 
+    /* ── Hero ── */
     .hero { background: #1A1A1A; text-align: center; padding: clamp(30px, 4vw, 50px) 5% clamp(16px, 3vw, 28px); }
     .hero h1 { font: 900 italic clamp(32px, 5vw, 52px)/1.05 Georgia, serif; color: #fff; margin: 0; }
 
-    .section-cream { background: #F5F0E8; padding: clamp(24px, 4vw, 48px) 5%; min-height: calc(100vh - 200px); }
+    /* ── Sections ── */
+    .section-cream { background: #F5F0E8; padding: clamp(24px, 4vw, 48px) 5%; }
+    .section-dark  { background: #222; padding: clamp(24px, 4vw, 48px) 5%; border-top: 1px solid #333; }
+    .section-dark h2 { font: 900 italic clamp(20px, 3vw, 28px)/1.1 Georgia, serif; color: #fff; margin-bottom: 20px; }
+    .max-800  { max-width: 800px;  margin: 0 auto; }
     .max-1000 { max-width: 1000px; margin: 0 auto; }
 
-    /* ── Filter bar ── */
-    .filter-card {
-      background: #fff;
-      border-radius: 10px;
-      padding: 20px 24px;
-      margin-bottom: 24px;
-      box-shadow: 0 1px 4px rgba(0,0,0,0.07);
-    }
-    .filter-grid {
-      display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
-      gap: 14px;
-      margin-bottom: 14px;
-    }
-    .filter-row {
-      display: grid;
-      grid-template-columns: 1fr 1fr auto;
-      gap: 14px;
-      align-items: end;
-    }
+    /* ── Shared card ── */
+    .card { background: #fff; border-radius: 10px; padding: 24px; margin-bottom: 20px; box-shadow: 0 1px 4px rgba(0,0,0,0.07); }
+    .card-title { font: 700 13px 'Manrope', sans-serif; color: #999; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 16px; }
+
+    /* ── Form fields ── */
     .field-group { display: flex; flex-direction: column; gap: 5px; }
     .field-group label { font: 700 11px 'Manrope', sans-serif; color: #888; letter-spacing: 0.8px; text-transform: uppercase; }
     .field-group input,
@@ -62,115 +53,161 @@
     }
     .field-group input:focus,
     .field-group select:focus { border-color: #C41E1E; }
+    .date-display { font: 600 14px 'Manrope', sans-serif; color: #1A1A1A; padding: 9px 12px; background: #F5F0E8; border-radius: 6px; border: 2px solid transparent; }
 
-    .btn-clear {
-      background: #F5F0E8;
-      color: #888;
-      font: 700 13px 'Manrope', sans-serif;
-      border: 1px solid #ddd;
-      border-radius: 6px;
-      padding: 9px 18px;
-      cursor: pointer;
-      white-space: nowrap;
-      transition: background 0.2s, color 0.2s;
-      height: fit-content;
-    }
-    .btn-clear:hover { background: #ece5d8; color: #1A1A1A; }
+    /* ── Session header grid ── */
+    .session-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+    .session-grid .span-2 { grid-column: span 2; }
 
-    .results-meta { font: 400 13px 'Manrope', sans-serif; color: #888; margin-bottom: 16px; }
-    .results-meta strong { color: #1A1A1A; font-weight: 700; }
-
-    .status-msg { font: 400 14px 'Manrope', sans-serif; color: #aaa; padding: 40px 0; text-align: center; }
-    .status-msg.error { color: #C41E1E; font-weight: 700; }
-
-    /* ── Session cards ── */
-    .session-card {
+    /* ── Scan input ── */
+    .scan-input-wrap { margin-bottom: 12px; }
+    .scan-input-wrap input {
+      width: 100%;
+      font: 400 clamp(17px, 2vw, 21px)/1 'Manrope', sans-serif;
+      padding: 14px 18px;
+      border: 2px solid #e8e0d5;
+      border-radius: 8px;
       background: #fff;
-      border-radius: 10px;
-      margin-bottom: 12px;
-      box-shadow: 0 1px 4px rgba(0,0,0,0.06);
-      overflow: hidden;
+      color: #1A1A1A;
+      outline: none;
+      transition: border-color 0.2s;
     }
+    .scan-input-wrap input:focus { border-color: #C41E1E; }
+    .scan-input-wrap input:disabled { background: #f0ece6; color: #bbb; }
+    .scan-hint { font: 400 12px 'Manrope', sans-serif; color: #bbb; margin-top: 5px; }
 
-    .session-summary {
-      display: flex;
-      align-items: center;
-      gap: 14px;
-      padding: 16px 20px;
-      cursor: pointer;
-      user-select: none;
-    }
-    .session-summary:hover { background: #fafafa; }
+    /* ── Product card ── */
+    .product-card { background: #fff; border-radius: 10px; padding: 18px 22px; margin-bottom: 14px; box-shadow: 0 1px 4px rgba(0,0,0,0.07); border-left: 4px solid #C41E1E; }
+    .product-label { font: 700 11px 'Manrope', sans-serif; color: #bbb; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 5px; }
+    .product-name-display { font: 700 17px 'Manrope', sans-serif; color: #1A1A1A; display: block; margin-bottom: 3px; }
+    .product-pack-display { font: 400 13px 'Manrope', sans-serif; color: #aaa; display: block; margin-bottom: 14px; }
 
-    .session-info { flex: 1; min-width: 0; }
-    .session-date { font: 700 15px 'Manrope', sans-serif; color: #1A1A1A; }
-    .session-meta { font: 400 12px 'Manrope', sans-serif; color: #888; margin-top: 2px; }
-
-    .session-badges { display: flex; gap: 6px; flex-shrink: 0; align-items: center; }
-    .badge {
-      font: 700 11px 'Manrope', sans-serif;
-      padding: 3px 10px;
-      border-radius: 20px;
-      white-space: nowrap;
-      text-transform: uppercase;
-      letter-spacing: 0.3px;
-    }
-    .badge-supplier { background: #F5F0E8; color: #555; }
-    .badge-fail     { background: #fde8e8; color: #C41E1E; }
-
-    .item-count { font: 700 13px 'Manrope', sans-serif; color: #aaa; white-space: nowrap; }
-    .expand-icon { color: #ccc; font-size: 18px; line-height: 1; transition: transform 0.25s; flex-shrink: 0; }
-    .session-card.open .expand-icon { transform: rotate(180deg); }
-
-    /* ── Session body ── */
-    .session-body { border-top: 1px solid #f0f0f0; display: none; }
-    .session-card.open .session-body { display: block; }
-
-    .received-by-row {
-      padding: 10px 20px;
-      font: 400 13px 'Manrope', sans-serif;
-      color: #888;
-      border-bottom: 1px solid #f5f5f5;
-      background: #fafafa;
-    }
-    .received-by-row strong { color: #555; }
-
-    /* ── Item rows ── */
-    .item-row {
-      display: flex;
-      align-items: center;
-      gap: 14px;
-      padding: 12px 20px;
-      border-bottom: 1px solid #f5f5f5;
-    }
-    .item-row:last-child { border-bottom: none; }
-    .item-row.temp-fail { background: #fffaf9; }
-
-    .item-name-wrap { flex: 1; min-width: 0; }
-    .item-name { font: 600 14px 'Manrope', sans-serif; color: #1A1A1A; }
-    .item-pack { font: 400 12px 'Manrope', sans-serif; color: #aaa; margin-top: 1px; }
-
-    .item-temp { font: 600 13px 'Manrope', sans-serif; white-space: nowrap; }
-    .item-temp.no-temp { color: #ccc; font-weight: 400; font-style: italic; }
-
-    .temp-badge {
-      display: inline-block;
-      font: 700 11px 'Manrope', sans-serif;
-      padding: 2px 8px;
-      border-radius: 10px;
-      margin-left: 5px;
-    }
+    /* ── Temp ── */
+    .temp-field { margin-bottom: 14px; }
+    .temp-field > label { font: 700 11px 'Manrope', sans-serif; color: #888; letter-spacing: 0.8px; text-transform: uppercase; display: block; margin-bottom: 6px; }
+    .temp-input-wrap { display: flex; align-items: center; gap: 10px; }
+    .temp-input-wrap input { width: 130px; font: 400 19px 'Manrope', sans-serif; padding: 9px 12px; border: 2px solid #e8e0d5; border-radius: 6px; outline: none; transition: border-color 0.2s; }
+    .temp-input-wrap input:focus { border-color: #C41E1E; }
+    .temp-badge { font: 700 13px 'Manrope', sans-serif; padding: 5px 14px; border-radius: 20px; min-width: 76px; text-align: center; }
     .temp-badge.pass { background: #e6f4e6; color: #2a7a2a; }
     .temp-badge.fail { background: #fde8e8; color: #C41E1E; }
+    .temp-threshold { font: 400 11px 'Manrope', sans-serif; color: #ccc; margin-top: 5px; }
 
-    /* ── No results ── */
-    .no-results { text-align: center; padding: 60px 20px; font: 400 15px 'Manrope', sans-serif; color: #aaa; }
-    .no-results strong { color: #1A1A1A; display: block; font-size: 18px; margin-bottom: 8px; }
+    /* ── Buttons ── */
+    .btn-primary { background: #C41E1E; color: #fff; font: 700 14px 'Manrope', sans-serif; border: none; border-radius: 6px; padding: 12px 24px; cursor: pointer; transition: background 0.2s; width: 100%; }
+    .btn-primary:hover { background: #a01818; }
+    .btn-primary:disabled { background: #ccc; cursor: not-allowed; }
+    .btn-submit { background: #1A1A1A; color: #fff; font: 700 15px 'Manrope', sans-serif; border: none; border-radius: 8px; padding: 14px 32px; cursor: pointer; transition: background 0.2s; width: 100%; margin-top: 8px; }
+    .btn-submit:hover { background: #333; }
+    .btn-submit:disabled { background: #bbb; cursor: not-allowed; }
 
-    @media (max-width: 640px) {
-      .filter-grid { grid-template-columns: 1fr; }
-      .filter-row  { grid-template-columns: 1fr; }
-      .session-badges { display: none; }
+    /* ── New product form ── */
+    .new-product-form { background: #fff; border-radius: 10px; padding: 18px 22px; margin-bottom: 14px; box-shadow: 0 1px 4px rgba(0,0,0,0.07); border-left: 4px solid #f0a500; }
+    .new-product-header { display: flex; align-items: center; gap: 10px; margin-bottom: 5px; }
+    .new-product-title { font: 700 14px 'Manrope', sans-serif; color: #1A1A1A; }
+    .new-product-code { font: 600 12px 'Courier New', monospace; background: #F5F0E8; padding: 3px 8px; border-radius: 4px; color: #555; }
+    .new-product-hint { font: 400 13px 'Manrope', sans-serif; color: #888; margin-bottom: 14px; }
+    .new-product-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 12px; }
+    .checkbox-label { display: flex; align-items: center; gap: 8px; font: 600 13px 'Manrope', sans-serif; color: #555; margin-bottom: 14px; cursor: pointer; }
+    .checkbox-label input[type="checkbox"] { width: 16px; height: 16px; cursor: pointer; accent-color: #C41E1E; }
+
+    /* ── Product selector ── */
+    .product-selector { background: #fff; border-radius: 10px; padding: 18px 22px; margin-bottom: 14px; box-shadow: 0 1px 4px rgba(0,0,0,0.07); }
+    .product-selector > label { font: 700 11px 'Manrope', sans-serif; color: #888; letter-spacing: 0.8px; text-transform: uppercase; display: block; margin-bottom: 8px; }
+    .product-selector input { width: 100%; font: 400 14px 'Manrope', sans-serif; padding: 9px 12px; border: 2px solid #e8e0d5; border-radius: 6px; outline: none; margin-bottom: 10px; transition: border-color 0.2s; }
+    .product-selector input:focus { border-color: #C41E1E; }
+    .product-options { max-height: 260px; overflow-y: auto; border: 1px solid #eee; border-radius: 6px; }
+    .product-option { display: flex; justify-content: space-between; align-items: center; padding: 11px 14px; cursor: pointer; border-bottom: 1px solid #f5f5f5; transition: background 0.15s; gap: 12px; }
+    .product-option:last-child { border-bottom: none; }
+    .product-option:hover { background: #F5F0E8; }
+    .option-name { font: 600 13px 'Manrope', sans-serif; color: #1A1A1A; }
+    .option-pack { font: 400 12px 'Manrope', sans-serif; color: #aaa; white-space: nowrap; flex-shrink: 0; }
+    .product-option-empty { padding: 20px; text-align: center; font: 400 13px 'Manrope', sans-serif; color: #ccc; }
+
+    /* ── Session items list ── */
+    .session-items-heading { font: 700 13px 'Manrope', sans-serif; color: #999; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 12px; }
+    .session-item { background: #fff; border-radius: 8px; padding: 12px 16px; margin-bottom: 8px; display: flex; align-items: center; gap: 12px; box-shadow: 0 1px 3px rgba(0,0,0,0.05); }
+    .item-info { flex: 1; min-width: 0; }
+    .item-name { font: 700 14px 'Manrope', sans-serif; color: #1A1A1A; display: block; }
+    .item-pack { font: 400 12px 'Manrope', sans-serif; color: #aaa; }
+    .item-temp { font: 600 13px 'Manrope', sans-serif; color: #555; white-space: nowrap; display: flex; align-items: center; gap: 5px; }
+    .item-temp.muted { color: #ccc; font-weight: 400; }
+    .item-temp-badge { font: 700 11px 'Manrope', sans-serif; padding: 2px 7px; border-radius: 10px; }
+    .item-temp-badge.pass { background: #e6f4e6; color: #2a7a2a; }
+    .item-temp-badge.fail { background: #fde8e8; color: #C41E1E; }
+    .item-remove { background: none; border: none; color: #ddd; font-size: 20px; cursor: pointer; padding: 0 4px; line-height: 1; flex-shrink: 0; transition: color 0.15s; }
+    .item-remove:hover { color: #C41E1E; }
+
+    /* ── Warning banner ── */
+    .warn-banner { background: #fff8e6; border: 1px solid #f0c050; border-radius: 6px; padding: 10px 14px; font: 600 13px 'Manrope', sans-serif; color: #a07000; margin-bottom: 12px; }
+
+    /* ── History filters ── */
+    .filter-card { background: #2e2e2e; border-radius: 10px; padding: 20px 24px; margin-bottom: 20px; }
+    .filter-grid  { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; margin-bottom: 14px; }
+    .filter-row   { display: grid; grid-template-columns: 1fr 1fr auto; gap: 14px; align-items: end; }
+    .filter-card .field-group label { color: #888; }
+    .filter-card .field-group input,
+    .filter-card .field-group select { background: #3a3a3a; border-color: #444; color: #fff; }
+    .filter-card .field-group input:focus,
+    .filter-card .field-group select:focus { border-color: #C41E1E; }
+    .filter-card .field-group select option { background: #3a3a3a; }
+    .btn-clear { background: #3a3a3a; color: #888; font: 700 13px 'Manrope', sans-serif; border: 1px solid #555; border-radius: 6px; padding: 9px 18px; cursor: pointer; white-space: nowrap; transition: background 0.2s, color 0.2s; height: fit-content; }
+    .btn-clear:hover { background: #444; color: #fff; }
+
+    .results-meta { font: 400 13px 'Manrope', sans-serif; color: #888; margin-bottom: 14px; }
+    .results-meta strong { color: #ccc; }
+
+    .history-status { font: 400 14px 'Manrope', sans-serif; color: #666; padding: 32px 0; text-align: center; }
+    .history-status.error { color: #C41E1E; }
+
+    /* ── History session cards ── */
+    .session-card { background: #2e2e2e; border-radius: 10px; margin-bottom: 10px; overflow: hidden; }
+    .session-summary { display: flex; align-items: center; gap: 12px; padding: 14px 18px; cursor: pointer; user-select: none; }
+    .session-summary:hover { background: #333; }
+    .session-info { flex: 1; min-width: 0; }
+    .session-date { font: 700 14px 'Manrope', sans-serif; color: #fff; }
+    .session-meta { font: 400 12px 'Manrope', sans-serif; color: #777; margin-top: 2px; }
+    .session-badges { display: flex; gap: 6px; flex-shrink: 0; }
+    .badge { font: 700 11px 'Manrope', sans-serif; padding: 3px 10px; border-radius: 20px; white-space: nowrap; text-transform: uppercase; letter-spacing: 0.3px; }
+    .badge-supplier { background: #3a3a3a; color: #aaa; }
+    .badge-fail     { background: #4a1a1a; color: #e87070; }
+    .item-count-badge { font: 700 12px 'Manrope', sans-serif; color: #666; white-space: nowrap; }
+    .expand-icon { color: #555; font-size: 18px; line-height: 1; transition: transform 0.25s; flex-shrink: 0; }
+    .session-card.open .expand-icon { transform: rotate(180deg); }
+
+    .session-body { border-top: 1px solid #383838; display: none; }
+    .session-card.open .session-body { display: block; }
+    .session-body-meta { padding: 9px 18px; font: 400 12px 'Manrope', sans-serif; color: #666; background: #282828; border-bottom: 1px solid #383838; }
+    .session-body-meta strong { color: #888; }
+
+    .history-item { display: flex; align-items: center; gap: 12px; padding: 11px 18px; border-bottom: 1px solid #333; }
+    .history-item:last-child { border-bottom: none; }
+    .history-item.temp-fail { background: #2d1f1f; }
+    .history-item-info { flex: 1; min-width: 0; }
+    .history-item-name { font: 600 13px 'Manrope', sans-serif; color: #ddd; }
+    .history-item-pack { font: 400 12px 'Manrope', sans-serif; color: #666; margin-top: 1px; }
+    .history-temp { font: 600 12px 'Manrope', sans-serif; white-space: nowrap; }
+    .history-temp.no-temp { color: #555; font-weight: 400; font-style: italic; }
+    .history-temp-badge { display: inline-block; font: 700 10px 'Manrope', sans-serif; padding: 2px 7px; border-radius: 10px; margin-left: 4px; }
+    .history-temp-badge.pass { background: #1a3a1a; color: #6abf6a; }
+    .history-temp-badge.fail { background: #4a1a1a; color: #e87070; }
+
+    .no-results { text-align: center; padding: 40px 20px; font: 400 14px 'Manrope', sans-serif; color: #555; }
+    .no-results strong { color: #888; display: block; font-size: 16px; margin-bottom: 6px; }
+
+    /* ── Toast ── */
+    .toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); padding: 12px 24px; border-radius: 6px; font: 700 14px 'Manrope', sans-serif; color: #fff; z-index: 99999; box-shadow: 0 4px 16px rgba(0,0,0,0.3); pointer-events: none; opacity: 1; transition: opacity 0.4s ease; white-space: nowrap; background: #1A1A1A; }
+    .toast.success { background: #2a7a2a; }
+    .toast.error   { background: #C41E1E; }
+    .toast.fade    { opacity: 0; }
+
+    @media (max-width: 600px) {
+      .session-grid    { grid-template-columns: 1fr; }
+      .session-grid .span-2 { grid-column: span 1; }
+      .new-product-grid { grid-template-columns: 1fr; }
+      .filter-grid     { grid-template-columns: 1fr; }
+      .filter-row      { grid-template-columns: 1fr; }
+      .session-badges  { display: none; }
     }
   </style>
 </head>
@@ -189,11 +226,109 @@
   </nav>
 
   <section class="hero">
-    <h1>RECEIVING HISTORY.</h1>
+    <h1>RECEIVING.</h1>
   </section>
 
+  <!-- ══ ENTRY FORM ══════════════════════════════════════════════ -->
   <div class="section-cream">
+    <div class="max-800">
+
+      <div class="card">
+        <div class="card-title">New Receiving Session</div>
+        <div class="session-grid">
+          <div class="field-group">
+            <label for="employee-name">Received By</label>
+            <input type="text" id="employee-name" placeholder="Your name" autocomplete="off">
+          </div>
+          <div class="field-group">
+            <label for="supplier-select">Supplier</label>
+            <select id="supplier-select">
+              <option value="">Select supplier…</option>
+              <option value="usfoods">US Foods</option>
+              <option value="sysco">Sysco</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+          <div class="field-group" id="other-supplier-wrap" hidden>
+            <label for="other-supplier">Supplier Name</label>
+            <input type="text" id="other-supplier" placeholder="Enter supplier name" autocomplete="off">
+          </div>
+          <div class="field-group span-2">
+            <label>Date</label>
+            <div class="date-display" id="date-display"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card" id="scan-card">
+        <div class="card-title">Scan Items</div>
+        <div class="scan-input-wrap">
+          <input type="text" id="barcode-input" placeholder="Scan barcode here…" autocomplete="off" spellcheck="false" disabled>
+          <p class="scan-hint" id="scan-hint">Enter your name and select a supplier to begin.</p>
+        </div>
+
+        <div id="barcode-warn" class="warn-banner" hidden></div>
+
+        <div id="product-card" class="product-card" hidden>
+          <div class="product-label">Product Identified</div>
+          <span class="product-name-display" id="product-name-display"></span>
+          <span class="product-pack-display" id="product-pack-display"></span>
+          <div id="temp-area" hidden>
+            <div class="temp-field">
+              <label for="temp-input">Temperature (°F)</label>
+              <div class="temp-input-wrap">
+                <input type="number" id="temp-input" placeholder="e.g. 38" step="0.1" min="-20" max="200">
+                <div id="temp-badge" class="temp-badge"></div>
+              </div>
+              <p class="temp-threshold">Must be below 42°F to pass</p>
+            </div>
+          </div>
+          <button id="add-item-btn" class="btn-primary" disabled>Add to Session</button>
+        </div>
+
+        <div id="new-product-form" class="new-product-form" hidden>
+          <div class="new-product-header">
+            <span class="new-product-title">Unknown Product</span>
+            <span class="new-product-code" id="new-product-code-display"></span>
+          </div>
+          <p class="new-product-hint">This barcode isn't in the system yet. Fill in the details to add it and continue.</p>
+          <div class="new-product-grid">
+            <div class="field-group">
+              <label for="new-product-name">Product Name</label>
+              <input type="text" id="new-product-name" placeholder="e.g. Cheese, Cheddar Mild" autocomplete="off">
+            </div>
+            <div class="field-group">
+              <label for="new-product-pack">Pack Size (e.g. 4/5/LB)</label>
+              <input type="text" id="new-product-pack" placeholder="e.g. 4/5/LB" autocomplete="off">
+            </div>
+          </div>
+          <label class="checkbox-label">
+            <input type="checkbox" id="new-product-temp">
+            Requires temperature check (refrigerated / dairy / fresh)
+          </label>
+          <button id="save-new-product-btn" class="btn-primary">Save & Continue</button>
+        </div>
+
+        <div id="product-selector" class="product-selector" hidden>
+          <label for="product-search">Select Product</label>
+          <input type="text" id="product-search" placeholder="Type to search products…" autocomplete="off">
+          <div id="product-options" class="product-options"></div>
+        </div>
+      </div>
+
+      <div id="session-section" hidden>
+        <div class="session-items-heading">Items This Session</div>
+        <div id="session-items"></div>
+        <button id="submit-btn" class="btn-submit" disabled>Submit Receiving Session</button>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ══ HISTORY ═════════════════════════════════════════════════ -->
+  <div class="section-dark">
     <div class="max-1000">
+      <h2>RECEIVING HISTORY.</h2>
 
       <div class="filter-card">
         <div class="filter-grid">
@@ -233,19 +368,266 @@
       </div>
 
       <div id="results-meta" class="results-meta" hidden></div>
-      <div id="status-msg" class="status-msg">Loading receiving records…</div>
-      <div id="results"></div>
+      <div id="history-status" class="history-status">Loading history…</div>
+      <div id="history-results"></div>
 
     </div>
   </div>
 
   <script type="module">
-    import { fetchLog } from '../../scripts/sheet-logger.js';
+    import { appendLog, fetchLog } from '../../scripts/sheet-logger.js';
 
     const LOG_PATH = '/dangpretz/receiving';
+    const TEMP_THRESHOLD = 42;
 
-    let allSessions = [];   // array of { sessionId, date, supplier, receivedBy, items[] }
-    let allItems    = [];   // flat list for filtering
+    // ─────────────────────────────────────────────────────────────
+    // PRODUCT CATALOG
+    // To add a product: copy any line, fill in all fields, save the file.
+    // usFoodsCode: the 7-digit product code at chars 7–13 of a US Foods barcode.
+    // requiresTemp: true for all dairy, refrigerated, and fresh produce items.
+    // ─────────────────────────────────────────────────────────────
+    const PRODUCTS = [
+      { id: 'usf-0877506', name: 'Butter, Salted Solid AA Grd',               packSize: '36/1/LB',    requiresTemp: true,  usFoodsCode: '0877506' },
+      { id: 'usf-0033858', name: 'Salt, Sea KO Not Iodz Gran Box',             packSize: '12/3/LB',    requiresTemp: false, usFoodsCode: '0033858' },
+      { id: 'usf-1008416', name: 'Flour, Bread Enriched Bleached Big Loaf',    packSize: '1/50/LB',    requiresTemp: false, usFoodsCode: '1008416' },
+      { id: 'usf-4364063', name: 'Mustard, Yellow Plastic Jar Shelf Stable',   packSize: '4/1/GAL',    requiresTemp: false, usFoodsCode: '4364063' },
+      { id: 'usf-7016876', name: 'Sugar, Powdered Confectionary',              packSize: '1/50/LB',    requiresTemp: false, usFoodsCode: '7016876' },
+      { id: 'usf-7329113', name: 'Mayonnaise, Heavy Plastic Jug Shelf Stable', packSize: '4/1/GAL',    requiresTemp: false, usFoodsCode: '7329113' },
+      { id: 'usf-0746479', name: 'Cheese, Pepper Jack Shredded Bag',           packSize: '4/5/LB',     requiresTemp: true,  usFoodsCode: '0746479' },
+      { id: 'usf-1324079', name: 'Cream, Whipping Heavy 40%',                  packSize: '2/1/GAL',    requiresTemp: true,  usFoodsCode: '1324079' },
+      { id: 'usf-1492816', name: 'Cheese, Parmesan Shaved Bag',                packSize: '2/5/LB',     requiresTemp: true,  usFoodsCode: '1492816' },
+      { id: 'usf-3547205', name: 'Pepper, Chili, Fresno Red Fresh',            packSize: '1/5/LB',     requiresTemp: true,  usFoodsCode: '3547205' },
+      { id: 'usf-5328406', name: 'Dressing, Ranch, Buttermilk',                packSize: '1/1/GAL',    requiresTemp: true,  usFoodsCode: '5328406' },
+      { id: 'usf-6773394', name: 'Juice, Lemon Meyer Blend',                   packSize: '1/32/OZ',    requiresTemp: false, usFoodsCode: '6773394' },
+      { id: 'usf-7017429', name: 'Basil, Fresh Herb',                          packSize: '1/1/LB',     requiresTemp: true,  usFoodsCode: '7017429' },
+      { id: 'usf-8123322', name: 'Cheese, Cheddar Yellow Mild Shredded',       packSize: '4/5/LB',     requiresTemp: true,  usFoodsCode: '8123322' },
+      { id: 'usf-5329420', name: 'Liner, 60 Gal',                              packSize: '1/100/EA',   requiresTemp: false, usFoodsCode: '5329420' },
+      { id: 'usf-8340861', name: 'Cheese, Cream Plain Loaf',                   packSize: '10/3/LB',    requiresTemp: true,  usFoodsCode: '8340861' },
+      { id: 'usf-7807993', name: 'Glove, Vinyl Medium',                        packSize: '10/100/EA',  requiresTemp: false, usFoodsCode: '7807993' },
+      { id: 'usf-3022647', name: 'Yeast, Dry Active',                          packSize: '20/1/LB',    requiresTemp: false, usFoodsCode: '3022647' },
+      { id: 'usf-6401780', name: 'Cheese, Cheddar Sharp Shredded',             packSize: '4/5/LB',     requiresTemp: true,  usFoodsCode: '6401780' },
+      { id: 'usf-3737152', name: 'Honey, Amber Light',                         packSize: '1/5/LB',     requiresTemp: false, usFoodsCode: '3737152' },
+      { id: 'usf-7330202', name: 'Mustard, Dijon Whole Grain Can',             packSize: '1/8.6/LB',   requiresTemp: false, usFoodsCode: '7330202' },
+      { id: 'usf-1332642', name: 'Cheese, Cheddar Mild Shredded',              packSize: '4/5/LB',     requiresTemp: true,  usFoodsCode: '1332642' },
+      { id: 'usf-7326432', name: 'Parsley, Washed and Destemmed',              packSize: '1/1/LB',     requiresTemp: true,  usFoodsCode: '7326432' },
+      { id: 'usf-3330487', name: 'Garlic, Chopped in Water',                   packSize: '6/32/OZ',    requiresTemp: true,  usFoodsCode: '3330487' },
+      { id: 'usf-9929174', name: 'Pepper, Jalapeno #1 Fresh',                  packSize: '1/10/LB',    requiresTemp: true,  usFoodsCode: '9929174' },
+      // ── Add new products below this line ──────────────────────
+    ];
+
+    // ════════════════════════════════════════════════════════════
+    // ENTRY FORM
+    // ════════════════════════════════════════════════════════════
+    let sessionId    = generateId();
+    let sessionItems = [];
+    let pendingProduct = null;
+    let pendingBarcode = '';
+
+    const nameInput       = document.getElementById('employee-name');
+    const supplierSelect  = document.getElementById('supplier-select');
+    const otherWrap       = document.getElementById('other-supplier-wrap');
+    const otherInput      = document.getElementById('other-supplier');
+    const barcodeInput    = document.getElementById('barcode-input');
+    const scanHint        = document.getElementById('scan-hint');
+    const barcodeWarn     = document.getElementById('barcode-warn');
+    const productCard     = document.getElementById('product-card');
+    const tempArea        = document.getElementById('temp-area');
+    const tempInput       = document.getElementById('temp-input');
+    const tempBadge       = document.getElementById('temp-badge');
+    const addItemBtn      = document.getElementById('add-item-btn');
+    const newProductForm  = document.getElementById('new-product-form');
+    const productSelector = document.getElementById('product-selector');
+    const productSearch   = document.getElementById('product-search');
+    const productOptions  = document.getElementById('product-options');
+    const sessionSection  = document.getElementById('session-section');
+    const sessionItemsEl  = document.getElementById('session-items');
+    const submitBtn       = document.getElementById('submit-btn');
+
+    document.getElementById('date-display').textContent =
+      new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+
+    nameInput.addEventListener('input', checkSessionReady);
+    supplierSelect.addEventListener('change', () => {
+      otherWrap.hidden = supplierSelect.value !== 'other';
+      checkSessionReady();
+    });
+    otherInput.addEventListener('input', checkSessionReady);
+
+    function checkSessionReady() {
+      const name     = nameInput.value.trim();
+      const supplier = supplierSelect.value;
+      const otherOk  = supplier !== 'other' || otherInput.value.trim();
+      const ready    = !!(name && supplier && otherOk);
+      barcodeInput.disabled = !ready;
+      scanHint.textContent  = ready
+        ? 'Scan a barcode or type it and press Enter.'
+        : 'Enter your name and select a supplier to begin.';
+      if (ready) barcodeInput.focus();
+    }
+
+    barcodeInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const raw = barcodeInput.value.trim();
+        barcodeInput.value = '';
+        if (raw) handleBarcode(raw);
+      }
+    });
+
+    function handleBarcode(raw) {
+      pendingBarcode = raw;
+      pendingProduct = null;
+      hideAll();
+      if (supplierSelect.value === 'usfoods') {
+        if (raw.length !== 16) {
+          barcodeWarn.hidden = false;
+          barcodeWarn.textContent = `US Foods barcodes are 16 characters — this one is ${raw.length}. Select the product manually below.`;
+          showProductSelector();
+          return;
+        }
+        const code  = raw.slice(6, 13);
+        const match = PRODUCTS.find((p) => p.usFoodsCode === code);
+        match ? showProductCard(match) : showNewProductForm(code);
+      } else {
+        showProductSelector();
+      }
+    }
+
+    function showProductCard(product) {
+      pendingProduct = product;
+      document.getElementById('product-name-display').textContent = product.name;
+      document.getElementById('product-pack-display').textContent = product.packSize;
+      tempArea.hidden = !product.requiresTemp;
+      if (product.requiresTemp) { tempInput.value = ''; tempBadge.textContent = ''; tempBadge.className = 'temp-badge'; }
+      productCard.hidden = false;
+      updateAddButton();
+      product.requiresTemp ? tempInput.focus() : addItemBtn.focus();
+    }
+
+    tempInput.addEventListener('input', () => {
+      const t = parseFloat(tempInput.value);
+      if (isNaN(t) || tempInput.value === '') { tempBadge.textContent = ''; tempBadge.className = 'temp-badge'; }
+      else if (t < TEMP_THRESHOLD) { tempBadge.textContent = '✓ Pass'; tempBadge.className = 'temp-badge pass'; }
+      else                          { tempBadge.textContent = '✗ Fail'; tempBadge.className = 'temp-badge fail'; }
+      updateAddButton();
+    });
+
+    function updateAddButton() {
+      if (!pendingProduct) { addItemBtn.disabled = true; return; }
+      addItemBtn.disabled = pendingProduct.requiresTemp ? isNaN(parseFloat(tempInput.value)) : false;
+    }
+
+    addItemBtn.addEventListener('click', addItem);
+    function addItem() {
+      if (!pendingProduct) return;
+      const temp = pendingProduct.requiresTemp ? parseFloat(tempInput.value) : null;
+      sessionItems.push({
+        barcode: pendingBarcode, productId: pendingProduct.id, productName: pendingProduct.name,
+        packSize: pendingProduct.packSize, requiresTemp: pendingProduct.requiresTemp,
+        temperature: temp, tempPass: temp !== null ? temp < TEMP_THRESHOLD : null,
+      });
+      pendingProduct = null; pendingBarcode = '';
+      hideAll(); renderSessionItems(); barcodeInput.focus();
+    }
+
+    function showNewProductForm(code) {
+      document.getElementById('new-product-code-display').textContent = `Code: ${code}`;
+      document.getElementById('new-product-name').value = '';
+      document.getElementById('new-product-pack').value = '';
+      document.getElementById('new-product-temp').checked = false;
+      newProductForm.hidden = false;
+      document.getElementById('new-product-name').focus();
+    }
+
+    document.getElementById('save-new-product-btn').addEventListener('click', async () => {
+      const name     = document.getElementById('new-product-name').value.trim();
+      const packSize = document.getElementById('new-product-pack').value.trim();
+      const reqTemp  = document.getElementById('new-product-temp').checked;
+      const code     = document.getElementById('new-product-code-display').textContent.replace('Code: ', '');
+      if (!name || !packSize) { showToast('Please fill in product name and pack size', 'error'); return; }
+      const newProduct = { id: `new-${code}`, name, packSize, requiresTemp: reqTemp, usFoodsCode: code };
+      PRODUCTS.push(newProduct);
+      try { await appendLog(LOG_PATH, { action: 'new_product', usFoodsCode: code, productName: name, packSize, requiresTemp: String(reqTemp), timeStamp: new Date().toISOString(), addedBy: nameInput.value.trim() }); } catch (_) {}
+      newProductForm.hidden = true;
+      showToast('Product added — remember to add it to the code!', 'success');
+      showProductCard(newProduct);
+    });
+
+    function showProductSelector() {
+      productSearch.value = ''; renderProductOptions('');
+      productSelector.hidden = false; productSearch.focus();
+    }
+
+    productSearch.addEventListener('input', () => renderProductOptions(productSearch.value));
+    function renderProductOptions(query) {
+      const q = query.toLowerCase().trim();
+      const matches = q ? PRODUCTS.filter((p) => p.name.toLowerCase().includes(q)) : [...PRODUCTS].sort((a, b) => a.name.localeCompare(b.name));
+      if (!matches.length) { productOptions.innerHTML = '<div class="product-option-empty">No products found</div>'; return; }
+      productOptions.innerHTML = matches.map((p) => `<div class="product-option" data-id="${escapeHtml(p.id)}"><span class="option-name">${escapeHtml(p.name)}</span><span class="option-pack">${escapeHtml(p.packSize)}</span></div>`).join('');
+      productOptions.querySelectorAll('.product-option').forEach((el) => {
+        el.addEventListener('click', () => {
+          const product = PRODUCTS.find((p) => p.id === el.dataset.id);
+          if (!product) return;
+          productSelector.hidden = true; barcodeWarn.hidden = true; showProductCard(product);
+        });
+      });
+    }
+
+    function renderSessionItems() {
+      if (!sessionItems.length) { sessionSection.hidden = true; submitBtn.disabled = true; return; }
+      sessionSection.hidden = false; submitBtn.disabled = false;
+      sessionItemsEl.innerHTML = sessionItems.map((item, i) => {
+        const tempHtml = item.requiresTemp
+          ? `<span class="item-temp">${item.temperature}°F <span class="item-temp-badge ${item.tempPass ? 'pass' : 'fail'}">${item.tempPass ? '✓ Pass' : '✗ Fail'}</span></span>`
+          : '<span class="item-temp muted">No temp req.</span>';
+        return `<div class="session-item"><div class="item-info"><span class="item-name">${escapeHtml(item.productName)}</span><span class="item-pack">${escapeHtml(item.packSize)}</span></div>${tempHtml}<button class="item-remove" data-index="${i}">&times;</button></div>`;
+      }).join('');
+      sessionItemsEl.querySelectorAll('.item-remove').forEach((btn) => {
+        btn.addEventListener('click', () => { sessionItems.splice(parseInt(btn.dataset.index, 10), 1); renderSessionItems(); });
+      });
+    }
+
+    submitBtn.addEventListener('click', submitSession);
+    async function submitSession() {
+      submitBtn.disabled = true; submitBtn.textContent = 'Submitting…';
+      const receivedBy   = nameInput.value.trim();
+      const supplierVal  = supplierSelect.value;
+      const supplierName = supplierVal === 'other' ? otherInput.value.trim() : supplierVal;
+      const date         = new Date().toISOString().slice(0, 10);
+      try {
+        for (const item of sessionItems) {
+          await appendLog(LOG_PATH, {
+            action: 'receive', sessionId, receivedBy, date, timeStamp: new Date().toISOString(),
+            supplier: supplierName, barcode: item.barcode, productId: item.productId,
+            productName: item.productName, packSize: item.packSize,
+            requiresTemp: String(item.requiresTemp),
+            temperature:  item.temperature !== null ? String(item.temperature) : '',
+            tempPass:     item.tempPass    !== null ? String(item.tempPass)    : '',
+          });
+        }
+        const count = sessionItems.length;
+        showToast(`✓ ${count} item${count !== 1 ? 's' : ''} logged`, 'success');
+        sessionItems = []; sessionId = generateId(); pendingProduct = null; pendingBarcode = '';
+        hideAll(); renderSessionItems();
+        await loadHistory();  // refresh history after submit
+        barcodeInput.focus();
+      } catch (err) {
+        showToast('Submit failed: ' + (err.message || 'unknown error'), 'error');
+        submitBtn.disabled = false;
+      } finally {
+        submitBtn.textContent = 'Submit Receiving Session';
+      }
+    }
+
+    function hideAll() {
+      productCard.hidden = true; newProductForm.hidden = true;
+      productSelector.hidden = true; barcodeWarn.hidden = true;
+    }
+
+    // ════════════════════════════════════════════════════════════
+    // HISTORY
+    // ════════════════════════════════════════════════════════════
+    let allSessions = [];
 
     const filterProduct  = document.getElementById('filter-product');
     const filterSupplier = document.getElementById('filter-supplier');
@@ -253,69 +635,46 @@
     const filterDateFrom = document.getElementById('filter-date-from');
     const filterDateTo   = document.getElementById('filter-date-to');
     const clearBtn       = document.getElementById('clear-btn');
-    const statusMsg      = document.getElementById('status-msg');
+    const historyStatus  = document.getElementById('history-status');
     const resultsMeta    = document.getElementById('results-meta');
-    const resultsEl      = document.getElementById('results');
+    const historyResults = document.getElementById('history-results');
 
-    // ── Wire filters ─────────────────────────────────────────────
     let debounce;
     filterProduct.addEventListener('input', () => { clearTimeout(debounce); debounce = setTimeout(applyFilters, 250); });
-    [filterSupplier, filterTemp, filterDateFrom, filterDateTo].forEach((el) => {
-      el.addEventListener('change', applyFilters);
-    });
+    [filterSupplier, filterTemp, filterDateFrom, filterDateTo].forEach((el) => el.addEventListener('change', applyFilters));
     clearBtn.addEventListener('click', () => {
-      filterProduct.value  = '';
-      filterSupplier.value = '';
-      filterTemp.value     = '';
-      filterDateFrom.value = '';
-      filterDateTo.value   = '';
-      applyFilters();
+      filterProduct.value = ''; filterSupplier.value = ''; filterTemp.value = '';
+      filterDateFrom.value = ''; filterDateTo.value = ''; applyFilters();
     });
 
-    // ── Load ─────────────────────────────────────────────────────
-    async function init() {
+    async function loadHistory() {
       try {
         const logs = await fetchLog(LOG_PATH);
         buildSessions(Array.isArray(logs) ? logs : []);
-        statusMsg.hidden = true;
+        historyStatus.hidden = true;
         applyFilters();
       } catch (err) {
-        statusMsg.className = 'status-msg error';
-        statusMsg.textContent = 'Failed to load records: ' + (err.message || 'unknown error');
+        historyStatus.className = 'history-status error';
+        historyStatus.textContent = 'Failed to load history: ' + (err.message || 'unknown error');
       }
     }
 
-    // Group log rows into sessions by sessionId, newest first
     function buildSessions(logs) {
-      const sessionMap = {};
-      logs
-        .filter((r) => r.action === 'receive')
-        .forEach((r) => {
-          const sid = r.sessionId || `legacy-${r.timeStamp}`;
-          if (!sessionMap[sid]) {
-            sessionMap[sid] = {
-              sessionId:  sid,
-              date:       r.date || '',
-              supplier:   r.supplier || '',
-              receivedBy: r.receivedBy || '',
-              items:      [],
-            };
-          }
-          sessionMap[sid].items.push({
-            productName:  r.productName || '—',
-            packSize:     r.packSize    || '',
-            requiresTemp: r.requiresTemp === 'true',
-            temperature:  r.temperature !== '' ? parseFloat(r.temperature) : null,
-            tempPass:     r.tempPass === 'true' ? true : r.tempPass === 'false' ? false : null,
-            barcode:      r.barcode || '',
-          });
-          allItems.push({ ...r, sessionId: sid });
+      const map = {};
+      logs.filter((r) => r.action === 'receive').forEach((r) => {
+        const sid = r.sessionId || `legacy-${r.timeStamp}`;
+        if (!map[sid]) map[sid] = { sessionId: sid, date: r.date || '', supplier: r.supplier || '', receivedBy: r.receivedBy || '', items: [] };
+        map[sid].items.push({
+          productName:  r.productName || '—',
+          packSize:     r.packSize    || '',
+          requiresTemp: r.requiresTemp === 'true',
+          temperature:  r.temperature !== '' ? parseFloat(r.temperature) : null,
+          tempPass:     r.tempPass === 'true' ? true : r.tempPass === 'false' ? false : null,
         });
-
-      allSessions = Object.values(sessionMap).sort((a, b) => b.date.localeCompare(a.date) || b.sessionId.localeCompare(a.sessionId));
+      });
+      allSessions = Object.values(map).sort((a, b) => b.date.localeCompare(a.date) || b.sessionId.localeCompare(a.sessionId));
     }
 
-    // ── Filter ───────────────────────────────────────────────────
     function applyFilters() {
       const product  = filterProduct.value.trim().toLowerCase();
       const supplier = filterSupplier.value.toLowerCase();
@@ -323,109 +682,86 @@
       const dateFrom = filterDateFrom.value;
       const dateTo   = filterDateTo.value;
 
-      // Filter at the item level, then rebuild sessions from matching items
-      const filteredSessions = allSessions
+      const filtered = allSessions
         .filter((s) => {
           if (supplier && s.supplier.toLowerCase() !== supplier) return false;
           if (dateFrom && s.date < dateFrom) return false;
           if (dateTo   && s.date > dateTo)   return false;
           return true;
         })
-        .map((s) => {
-          const filteredItems = s.items.filter((item) => {
+        .map((s) => ({
+          ...s,
+          items: s.items.filter((item) => {
             if (product && !item.productName.toLowerCase().includes(product)) return false;
             if (temp === 'pass')    return item.tempPass === true;
             if (temp === 'fail')    return item.tempPass === false;
             if (temp === 'checked') return item.requiresTemp;
             return true;
-          });
-          return { ...s, items: filteredItems };
-        })
+          }),
+        }))
         .filter((s) => s.items.length > 0);
 
-      const totalItems   = allSessions.reduce((n, s) => n + s.items.length, 0);
-      const shownItems   = filteredSessions.reduce((n, s) => n + s.items.length, 0);
+      const totalItems = allSessions.reduce((n, s) => n + s.items.length, 0);
+      const shownItems = filtered.reduce((n, s) => n + s.items.length, 0);
       resultsMeta.hidden = false;
-      resultsMeta.innerHTML = `Showing <strong>${shownItems}</strong> of <strong>${totalItems}</strong> received items across <strong>${filteredSessions.length}</strong> session${filteredSessions.length !== 1 ? 's' : ''}`;
+      resultsMeta.innerHTML = `Showing <strong>${shownItems}</strong> of <strong>${totalItems}</strong> received items across <strong>${filtered.length}</strong> session${filtered.length !== 1 ? 's' : ''}`;
 
-      renderResults(filteredSessions);
-    }
-
-    // ── Render ───────────────────────────────────────────────────
-    function renderResults(sessions) {
-      if (sessions.length === 0) {
-        resultsEl.innerHTML = `<div class="no-results"><strong>No records found</strong>Try adjusting your filters.</div>`;
+      if (!filtered.length) {
+        historyResults.innerHTML = '<div class="no-results"><strong>No records found</strong>Try adjusting your filters.</div>';
         return;
       }
 
-      resultsEl.innerHTML = sessions.map((s) => renderSession(s)).join('');
+      historyResults.innerHTML = filtered.map((s) => {
+        const dateLabel     = s.date ? new Date(s.date + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' }) : '—';
+        const supplierLabel = s.supplier === 'usfoods' ? 'US Foods' : s.supplier === 'sysco' ? 'Sysco' : (s.supplier || '—');
+        const hasFail       = s.items.some((i) => i.tempPass === false);
+        const count         = s.items.length;
 
-      resultsEl.querySelectorAll('.session-summary').forEach((el) => {
+        const itemsHtml = s.items.map((item) => {
+          const tempHtml = item.requiresTemp && item.temperature !== null
+            ? `<span class="history-temp">${item.temperature}°F<span class="history-temp-badge ${item.tempPass ? 'pass' : 'fail'}">${item.tempPass ? '✓' : '✗'}</span></span>`
+            : '<span class="history-temp no-temp">No temp req.</span>';
+          return `<div class="history-item${item.tempPass === false ? ' temp-fail' : ''}"><div class="history-item-info"><div class="history-item-name">${escapeHtml(item.productName)}</div>${item.packSize ? `<div class="history-item-pack">${escapeHtml(item.packSize)}</div>` : ''}</div>${tempHtml}</div>`;
+        }).join('');
+
+        return `<div class="session-card">
+          <div class="session-summary">
+            <div class="session-info"><div class="session-date">${escapeHtml(dateLabel)}</div><div class="session-meta">Received by ${escapeHtml(s.receivedBy || '—')}</div></div>
+            <div class="session-badges"><span class="badge badge-supplier">${escapeHtml(supplierLabel)}</span>${hasFail ? '<span class="badge badge-fail">Temp Fail</span>' : ''}</div>
+            <span class="item-count-badge">${count} item${count !== 1 ? 's' : ''}</span>
+            <span class="expand-icon">&#8964;</span>
+          </div>
+          <div class="session-body">
+            <div class="session-body-meta"><strong>Supplier:</strong> ${escapeHtml(supplierLabel)} &nbsp;·&nbsp; <strong>Received by:</strong> ${escapeHtml(s.receivedBy || '—')} &nbsp;·&nbsp; <strong>Date:</strong> ${escapeHtml(s.date || '—')}</div>
+            ${itemsHtml}
+          </div>
+        </div>`;
+      }).join('');
+
+      historyResults.querySelectorAll('.session-summary').forEach((el) => {
         el.addEventListener('click', () => el.closest('.session-card').classList.toggle('open'));
       });
     }
 
-    function renderSession(s) {
-      const dateLabel    = s.date ? new Date(s.date + 'T12:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' }) : '—';
-      const supplierLabel = supplierName(s.supplier);
-      const hasFail      = s.items.some((i) => i.tempPass === false);
-      const itemCount    = s.items.length;
-
-      const itemsHtml = s.items.map((item) => {
-        const tempHtml = item.requiresTemp && item.temperature !== null
-          ? `<span class="item-temp">${item.temperature}°F<span class="temp-badge ${item.tempPass ? 'pass' : 'fail'}">${item.tempPass ? '✓ Pass' : '✗ Fail'}</span></span>`
-          : `<span class="item-temp no-temp">No temp req.</span>`;
-        return `
-          <div class="item-row${item.tempPass === false ? ' temp-fail' : ''}">
-            <div class="item-name-wrap">
-              <div class="item-name">${escapeHtml(item.productName)}</div>
-              ${item.packSize ? `<div class="item-pack">${escapeHtml(item.packSize)}</div>` : ''}
-            </div>
-            ${tempHtml}
-          </div>`;
-      }).join('');
-
-      return `
-        <div class="session-card">
-          <div class="session-summary">
-            <div class="session-info">
-              <div class="session-date">${escapeHtml(dateLabel)}</div>
-              <div class="session-meta">Received by ${escapeHtml(s.receivedBy || '—')}</div>
-            </div>
-            <div class="session-badges">
-              <span class="badge badge-supplier">${escapeHtml(supplierLabel)}</span>
-              ${hasFail ? '<span class="badge badge-fail">Temp Fail</span>' : ''}
-            </div>
-            <span class="item-count">${itemCount} item${itemCount !== 1 ? 's' : ''}</span>
-            <span class="expand-icon">&#8964;</span>
-          </div>
-          <div class="session-body">
-            <div class="received-by-row">
-              <strong>Supplier:</strong> ${escapeHtml(supplierLabel)} &nbsp;·&nbsp;
-              <strong>Received by:</strong> ${escapeHtml(s.receivedBy || '—')} &nbsp;·&nbsp;
-              <strong>Date:</strong> ${escapeHtml(s.date || '—')}
-            </div>
-            ${itemsHtml}
-          </div>
-        </div>`;
+    // ════════════════════════════════════════════════════════════
+    // UTILITIES
+    // ════════════════════════════════════════════════════════════
+    function generateId() {
+      return typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `rec-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
     }
-
-    function supplierName(val) {
-      if (!val) return '—';
-      if (val === 'usfoods') return 'US Foods';
-      if (val === 'sysco')   return 'Sysco';
-      return val;
-    }
-
     function escapeHtml(s) {
-      return String(s)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
+      return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+    function showToast(msg, kind = '') {
+      const t = document.createElement('div');
+      t.className = 'toast' + (kind ? ' ' + kind : '');
+      t.textContent = msg;
+      document.body.appendChild(t);
+      setTimeout(() => { t.classList.add('fade'); setTimeout(() => t.remove(), 400); }, 3500);
     }
 
-    init();
+    // Boot
+    loadHistory();
   </script>
 </body>
 </html>

--- a/static/receiving/index.html
+++ b/static/receiving/index.html
@@ -10,6 +10,7 @@
   <style>
     /* ── Design system ── */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    [hidden] { display: none !important; }
     body { font-family: 'Manrope', sans-serif; color: #1A1A1A; background: #1A1A1A; -webkit-font-smoothing: antialiased; }
     a { color: inherit; text-decoration: none; }
 

--- a/static/receiving/index.html
+++ b/static/receiving/index.html
@@ -1,0 +1,837 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Receiving | Dangerous Pretzel Co.</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700;800&family=Paytone+One&display=swap" rel="stylesheet">
+  <style>
+    /* ── Design system ── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Manrope', sans-serif; color: #1A1A1A; background: #1A1A1A; -webkit-font-smoothing: antialiased; }
+    a { color: inherit; text-decoration: none; }
+
+    .site-nav { background: #1A1A1A; padding: 14px 5%; position: sticky; top: 0; z-index: 9999; border-bottom: 1px solid #333; }
+    .nav-wrap { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; }
+    .nav-logo { height: 46px; }
+    .nav-links { display: flex; align-items: center; gap: 20px; }
+    .nav-links a { color: #fff; font: 400 15px/1 'Manrope', sans-serif; transition: color 0.2s; }
+    .nav-links a:hover { color: #C41E1E; }
+
+    .hero { background: #1A1A1A; text-align: center; padding: clamp(30px, 4vw, 50px) 5% clamp(16px, 3vw, 28px); }
+    .hero h1 { font: 900 italic clamp(32px, 5vw, 52px)/1.05 Georgia, serif; color: #fff; margin: 0; }
+
+    .section-cream { background: #F5F0E8; padding: clamp(32px, 5vw, 60px) 5%; min-height: calc(100vh - 200px); }
+    .max-800 { max-width: 800px; margin: 0 auto; }
+
+    /* ── Cards ── */
+    .card {
+      background: #fff;
+      border-radius: 10px;
+      padding: 24px;
+      margin-bottom: 20px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+    }
+    .card-title {
+      font: 700 13px 'Manrope', sans-serif;
+      color: #999;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      margin-bottom: 16px;
+    }
+
+    /* ── Form fields ── */
+    .field-group { display: flex; flex-direction: column; gap: 6px; }
+    .field-group label {
+      font: 700 12px 'Manrope', sans-serif;
+      color: #555;
+      letter-spacing: 0.5px;
+    }
+    .field-group input,
+    .field-group select {
+      font: 400 15px 'Manrope', sans-serif;
+      padding: 10px 14px;
+      border: 2px solid #ddd;
+      border-radius: 6px;
+      background: #fff;
+      color: #1A1A1A;
+      outline: none;
+      transition: border-color 0.2s;
+      width: 100%;
+    }
+    .field-group input:focus,
+    .field-group select:focus { border-color: #C41E1E; }
+
+    .session-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+    .session-grid .span-2 { grid-column: span 2; }
+
+    .date-display {
+      font: 600 15px 'Manrope', sans-serif;
+      color: #1A1A1A;
+      padding: 10px 14px;
+      background: #F5F0E8;
+      border-radius: 6px;
+      border: 2px solid transparent;
+    }
+
+    /* ── Scan input ── */
+    .scan-input-wrap { margin-bottom: 16px; }
+    .scan-input-wrap input {
+      width: 100%;
+      font: 400 clamp(18px, 2.5vw, 22px)/1 'Manrope', sans-serif;
+      padding: 16px 20px;
+      border: 2px solid #ddd;
+      border-radius: 8px;
+      background: #fff;
+      color: #1A1A1A;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+    .scan-input-wrap input:focus { border-color: #C41E1E; }
+    .scan-input-wrap input:disabled { background: #f0ece6; color: #aaa; }
+    .scan-hint { font: 400 12px 'Manrope', sans-serif; color: #aaa; margin-top: 6px; }
+
+    /* ── Product card ── */
+    .product-card {
+      background: #fff;
+      border-radius: 10px;
+      padding: 20px 24px;
+      margin-bottom: 16px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+      border-left: 4px solid #C41E1E;
+    }
+    .product-label { font: 700 11px 'Manrope', sans-serif; color: #999; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 6px; }
+    .product-name-display { font: 700 18px 'Manrope', sans-serif; color: #1A1A1A; display: block; margin-bottom: 4px; }
+    .product-pack-display { font: 400 13px 'Manrope', sans-serif; color: #888; display: block; margin-bottom: 16px; }
+
+    /* ── Temp area ── */
+    .temp-field { margin-bottom: 16px; }
+    .temp-field label { font: 700 12px 'Manrope', sans-serif; color: #555; letter-spacing: 0.5px; display: block; margin-bottom: 6px; }
+    .temp-input-wrap { display: flex; align-items: center; gap: 10px; }
+    .temp-input-wrap input {
+      width: 140px;
+      font: 400 20px 'Manrope', sans-serif;
+      padding: 10px 14px;
+      border: 2px solid #ddd;
+      border-radius: 6px;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+    .temp-input-wrap input:focus { border-color: #C41E1E; }
+    .temp-badge {
+      font: 700 14px 'Manrope', sans-serif;
+      padding: 6px 14px;
+      border-radius: 20px;
+      min-width: 80px;
+      text-align: center;
+    }
+    .temp-badge.pass { background: #e6f4e6; color: #2a7a2a; }
+    .temp-badge.fail { background: #fde8e8; color: #C41E1E; }
+    .temp-threshold { font: 400 12px 'Manrope', sans-serif; color: #aaa; margin-top: 6px; }
+
+    /* ── Buttons ── */
+    .btn-primary {
+      background: #C41E1E;
+      color: #fff;
+      font: 700 14px 'Manrope', sans-serif;
+      border: none;
+      border-radius: 6px;
+      padding: 12px 24px;
+      cursor: pointer;
+      transition: background 0.2s;
+      width: 100%;
+    }
+    .btn-primary:hover { background: #a01818; }
+    .btn-primary:disabled { background: #ccc; cursor: not-allowed; }
+
+    .btn-secondary {
+      background: #F5F0E8;
+      color: #1A1A1A;
+      font: 700 13px 'Manrope', sans-serif;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      padding: 10px 20px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    .btn-secondary:hover { background: #ece5d8; }
+
+    .btn-submit {
+      background: #1A1A1A;
+      color: #fff;
+      font: 700 15px 'Manrope', sans-serif;
+      border: none;
+      border-radius: 8px;
+      padding: 16px 32px;
+      cursor: pointer;
+      transition: background 0.2s;
+      width: 100%;
+      margin-top: 8px;
+    }
+    .btn-submit:hover { background: #333; }
+    .btn-submit:disabled { background: #bbb; cursor: not-allowed; }
+
+    /* ── New product form ── */
+    .new-product-form {
+      background: #fff;
+      border-radius: 10px;
+      padding: 20px 24px;
+      margin-bottom: 16px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+      border-left: 4px solid #f0a500;
+    }
+    .new-product-header { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; }
+    .new-product-title { font: 700 15px 'Manrope', sans-serif; color: #1A1A1A; }
+    .new-product-code { font: 600 12px 'Courier New', monospace; background: #F5F0E8; padding: 3px 8px; border-radius: 4px; color: #555; }
+    .new-product-hint { font: 400 13px 'Manrope', sans-serif; color: #888; margin-bottom: 16px; }
+    .new-product-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 12px; }
+    .checkbox-label { display: flex; align-items: center; gap: 8px; font: 600 13px 'Manrope', sans-serif; color: #555; margin-bottom: 16px; cursor: pointer; }
+    .checkbox-label input[type="checkbox"] { width: 16px; height: 16px; cursor: pointer; accent-color: #C41E1E; }
+
+    /* ── Product selector ── */
+    .product-selector {
+      background: #fff;
+      border-radius: 10px;
+      padding: 20px 24px;
+      margin-bottom: 16px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.07);
+    }
+    .product-selector label { font: 700 12px 'Manrope', sans-serif; color: #555; letter-spacing: 0.5px; display: block; margin-bottom: 8px; }
+    .product-selector input {
+      width: 100%;
+      font: 400 15px 'Manrope', sans-serif;
+      padding: 10px 14px;
+      border: 2px solid #ddd;
+      border-radius: 6px;
+      outline: none;
+      margin-bottom: 10px;
+      transition: border-color 0.2s;
+    }
+    .product-selector input:focus { border-color: #C41E1E; }
+    .product-options { max-height: 280px; overflow-y: auto; border: 1px solid #eee; border-radius: 6px; }
+    .product-option {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 12px 14px;
+      cursor: pointer;
+      border-bottom: 1px solid #f0f0f0;
+      transition: background 0.15s;
+      gap: 12px;
+    }
+    .product-option:last-child { border-bottom: none; }
+    .product-option:hover { background: #F5F0E8; }
+    .option-name { font: 600 14px 'Manrope', sans-serif; color: #1A1A1A; }
+    .option-pack { font: 400 12px 'Manrope', sans-serif; color: #888; white-space: nowrap; flex-shrink: 0; }
+    .product-option-empty { padding: 20px; text-align: center; font: 400 14px 'Manrope', sans-serif; color: #bbb; }
+
+    /* ── Session items ── */
+    .session-items-heading {
+      font: 700 13px 'Manrope', sans-serif;
+      color: #999;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      margin-bottom: 12px;
+    }
+    .session-item {
+      background: #fff;
+      border-radius: 8px;
+      padding: 14px 16px;
+      margin-bottom: 8px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    }
+    .item-info { flex: 1; min-width: 0; }
+    .item-name { font: 700 14px 'Manrope', sans-serif; color: #1A1A1A; display: block; }
+    .item-pack { font: 400 12px 'Manrope', sans-serif; color: #888; }
+    .item-temp { font: 600 13px 'Manrope', sans-serif; color: #555; white-space: nowrap; display: flex; align-items: center; gap: 5px; }
+    .item-temp.muted { color: #bbb; font-weight: 400; }
+    .item-temp-badge { font: 700 11px 'Manrope', sans-serif; padding: 2px 7px; border-radius: 10px; }
+    .item-temp-badge.pass { background: #e6f4e6; color: #2a7a2a; }
+    .item-temp-badge.fail { background: #fde8e8; color: #C41E1E; }
+    .item-remove {
+      background: none;
+      border: none;
+      color: #ccc;
+      font-size: 20px;
+      cursor: pointer;
+      padding: 0 4px;
+      line-height: 1;
+      flex-shrink: 0;
+      transition: color 0.15s;
+    }
+    .item-remove:hover { color: #C41E1E; }
+
+    /* ── Toast ── */
+    .toast {
+      position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%);
+      padding: 12px 24px; border-radius: 6px; font: 700 14px 'Manrope', sans-serif;
+      color: #fff; z-index: 99999; box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+      pointer-events: none; opacity: 1; transition: opacity 0.4s ease;
+      white-space: nowrap; background: #1A1A1A;
+    }
+    .toast.success { background: #2a7a2a; }
+    .toast.error   { background: #C41E1E; }
+    .toast.fade    { opacity: 0; }
+
+    /* ── Scan area locked state hint ── */
+    .locked-hint {
+      text-align: center;
+      padding: 32px;
+      font: 400 14px 'Manrope', sans-serif;
+      color: #bbb;
+    }
+
+    /* ── Warning banner ── */
+    .warn-banner {
+      background: #fff8e6;
+      border: 1px solid #f0c050;
+      border-radius: 6px;
+      padding: 10px 14px;
+      font: 600 13px 'Manrope', sans-serif;
+      color: #a07000;
+      margin-bottom: 12px;
+    }
+
+    @media (max-width: 540px) {
+      .session-grid { grid-template-columns: 1fr; }
+      .session-grid .span-2 { grid-column: span 1; }
+      .new-product-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+
+  <nav class="site-nav">
+    <div class="nav-wrap">
+      <a href="../v2/index.html"><img src="https://www.dangerouspretzel.com/images/logos/svg-logo.svg" alt="Dangerous Pretzel Co." class="nav-logo"></a>
+      <div class="nav-links">
+        <a href="../v2/menu.html">Menu</a>
+        <a href="../v2/catering.html">Catering</a>
+        <a href="../v2/index.html">Home</a>
+        <a href="../delivery-planner/index.html">Delivery Planner</a>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>RECEIVING.</h1>
+  </section>
+
+  <div class="section-cream">
+    <div class="max-800">
+
+      <!-- Session Header -->
+      <div class="card" id="session-header">
+        <div class="card-title">Session Details</div>
+        <div class="session-grid">
+          <div class="field-group">
+            <label for="employee-name">Received By</label>
+            <input type="text" id="employee-name" placeholder="Your name" autocomplete="off">
+          </div>
+          <div class="field-group">
+            <label for="supplier-select">Supplier</label>
+            <select id="supplier-select">
+              <option value="">Select supplier…</option>
+              <option value="usfoods">US Foods</option>
+              <option value="sysco">Sysco</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+          <div class="field-group" id="other-supplier-wrap" hidden>
+            <label for="other-supplier">Supplier Name</label>
+            <input type="text" id="other-supplier" placeholder="Enter supplier name" autocomplete="off">
+          </div>
+          <div class="field-group span-2">
+            <label>Date</label>
+            <div class="date-display" id="date-display"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Scan Area -->
+      <div class="card" id="scan-card">
+        <div class="card-title">Scan Items</div>
+
+        <div class="scan-input-wrap">
+          <input
+            type="text"
+            id="barcode-input"
+            placeholder="Scan barcode here…"
+            autocomplete="off"
+            spellcheck="false"
+            disabled
+          >
+          <p class="scan-hint" id="scan-hint">Enter your name and select a supplier to begin.</p>
+        </div>
+
+        <!-- Inline warning (non-16-char barcode with US Foods selected) -->
+        <div id="barcode-warn" class="warn-banner" hidden></div>
+
+        <!-- Matched product card -->
+        <div id="product-card" class="product-card" hidden>
+          <div class="product-label">Product Identified</div>
+          <span class="product-name-display" id="product-name-display"></span>
+          <span class="product-pack-display" id="product-pack-display"></span>
+
+          <div id="temp-area" hidden>
+            <div class="temp-field">
+              <label for="temp-input">Temperature (°F)</label>
+              <div class="temp-input-wrap">
+                <input type="number" id="temp-input" placeholder="e.g. 38" step="0.1" min="-20" max="200">
+                <div id="temp-badge" class="temp-badge"></div>
+              </div>
+              <p class="temp-threshold">Must be below 42°F to pass</p>
+            </div>
+          </div>
+
+          <button id="add-item-btn" class="btn-primary" disabled>Add to Session</button>
+        </div>
+
+        <!-- New product form (US Foods unknown barcode) -->
+        <div id="new-product-form" class="new-product-form" hidden>
+          <div class="new-product-header">
+            <span class="new-product-title">Unknown Product</span>
+            <span class="new-product-code" id="new-product-code-display"></span>
+          </div>
+          <p class="new-product-hint">This barcode isn't in the system yet. Fill in the details below to add it and continue.</p>
+          <div class="new-product-grid">
+            <div class="field-group">
+              <label for="new-product-name">Product Name</label>
+              <input type="text" id="new-product-name" placeholder="e.g. Cheese, Cheddar Mild" autocomplete="off">
+            </div>
+            <div class="field-group">
+              <label for="new-product-pack">Pack Size (e.g. 4/5/LB)</label>
+              <input type="text" id="new-product-pack" placeholder="e.g. 4/5/LB" autocomplete="off">
+            </div>
+          </div>
+          <label class="checkbox-label">
+            <input type="checkbox" id="new-product-temp">
+            Requires temperature check (refrigerated / dairy / fresh)
+          </label>
+          <button id="save-new-product-btn" class="btn-primary">Save & Continue</button>
+        </div>
+
+        <!-- Product selector (Sysco / Other / fallback) -->
+        <div id="product-selector" class="product-selector" hidden>
+          <label for="product-search">Select Product</label>
+          <input type="text" id="product-search" placeholder="Type to search products…" autocomplete="off">
+          <div id="product-options" class="product-options"></div>
+        </div>
+
+      </div>
+
+      <!-- Session Items -->
+      <div id="session-section" hidden>
+        <div class="session-items-heading">Items This Session</div>
+        <div id="session-items"></div>
+        <button id="submit-btn" class="btn-submit" disabled>Submit Receiving Session</button>
+      </div>
+
+    </div>
+  </div>
+
+  <script type="module">
+    import { appendLog } from '../../scripts/sheet-logger.js';
+
+    // ─────────────────────────────────────────────────────────────
+    // PRODUCT CATALOG
+    // To add a product: copy any line below, fill in all fields, save the file.
+    //
+    // Fields:
+    //   id          – unique identifier (use "usf-XXXXXXX" for US Foods items)
+    //   name        – full product name as it should appear in records
+    //   packSize    – case size in COUNT/SIZE/UNIT format (e.g. 4/5/LB)
+    //   requiresTemp – true for all dairy, refrigerated, and fresh produce items
+    //   usFoodsCode – the 7-digit product code found at chars 7–13 of the US Foods
+    //                 barcode (leave as '' for Sysco-only items)
+    // ─────────────────────────────────────────────────────────────
+    const PRODUCTS = [
+      { id: 'usf-0877506', name: 'Butter, Salted Solid AA Grd',               packSize: '36/1/LB',    requiresTemp: true,  usFoodsCode: '0877506' },
+      { id: 'usf-0033858', name: 'Salt, Sea KO Not Iodz Gran Box',             packSize: '12/3/LB',    requiresTemp: false, usFoodsCode: '0033858' },
+      { id: 'usf-1008416', name: 'Flour, Bread Enriched Bleached Big Loaf',    packSize: '1/50/LB',    requiresTemp: false, usFoodsCode: '1008416' },
+      { id: 'usf-4364063', name: 'Mustard, Yellow Plastic Jar Shelf Stable',   packSize: '4/1/GAL',    requiresTemp: false, usFoodsCode: '4364063' },
+      { id: 'usf-7016876', name: 'Sugar, Powdered Confectionary',              packSize: '1/50/LB',    requiresTemp: false, usFoodsCode: '7016876' },
+      { id: 'usf-7329113', name: 'Mayonnaise, Heavy Plastic Jug Shelf Stable', packSize: '4/1/GAL',    requiresTemp: false, usFoodsCode: '7329113' },
+      { id: 'usf-0746479', name: 'Cheese, Pepper Jack Shredded Bag',           packSize: '4/5/LB',     requiresTemp: true,  usFoodsCode: '0746479' },
+      { id: 'usf-1324079', name: 'Cream, Whipping Heavy 40%',                  packSize: '2/1/GAL',    requiresTemp: true,  usFoodsCode: '1324079' },
+      { id: 'usf-1492816', name: 'Cheese, Parmesan Shaved Bag',                packSize: '2/5/LB',     requiresTemp: true,  usFoodsCode: '1492816' },
+      { id: 'usf-3547205', name: 'Pepper, Chili, Fresno Red Fresh',            packSize: '1/5/LB',     requiresTemp: true,  usFoodsCode: '3547205' },
+      { id: 'usf-5328406', name: 'Dressing, Ranch, Buttermilk',                packSize: '1/1/GAL',    requiresTemp: true,  usFoodsCode: '5328406' },
+      { id: 'usf-6773394', name: 'Juice, Lemon Meyer Blend',                   packSize: '1/32/OZ',    requiresTemp: false, usFoodsCode: '6773394' },
+      { id: 'usf-7017429', name: 'Basil, Fresh Herb',                          packSize: '1/1/LB',     requiresTemp: true,  usFoodsCode: '7017429' },
+      { id: 'usf-8123322', name: 'Cheese, Cheddar Yellow Mild Shredded',       packSize: '4/5/LB',     requiresTemp: true,  usFoodsCode: '8123322' },
+      { id: 'usf-5329420', name: 'Liner, 60 Gal',                              packSize: '1/100/EA',   requiresTemp: false, usFoodsCode: '5329420' },
+      { id: 'usf-8340861', name: 'Cheese, Cream Plain Loaf',                   packSize: '10/3/LB',    requiresTemp: true,  usFoodsCode: '8340861' },
+      { id: 'usf-7807993', name: 'Glove, Vinyl Medium',                        packSize: '10/100/EA',  requiresTemp: false, usFoodsCode: '7807993' },
+      { id: 'usf-3022647', name: 'Yeast, Dry Active',                          packSize: '20/1/LB',    requiresTemp: false, usFoodsCode: '3022647' },
+      { id: 'usf-6401780', name: 'Cheese, Cheddar Sharp Shredded',             packSize: '4/5/LB',     requiresTemp: true,  usFoodsCode: '6401780' },
+      { id: 'usf-3737152', name: 'Honey, Amber Light',                         packSize: '1/5/LB',     requiresTemp: false, usFoodsCode: '3737152' },
+      { id: 'usf-7330202', name: 'Mustard, Dijon Whole Grain Can',             packSize: '1/8.6/LB',   requiresTemp: false, usFoodsCode: '7330202' },
+      { id: 'usf-1332642', name: 'Cheese, Cheddar Mild Shredded',              packSize: '4/5/LB',     requiresTemp: true,  usFoodsCode: '1332642' },
+      { id: 'usf-7326432', name: 'Parsley, Washed and Destemmed',              packSize: '1/1/LB',     requiresTemp: true,  usFoodsCode: '7326432' },
+      { id: 'usf-3330487', name: 'Garlic, Chopped in Water',                   packSize: '6/32/OZ',    requiresTemp: true,  usFoodsCode: '3330487' },
+      { id: 'usf-9929174', name: 'Pepper, Jalapeno #1 Fresh',                  packSize: '1/10/LB',    requiresTemp: true,  usFoodsCode: '9929174' },
+      // ── Add new products below this line ─────────────────────────
+    ];
+
+    const TEMP_THRESHOLD = 42;
+    const LOG_PATH = '/dangpretz/receiving';
+
+    // ── State ────────────────────────────────────────────────────
+    let sessionId = generateId();
+    let sessionItems = [];
+    let pendingProduct = null;
+    let pendingBarcode = '';
+
+    // ── DOM refs ─────────────────────────────────────────────────
+    const nameInput       = document.getElementById('employee-name');
+    const supplierSelect  = document.getElementById('supplier-select');
+    const otherWrap       = document.getElementById('other-supplier-wrap');
+    const otherInput      = document.getElementById('other-supplier');
+    const barcodeInput    = document.getElementById('barcode-input');
+    const scanHint        = document.getElementById('scan-hint');
+    const barcodeWarn     = document.getElementById('barcode-warn');
+    const productCard     = document.getElementById('product-card');
+    const tempArea        = document.getElementById('temp-area');
+    const tempInput       = document.getElementById('temp-input');
+    const tempBadge       = document.getElementById('temp-badge');
+    const addItemBtn      = document.getElementById('add-item-btn');
+    const newProductForm  = document.getElementById('new-product-form');
+    const productSelector = document.getElementById('product-selector');
+    const productSearch   = document.getElementById('product-search');
+    const productOptions  = document.getElementById('product-options');
+    const sessionSection  = document.getElementById('session-section');
+    const sessionItemsEl  = document.getElementById('session-items');
+    const submitBtn       = document.getElementById('submit-btn');
+
+    // ── Date display ─────────────────────────────────────────────
+    document.getElementById('date-display').textContent =
+      new Date().toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+
+    // ── Session header listeners ──────────────────────────────────
+    nameInput.addEventListener('input', checkSessionReady);
+    supplierSelect.addEventListener('change', () => {
+      otherWrap.hidden = supplierSelect.value !== 'other';
+      checkSessionReady();
+    });
+    otherInput.addEventListener('input', checkSessionReady);
+
+    function checkSessionReady() {
+      const name = nameInput.value.trim();
+      const supplier = supplierSelect.value;
+      const otherOk = supplier !== 'other' || otherInput.value.trim();
+      const ready = name && supplier && otherOk;
+      barcodeInput.disabled = !ready;
+      scanHint.textContent = ready
+        ? 'Scan a barcode or type it and press Enter.'
+        : 'Enter your name and select a supplier to begin.';
+      if (ready) barcodeInput.focus();
+    }
+
+    // ── Barcode input ─────────────────────────────────────────────
+    barcodeInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const raw = barcodeInput.value.trim();
+        barcodeInput.value = '';
+        if (raw) handleBarcode(raw);
+      }
+    });
+
+    function handleBarcode(raw) {
+      pendingBarcode = raw;
+      pendingProduct = null;
+      hideAll();
+
+      const supplier = supplierSelect.value;
+
+      if (supplier === 'usfoods') {
+        if (raw.length !== 16) {
+          barcodeWarn.hidden = false;
+          barcodeWarn.textContent = `US Foods barcodes are 16 characters — this one is ${raw.length}. Select the product manually below.`;
+          showProductSelector();
+          return;
+        }
+        const code = raw.slice(6, 13);
+        const match = PRODUCTS.find((p) => p.usFoodsCode === code);
+        if (match) {
+          showProductCard(match);
+        } else {
+          showNewProductForm(code);
+        }
+      } else {
+        // Sysco or Other: manual select
+        showProductSelector();
+      }
+    }
+
+    // ── Product card ─────────────────────────────────────────────
+    function showProductCard(product) {
+      pendingProduct = product;
+      document.getElementById('product-name-display').textContent = product.name;
+      document.getElementById('product-pack-display').textContent = product.packSize;
+
+      tempArea.hidden = !product.requiresTemp;
+      if (product.requiresTemp) {
+        tempInput.value = '';
+        tempBadge.textContent = '';
+        tempBadge.className = 'temp-badge';
+      }
+
+      productCard.hidden = false;
+      updateAddButton();
+
+      if (product.requiresTemp) {
+        tempInput.focus();
+      } else {
+        addItemBtn.focus();
+      }
+    }
+
+    // ── Temp ─────────────────────────────────────────────────────
+    tempInput.addEventListener('input', () => {
+      const t = parseFloat(tempInput.value);
+      if (isNaN(t) || tempInput.value === '') {
+        tempBadge.textContent = '';
+        tempBadge.className = 'temp-badge';
+      } else if (t < TEMP_THRESHOLD) {
+        tempBadge.textContent = '✓ Pass';
+        tempBadge.className = 'temp-badge pass';
+      } else {
+        tempBadge.textContent = '✗ Fail';
+        tempBadge.className = 'temp-badge fail';
+      }
+      updateAddButton();
+    });
+
+    function updateAddButton() {
+      if (!pendingProduct) { addItemBtn.disabled = true; return; }
+      if (pendingProduct.requiresTemp) {
+        addItemBtn.disabled = isNaN(parseFloat(tempInput.value));
+      } else {
+        addItemBtn.disabled = false;
+      }
+    }
+
+    // ── Add item ─────────────────────────────────────────────────
+    addItemBtn.addEventListener('click', addItem);
+
+    function addItem() {
+      if (!pendingProduct) return;
+      const temp = pendingProduct.requiresTemp ? parseFloat(tempInput.value) : null;
+      sessionItems.push({
+        barcode:      pendingBarcode,
+        productId:    pendingProduct.id,
+        productName:  pendingProduct.name,
+        packSize:     pendingProduct.packSize,
+        requiresTemp: pendingProduct.requiresTemp,
+        temperature:  temp,
+        tempPass:     temp !== null ? temp < TEMP_THRESHOLD : null,
+      });
+      pendingProduct = null;
+      pendingBarcode = '';
+      hideAll();
+      renderSessionItems();
+      barcodeInput.focus();
+    }
+
+    // ── New product form ─────────────────────────────────────────
+    function showNewProductForm(code) {
+      document.getElementById('new-product-code-display').textContent = `Code: ${code}`;
+      document.getElementById('new-product-name').value = '';
+      document.getElementById('new-product-pack').value = '';
+      document.getElementById('new-product-temp').checked = false;
+      newProductForm.hidden = false;
+      document.getElementById('new-product-name').focus();
+    }
+
+    document.getElementById('save-new-product-btn').addEventListener('click', async () => {
+      const name     = document.getElementById('new-product-name').value.trim();
+      const packSize = document.getElementById('new-product-pack').value.trim();
+      const reqTemp  = document.getElementById('new-product-temp').checked;
+      const codeText = document.getElementById('new-product-code-display').textContent.replace('Code: ', '');
+
+      if (!name || !packSize) {
+        showToast('Please fill in product name and pack size', 'error');
+        return;
+      }
+
+      const newProduct = { id: `new-${codeText}`, name, packSize, requiresTemp: reqTemp, usFoodsCode: codeText };
+      PRODUCTS.push(newProduct);
+
+      // Log the new product so it can be added to the code later
+      try {
+        await appendLog(LOG_PATH, {
+          action:       'new_product',
+          usFoodsCode:  codeText,
+          productName:  name,
+          packSize,
+          requiresTemp: String(reqTemp),
+          timeStamp:    new Date().toISOString(),
+          addedBy:      nameInput.value.trim(),
+        });
+      } catch (_) { /* non-critical — proceed regardless */ }
+
+      newProductForm.hidden = true;
+      showToast('Product added — remember to add it to the code!', 'success');
+      showProductCard(newProduct);
+    });
+
+    // ── Product selector ─────────────────────────────────────────
+    function showProductSelector() {
+      productSearch.value = '';
+      renderProductOptions('');
+      productSelector.hidden = false;
+      productSearch.focus();
+    }
+
+    productSearch.addEventListener('input', () => renderProductOptions(productSearch.value));
+
+    function renderProductOptions(query) {
+      const q = query.toLowerCase().trim();
+      const matches = q
+        ? PRODUCTS.filter((p) => p.name.toLowerCase().includes(q))
+        : [...PRODUCTS].sort((a, b) => a.name.localeCompare(b.name));
+
+      if (matches.length === 0) {
+        productOptions.innerHTML = '<div class="product-option-empty">No products found</div>';
+        return;
+      }
+      productOptions.innerHTML = matches.map((p) => `
+        <div class="product-option" data-id="${escapeHtml(p.id)}">
+          <span class="option-name">${escapeHtml(p.name)}</span>
+          <span class="option-pack">${escapeHtml(p.packSize)}</span>
+        </div>`).join('');
+
+      productOptions.querySelectorAll('.product-option').forEach((el) => {
+        el.addEventListener('click', () => {
+          const product = PRODUCTS.find((p) => p.id === el.dataset.id);
+          if (!product) return;
+          productSelector.hidden = true;
+          barcodeWarn.hidden = true;
+          showProductCard(product);
+        });
+      });
+    }
+
+    // ── Session items ─────────────────────────────────────────────
+    function renderSessionItems() {
+      if (sessionItems.length === 0) {
+        sessionSection.hidden = true;
+        submitBtn.disabled = true;
+        return;
+      }
+      sessionSection.hidden = false;
+      submitBtn.disabled = false;
+
+      sessionItemsEl.innerHTML = sessionItems.map((item, i) => {
+        const tempHtml = item.requiresTemp
+          ? `<span class="item-temp">${item.temperature}°F <span class="item-temp-badge ${item.tempPass ? 'pass' : 'fail'}">${item.tempPass ? '✓ Pass' : '✗ Fail'}</span></span>`
+          : '<span class="item-temp muted">No temp req.</span>';
+        return `
+          <div class="session-item">
+            <div class="item-info">
+              <span class="item-name">${escapeHtml(item.productName)}</span>
+              <span class="item-pack">${escapeHtml(item.packSize)}</span>
+            </div>
+            ${tempHtml}
+            <button class="item-remove" data-index="${i}" title="Remove item">&times;</button>
+          </div>`;
+      }).join('');
+
+      sessionItemsEl.querySelectorAll('.item-remove').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          sessionItems.splice(parseInt(btn.dataset.index, 10), 1);
+          renderSessionItems();
+        });
+      });
+    }
+
+    // ── Submit ────────────────────────────────────────────────────
+    submitBtn.addEventListener('click', submitSession);
+
+    async function submitSession() {
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Submitting…';
+
+      const receivedBy   = nameInput.value.trim();
+      const supplierVal  = supplierSelect.value;
+      const supplierName = supplierVal === 'other' ? otherInput.value.trim() : supplierVal;
+      const date         = new Date().toISOString().slice(0, 10);
+
+      try {
+        for (const item of sessionItems) {
+          await appendLog(LOG_PATH, {
+            action:       'receive',
+            sessionId,
+            receivedBy,
+            date,
+            timeStamp:    new Date().toISOString(),
+            supplier:     supplierName,
+            barcode:      item.barcode,
+            productId:    item.productId,
+            productName:  item.productName,
+            packSize:     item.packSize,
+            requiresTemp: String(item.requiresTemp),
+            temperature:  item.temperature !== null ? String(item.temperature) : '',
+            tempPass:     item.tempPass !== null ? String(item.tempPass) : '',
+          });
+        }
+        const count = sessionItems.length;
+        showToast(`✓ ${count} item${count !== 1 ? 's' : ''} logged successfully`, 'success');
+        sessionItems = [];
+        sessionId = generateId();
+        pendingProduct = null;
+        pendingBarcode = '';
+        hideAll();
+        renderSessionItems();
+        barcodeInput.focus();
+      } catch (err) {
+        showToast('Submit failed: ' + (err.message || 'unknown error'), 'error');
+        submitBtn.disabled = false;
+      } finally {
+        submitBtn.textContent = 'Submit Receiving Session';
+      }
+    }
+
+    // ── Utilities ─────────────────────────────────────────────────
+    function hideAll() {
+      productCard.hidden     = true;
+      newProductForm.hidden  = true;
+      productSelector.hidden = true;
+      barcodeWarn.hidden     = true;
+    }
+
+    function generateId() {
+      return typeof crypto !== 'undefined' && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `rec-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    }
+
+    function escapeHtml(s) {
+      return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    }
+
+    function showToast(msg, kind = '') {
+      const t = document.createElement('div');
+      t.className = 'toast' + (kind ? ' ' + kind : '');
+      t.textContent = msg;
+      document.body.appendChild(t);
+      setTimeout(() => { t.classList.add('fade'); setTimeout(() => t.remove(), 400); }, 3500);
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a single page at `/static/deliveries/index.html` combining receiving entry and history
- Top half: full receiving session form — employee name, supplier selection, barcode scanning, auto-product identification (US Foods), manual product selector (Sysco/Other), temperature tracking with pass/fail against 42°F threshold
- Bottom half: searchable receiving history filtered by product, supplier, date range, and temperature result
- Unknown US Foods products can be added on the fly and are automatically available in all future sessions (persisted via the receiving log)
- History refreshes automatically after each session is submitted

## Test plan
- [ ] Enter name + select US Foods → barcode input unlocks
- [ ] Scan a known 16-char US Foods barcode → product auto-identifies
- [ ] Scan an unknown barcode → add new product form appears, save it, confirm it appears in future sessions
- [ ] Select Sysco → manual product selector appears
- [ ] Select Other → supplier name field appears
- [ ] Temp-required product: enter temp above 42 → red fail badge; below 42 → green pass badge
- [ ] Submit session → history refreshes and new session appears at top
- [ ] History filters work: product search, supplier, date range, temp pass/fail
- [ ] Confirm no other pages affected (new file only)

Test URLs:
- Before: https://main--website--dangpretz.aem.page/static/receiving/index.html
- After: https://feature-delivery-history-page--website--dangpretz.aem.page/static/deliveries/index.html