### PR TITLE
Rename deliveries page to Receiving History and add nav links

### DIFF
--- a/static/barcode-lookup/index.html
+++ b/static/barcode-lookup/index.html
@@ -187,6 +187,7 @@
         <a href="../v2/catering.html">Catering</a>
         <a href="../v2/index.html">Home</a>
         <a href="../delivery-planner/index.html">Delivery Planner</a>
+        <a href="../deliveries/index.html">Receiving History</a>
       </div>
     </div>
   </nav>

--- a/static/deliveries/index.html
+++ b/static/deliveries/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Receiving | Dangerous Pretzel Co.</title>
+  <title>Receiving History | Dangerous Pretzel Co.</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700;800&family=Paytone+One&display=swap" rel="stylesheet">
@@ -221,12 +221,13 @@
         <a href="../v2/catering.html">Catering</a>
         <a href="../v2/index.html">Home</a>
         <a href="../delivery-planner/index.html">Delivery Planner</a>
+        <a href="../deliveries/index.html">Receiving History</a>
       </div>
     </div>
   </nav>
 
   <section class="hero">
-    <h1>RECEIVING.</h1>
+    <h1>RECEIVING HISTORY.</h1>
   </section>
 
   <!-- ══ ENTRY FORM ══════════════════════════════════════════════ -->

--- a/static/receiving/index.html
+++ b/static/receiving/index.html
@@ -319,6 +319,7 @@
         <a href="../v2/catering.html">Catering</a>
         <a href="../v2/index.html">Home</a>
         <a href="../delivery-planner/index.html">Delivery Planner</a>
+        <a href="../deliveries/index.html">Receiving History</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- Renames the deliveries page title and hero heading to "Receiving History"
- Adds "Receiving History" nav link to the barcode lookup and receiving pages
- No functional changes — cosmetic and navigation only

Test URLs:
- Before: https://main--website--dangpretz.aem.page/static/deliveries/index.html
- After: https://feature-delivery-history-page--website--dangpretz.aem.page/static/deliveries/index.html