### PR TITLE
Phase 3: FOH retail dips (hot ranch, sweet cream, house mustard, honey mustard) + onHand bucket

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -681,17 +681,24 @@ export function getInventoryReport(args) {
         }
       });
     } else if (row.action === 'cheese_done') {
-      // FOH cheese batch: 1 batch = CHEESE_BATCH_SIZE dips; lives in cf
-      // (refrigerated) until consumed by deliveries or FOH walk-in.
-      // No separate "bake" stage — single-step product. Same dough-age
-      // queue mechanics so the 5-day shelf-life alert fires.
+      // FOH dip batch (cheese or any retail dip in DIP_CONFIG). 1 batch =
+      // singleBatchSize dips by default; if c.size === 'double', credits
+      // doubleBatchSize. Lives in cf (refrigerated) until consumed by
+      // deliveries or FOH walk-in. No separate "bake" stage — single-step
+      // product. Same dough-age queue mechanics so the shelf-life alert fires.
       let comps = []; try { comps = JSON.parse(row.completions || '[]'); } catch {}
       comps.forEach((c) => {
         let key = (c.sku || '').trim();
         if (!key) return;
         if (skuAliases[key]) key = skuAliases[key];
-        const bs = getBatchSize(key);
-        if (!bs) return;
+        const cfg = DIP_CONFIG[key];
+        let bs;
+        if (cfg) {
+          bs = c.size === 'double' ? cfg.doubleBatchSize : cfg.singleBatchSize;
+        } else {
+          bs = getBatchSize(key);
+          if (!bs) return;
+        }
         const batches = Number(c.batches) || 0;
         const p = batches * bs;
         cf[key] = (cf[key] || 0) + p;

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -40,14 +40,91 @@
 export const DOUGH_AGE_WARN_DAYS = 5; // yellow aging-dough banner threshold
 export const DOUGH_AGE_FAIL_DAYS = 6; // red banner — discard or use today
 
-// Cheese-dip production rules. Lead-time semantics: a batch must be ready
-// at least 2 days before the delivery it covers, but can be made up to 5
-// days ahead. After 5 days, cheese goes stale (mirrors the dough age queue
-// for shape work).
-export const CHEESE_MIN_LEAD = 2; // make ≥ N days before delivery
-export const CHEESE_MAX_LEAD = 5; // no more than N days before delivery
-export const CHEESE_BATCH_SIZE = 150; // dips per batch
-export const CHEESE_DAILY_CAP = 1; // max batches/day for FOH cheese maker
+// FOH dip production rules — one entry per SKU made by the FOH cheese maker.
+// Lead-time: a batch must be ready ≥ minLead days before consumption, but
+// can be made up to maxLead days ahead. Past maxLead the batch goes stale.
+//   - cheese is one batch size only (150 dips); single/double map to same value
+//   - retail dips have a single (35) or double (70) batch size — the scheduler
+//     picks single by default, upgrades to double if the same-day deficit
+//     exceeds singleBatchSize
+//   - all dips share the same FOH cheese maker (dailyCap=1 across the lane;
+//     enforcement in scheduleDip is per-SKU for now — Phase 4 cross-dip cap
+//     deferred)
+export const DIP_CONFIG = {
+  '3oz cheese dip': {
+    key: 'cheese',
+    emoji: '🧀',
+    label: 'cheese dip',
+    minLead: 2,
+    maxLead: 5,
+    singleBatchSize: 150,
+    doubleBatchSize: 150, // cheese has only one size
+    dailyCap: 1,
+    shelfLifeDays: 5,
+    // Square match patterns — used by the worker's /dip-consumption endpoint.
+    squareNames: [/^dangerous\s*dip(\s*-\s*catering)?$/i],
+    squareModifiers: [/^dangerous\s*dip$/i],
+  },
+  'hot ranch dip': {
+    key: 'hot-ranch',
+    emoji: '🌶',
+    label: 'hot ranch',
+    minLead: 1,
+    maxLead: 7,
+    singleBatchSize: 35,
+    doubleBatchSize: 70,
+    dailyCap: 1,
+    shelfLifeDays: 7,
+    squareNames: [/^hot\s*ranch(\s*-\s*catering)?$/i],
+    squareModifiers: [/^hot\s*ranch$/i],
+  },
+  'sweet cream dip': {
+    key: 'sweet-cream',
+    emoji: '🥛',
+    label: 'sweet cream',
+    minLead: 1,
+    maxLead: 7,
+    singleBatchSize: 35,
+    doubleBatchSize: 70,
+    dailyCap: 1,
+    shelfLifeDays: 7,
+    squareNames: [/^sweet\s*cream(\s*-\s*catering)?$/i],
+    squareModifiers: [/^sweet\s*cream$/i],
+  },
+  'house mustard dip': {
+    key: 'house-mustard',
+    emoji: '💛',
+    label: 'house mustard',
+    minLead: 1,
+    maxLead: 7,
+    singleBatchSize: 35,
+    doubleBatchSize: 70,
+    dailyCap: 1,
+    shelfLifeDays: 7,
+    squareNames: [/^house\s*mustard(\s*-\s*catering)?$/i],
+    squareModifiers: [/^house\s*mustard$/i],
+  },
+  'honey mustard dip': {
+    key: 'honey-mustard',
+    emoji: '🍯',
+    label: 'honey mustard',
+    minLead: 1,
+    maxLead: 7,
+    singleBatchSize: 35,
+    doubleBatchSize: 70,
+    dailyCap: 1,
+    shelfLifeDays: 7,
+    squareNames: [/^honey\s*mustard(\s*-\s*catering)?$/i],
+    squareModifiers: [/^honey\s*mustard$/i],
+  },
+};
+
+// Backward-compat shims — callers that imported the old constants still work.
+// Phase 3b+ should read DIP_CONFIG['3oz cheese dip'] directly.
+export const CHEESE_MIN_LEAD = DIP_CONFIG['3oz cheese dip'].minLead;
+export const CHEESE_MAX_LEAD = DIP_CONFIG['3oz cheese dip'].maxLead;
+export const CHEESE_BATCH_SIZE = DIP_CONFIG['3oz cheese dip'].singleBatchSize;
+export const CHEESE_DAILY_CAP = DIP_CONFIG['3oz cheese dip'].dailyCap;
 
 // Pretzels per batch (per-SKU; skuConfig override takes priority).
 // 3oz cheese dip is in here at batchSize 150 — it's tracked production now,
@@ -825,109 +902,108 @@ function addDaysISO(s, n) {
 }
 
 /**
- * Schedule cheese-dip batches for the FOH cheese maker.
+ * Schedule batches for any FOH dip (cheese, hot ranch, sweet cream, etc).
  *
- * Phantom-delivery model: combines per-day delivery demand (from active
- * deliveries with `3oz cheese dip` line items) with a constant FOH walk-in
- * rate (`fohDailyAvg`, fed in from the Square consumption endpoint), then
- * walks forward day-by-day. When inventory would dip negative, schedules
- * one batch on the LATEST valid day inside the [delivery − CHEESE_MAX_LEAD,
- * delivery − CHEESE_MIN_LEAD] window. Honors the 1-batch/day capacity cap.
+ * Phantom-delivery model: combines per-day delivery demand (line items
+ * matching this dip's SKU) with a constant FOH walk-in rate, walks
+ * forward day-by-day, and when inventory would dip negative, schedules
+ * one batch on the LATEST valid day inside the [day − maxLead, day − minLead]
+ * window. Honors the dailyCap cap. Single batch by default; upgrades to
+ * double when same-day deficit exceeds singleBatchSize.
  *
  * Used by:
- *   - production app (Cheese tab) — manager sees per-day "make a batch" cards.
+ *   - production app (Dips tab) — manager sees per-day "make a batch" cards.
  *   - worker (/foh-cal.ics) — emits an iCalendar VEVENT per scheduled batch.
  * Both call this exact function so the calendar and the manager view never
  * disagree.
  *
  * @param {Object} args
+ * @param {string} args.dipSku              Key into DIP_CONFIG (e.g. '3oz cheese dip').
  * @param {Array}  args.deliveries          Resolved deliveries (active + confirmed).
  * @param {Object} args.inventoryReport     From getInventoryReport.
- * @param {number} args.fohDailyAvg         Average FOH walk-in cheese dips/day (Square).
+ * @param {number} args.fohDailyAvg         Average FOH walk-in units/day for this dip (Square).
  * @param {string} args.today               'YYYY-MM-DD' (Mountain TZ).
  * @param {Object} args.skuAliases          From resolveProductionLogs.
  * @param {number} [args.lookaheadDays=14]  How far forward to plan.
  * @returns {{
- *   batches: Array<{date: string, dayIndex: number, covers: Array<{customer, qty, deliveryDate}>, foh: number, overdue: boolean}>,
- *   demandByDate: Array<{date: string, delivery: number, foh: number, total: number}>,
+ *   dipSku: string,
+ *   batches: Array<{date, dayIndex, covers, foh, overdue, fillsDay, size: 'single'|'double', units: number}>,
+ *   demandByDate: Array<{date, delivery, foh, total, covers}>,
  *   startInventory: number,
  *   fohDailyAvg: number,
  * }}
  */
-export function scheduleCheese({
-  deliveries, inventoryReport, fohDailyAvg, today, skuAliases, lookaheadDays = 14,
+export function scheduleDip({
+  dipSku, deliveries, inventoryReport, fohDailyAvg, today, skuAliases, lookaheadDays = 14,
 }) {
+  const cfg = DIP_CONFIG[dipSku];
+  if (!cfg) throw new Error(`scheduleDip: unknown dipSku "${dipSku}"`);
   const dailyAvg = Math.max(0, Number(fohDailyAvg) || 0);
   // Look further than the user-visible horizon so the algorithm "sees" deliveries
   // whose window straddles the edge (e.g. a delivery on day 16 has a window
   // ending on day 14, which we still need to plan for).
-  const dayCount = lookaheadDays + CHEESE_MAX_LEAD + 1;
+  const dayCount = lookaheadDays + cfg.maxLead + 1;
 
-  // Per-day demand. delivery from line items; foh constant (manager-tunable
-  // via Square consumption endpoint). We accumulate "covers" for each day
-  // so the calendar event can list which customers a batch is for.
   const demand = Array.from({ length: dayCount }, (_, i) => ({
     date: addDaysISO(today, i),
     delivery: 0,
     foh: dailyAvg,
     total: dailyAvg,
-    covers: [], // [{ customer, qty, deliveryDate }]
+    covers: [],
   }));
 
   (deliveries || []).forEach((d) => {
     if (['delivered', 'picked_up', 'cancelled'].includes(d.status)) return;
-    if (!d.date || d.date < today) return; // past unconfirmed ghosts don't count
+    if (!d.date || d.date < today) return;
     let lineItems = [];
     try { lineItems = JSON.parse(d.lineItems || '[]'); } catch {}
-    let cheeseQty = 0;
+    let qtyForDip = 0;
     lineItems.forEach(({ sku, quantity }) => {
       let key = (sku || '').trim();
       if (skuAliases && skuAliases[key]) key = skuAliases[key];
-      if (key !== CHEESE_SKU_KEY) return;
-      cheeseQty += Number(quantity) || 0;
+      if (key !== dipSku) return;
+      qtyForDip += Number(quantity) || 0;
     });
-    if (cheeseQty <= 0) return;
-    // Find the day index for this delivery (today=0).
+    if (qtyForDip <= 0) return;
     const dayIdx = (() => {
       const ms = parseISODate(d.date) - parseISODate(today);
       return Math.round(ms / 86400000);
     })();
     if (dayIdx < 0 || dayIdx >= dayCount) return;
-    demand[dayIdx].delivery += cheeseQty;
-    demand[dayIdx].total += cheeseQty;
+    demand[dayIdx].delivery += qtyForDip;
+    demand[dayIdx].total += qtyForDip;
     demand[dayIdx].covers.push({
       customer: d.customer || d.location || '?',
-      qty: cheeseQty,
+      qty: qtyForDip,
       deliveryDate: d.date,
     });
   });
 
-  // Starting inventory = sum across all three buckets for cheese.
-  //   - cheese_done log entries credit `cf`.
-  //   - Stock tab snapshots: pre-Phase-3a wrote to `fr` (the bug we
-  //     patched in #8); Phase 3a+ writes to `oh` (the on-hand bucket
-  //     for SKUs without a dough/bake lifecycle). Sum all three so old
-  //     and new snapshots both flow through correctly during transition.
-  const cfStart = inventoryReport?.effective?.coldFerment?.[CHEESE_SKU_KEY] || 0;
-  const frStart = inventoryReport?.effective?.frozen?.[CHEESE_SKU_KEY] || 0;
-  const ohStart = inventoryReport?.effective?.onHand?.[CHEESE_SKU_KEY] || 0;
+  // Starting inventory = sum across all three buckets. Pre-Phase-3a snapshots
+  // wrote to `fr`; Phase-3a+ writes to `oh`; cheese_done credits `cf`.
+  const cfStart = inventoryReport?.effective?.coldFerment?.[dipSku] || 0;
+  const frStart = inventoryReport?.effective?.frozen?.[dipSku] || 0;
+  const ohStart = inventoryReport?.effective?.onHand?.[dipSku] || 0;
   const startInventory = cfStart + frStart + ohStart;
 
-  // Walk forward. Track running stock. When stock would go negative on day i,
-  // schedule a batch on the latest valid day inside the [i-MAX_LEAD, i-MIN_LEAD]
-  // window. If no valid day exists (all in the past, or all already booked),
-  // mark it as overdue and force-place on today.
   const batches = [];
   const hasBatchOn = (dayIdx) => batches.some((b) => b.dayIndex === dayIdx);
+  // Pick batch size at placement time. If the immediate deficit (-inv at the
+  // time we decide to place) exceeds a single, upgrade to double.
+  const pickSize = (deficit) => {
+    if (cfg.doubleBatchSize === cfg.singleBatchSize) return { size: 'single', units: cfg.singleBatchSize };
+    if (deficit > cfg.singleBatchSize) return { size: 'double', units: cfg.doubleBatchSize };
+    return { size: 'single', units: cfg.singleBatchSize };
+  };
 
   let inv = startInventory;
   for (let i = 0; i < dayCount; i++) {
     inv -= demand[i].total;
     while (inv < 0) {
-      // Need 1 more batch placed on a day < i and within the window.
       let placed = false;
-      const earliest = Math.max(0, i - CHEESE_MAX_LEAD);
-      const latest = i - CHEESE_MIN_LEAD;
+      const earliest = Math.max(0, i - cfg.maxLead);
+      const latest = i - cfg.minLead;
+      const { size, units } = pickSize(-inv);
       for (let j = latest; j >= earliest; j--) {
         if (j < 0) break;
         if (hasBatchOn(j)) continue;
@@ -938,14 +1014,14 @@ export function scheduleCheese({
           foh: demand[i].foh,
           overdue: false,
           fillsDay: i,
+          size,
+          units,
         });
-        inv += CHEESE_BATCH_SIZE;
+        inv += units;
         placed = true;
         break;
       }
       if (!placed) {
-        // Window's all past or full. Force-place on today (or earliest open day)
-        // and flag overdue so the manager knows it's late.
         for (let j = 0; j < i; j++) {
           if (!hasBatchOn(j)) {
             batches.push({
@@ -955,26 +1031,32 @@ export function scheduleCheese({
               foh: demand[i].foh,
               overdue: true,
               fillsDay: i,
+              size,
+              units,
             });
-            inv += CHEESE_BATCH_SIZE;
+            inv += units;
             placed = true;
             break;
           }
         }
-        if (!placed) {
-          // Even today is full or i=0. Bail to avoid infinite loop.
-          break;
-        }
+        if (!placed) break; // bail to avoid infinite loop
       }
     }
   }
 
   return {
+    dipSku,
     batches: batches.sort((a, b) => a.dayIndex - b.dayIndex),
     demandByDate: demand.slice(0, lookaheadDays + 1),
     startInventory,
     fohDailyAvg: dailyAvg,
   };
+}
+
+// Backward-compat shim — existing callers still work, get the same output
+// with size:'single' on every batch (cheese has only one size).
+export function scheduleCheese(args) {
+  return scheduleDip({ dipSku: CHEESE_SKU_KEY, ...args });
 }
 
 export const CHEESE_KEY = CHEESE_SKU_KEY; // exported for callers that need the canonical SKU name

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -367,15 +367,19 @@ export function resolveProductionLogs(logs) {
     if (action === 'inventory') {
       try {
         const snaps = JSON.parse(row.snapshots || '[]');
-        const cf = {}; const
-          fr = {};
+        const cf = {};
+        const fr = {};
+        const oh = {}; // on-hand bucket — for SKUs with no dough/bake lifecycle (cheese, dips)
         snaps.forEach((sn) => {
           const k = canonicalSku(sn.sku);
           if (!k) return;
           cf[k] = Number(sn.coldFerment) || 0;
           fr[k] = Number(sn.frozen) || 0;
+          oh[k] = Number(sn.onHand) || 0;
         });
-        s.coldFerment = cf; s.frozen = fr;
+        s.coldFerment = cf;
+        s.frozen = fr;
+        s.onHand = oh;
       } catch {}
       if (row.timeStamp && (!latestInventoryTs || row.timeStamp > latestInventoryTs)) {
         latestInventoryTs = row.timeStamp;
@@ -476,14 +480,16 @@ export function resolveProductionLogs(logs) {
  * callers should use getInventoryReport().
  */
 export function getLatestInventory(productionState) {
-  const cf = {}; const
-    fr = {};
+  const cf = {};
+  const fr = {};
+  const oh = {};
   Object.keys(productionState).sort().forEach((ds) => {
     const s = productionState[ds];
     Object.entries(s.coldFerment || {}).forEach(([sku, n]) => { cf[sku] = Number(n) || 0; });
     Object.entries(s.frozen || {}).forEach(([sku, n]) => { fr[sku] = Number(n) || 0; });
+    Object.entries(s.onHand || {}).forEach(([sku, n]) => { oh[sku] = Number(n) || 0; });
   });
-  return { coldFerment: cf, frozen: fr };
+  return { coldFerment: cf, frozen: fr, onHand: oh };
 }
 
 /**
@@ -512,10 +518,16 @@ export function getInventoryReport(args) {
   const inv = getLatestInventory(productionState);
   const cf = { ...inv.coldFerment };
   const fr = { ...inv.frozen };
-  const snapshotRaw = { coldFerment: { ...inv.coldFerment }, frozen: { ...inv.frozen } };
+  const oh = { ...(inv.onHand || {}) };
+  const snapshotRaw = {
+    coldFerment: { ...inv.coldFerment },
+    frozen: { ...inv.frozen },
+    onHand: { ...(inv.onHand || {}) },
+  };
   const latestInvDate = Object.keys(productionState)
     .filter((ds) => Object.keys(productionState[ds].coldFerment || {}).length > 0
-                  || Object.keys(productionState[ds].frozen || {}).length > 0)
+                  || Object.keys(productionState[ds].frozen || {}).length > 0
+                  || Object.keys(productionState[ds].onHand || {}).length > 0)
     .sort().pop() || null;
 
   // Seed dough queue with snapshot cf — conservative ts = snapshot timestamp.
@@ -640,6 +652,11 @@ export function getInventoryReport(args) {
         const qty = Number(quantity) || 0;
         if (qty <= 0) return;
         if (fr[key] != null) fr[key] = Math.max(0, fr[key] - qty);
+        // onHand bucket: lifecycle-less SKUs (cheese, dips) live here.
+        // Until the first post-Phase-3a snapshot lands, oh[cheese] is
+        // undefined and fr deduction handles it. Once oh is populated,
+        // fr[cheese] = 0 so the fr line is a harmless no-op.
+        if (oh[key] != null) oh[key] = Math.max(0, oh[key] - qty);
         if (!flowDelivered[key]) flowDelivered[key] = [];
         flowDelivered[key].push({ customer: cust, qty, confirmedAt: delivery._confirmedAt || '' });
       });
@@ -647,6 +664,7 @@ export function getInventoryReport(args) {
 
   Object.keys(cf).forEach((k) => { cf[k] = Math.max(0, Math.round(cf[k])); });
   Object.keys(fr).forEach((k) => { fr[k] = Math.max(0, Math.round(fr[k])); });
+  Object.keys(oh).forEach((k) => { oh[k] = Math.max(0, Math.round(oh[k])); });
 
   // Aging dough alerts
   const now = Date.now();
@@ -669,7 +687,7 @@ export function getInventoryReport(args) {
   agingDough.sort((a, b) => b.ageDays - a.ageDays);
 
   return {
-    effective: { coldFerment: cf, frozen: fr },
+    effective: { coldFerment: cf, frozen: fr, onHand: oh },
     doughQueue,
     flowsSinceSnapshot: { shape: flowShape, bfp: flowBfp, delivered: flowDelivered },
     alerts: { agingDough },
@@ -884,18 +902,16 @@ export function scheduleCheese({
     });
   });
 
-  // Starting inventory = effective cf + fr for cheese.
-  //   - cheese_done log entries credit `cf` (the dough convention we
-  //     reused for batches-on-hand).
-  //   - The Stock tab's manual count writes to BOTH `cf` and `fr` from a
-  //     single user-entered "on hand" number; for items without a real
-  //     dough/baking lifecycle (cheese, bulk dip, etc.) the value lands
-  //     in `fr`. Sum both so a manual stock count reflects in the
-  //     scheduler — otherwise scheduleCheese sees 0 and force-overdues
-  //     every upcoming batch even when the fridge is full.
+  // Starting inventory = sum across all three buckets for cheese.
+  //   - cheese_done log entries credit `cf`.
+  //   - Stock tab snapshots: pre-Phase-3a wrote to `fr` (the bug we
+  //     patched in #8); Phase 3a+ writes to `oh` (the on-hand bucket
+  //     for SKUs without a dough/bake lifecycle). Sum all three so old
+  //     and new snapshots both flow through correctly during transition.
   const cfStart = inventoryReport?.effective?.coldFerment?.[CHEESE_SKU_KEY] || 0;
   const frStart = inventoryReport?.effective?.frozen?.[CHEESE_SKU_KEY] || 0;
-  const startInventory = cfStart + frStart;
+  const ohStart = inventoryReport?.effective?.onHand?.[CHEESE_SKU_KEY] || 0;
+  const startInventory = cfStart + frStart + ohStart;
 
   // Walk forward. Track running stock. When stock would go negative on day i,
   // schedule a batch on the latest valid day inside the [i-MAX_LEAD, i-MIN_LEAD]

--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1040,12 +1040,13 @@
     BATCH_SIZES, CASE_SIZES, TRAY_SIZES, FOH_SKUS, BAKE_GROUPS,
     DOUGH_AGE_WARN_DAYS, DOUGH_AGE_FAIL_DAYS,
     CHEESE_BATCH_SIZE, CHEESE_KEY, CHEESE_MAX_LEAD,
+    DIP_CONFIG,
     makeSkuMeta,
     resolveDeliveries, resolveProductionLogs,
     getInventoryReport, attributeDeliveryCoverage,
-    scheduleCheese,
+    scheduleCheese, scheduleDip,
     isShapeOnlyDelivery,
-  } from '../../scripts/inventory.js?v=2026-05-07-pack-list-shape-only';
+  } from '../../scripts/inventory.js?v=2026-05-08-dips';
 
   // Shape-only catering + box expansion. ENABLED BY DEFAULT — catering
   // boxes (Catering: ...) and FOH Placeholder deliveries skip BFP and
@@ -1062,9 +1063,13 @@
     } catch (_) { return true; }
   })();
 
-  // FOH cheese consumption — fetched from the worker on load. Updated on
-  // every loadProduction() since the rate is stable across hours.
-  const CHEESE_CONSUMPTION_URL = 'https://dpc-catering-checkout.drew-f39.workers.dev/cheese-consumption?days=28';
+  // FOH dip consumption — single Square scan returns dailyAvg for cheese
+  // + 4 retail dips. Fetched on load; rate is stable across hours.
+  const DIP_CONSUMPTION_URL = 'https://dpc-catering-checkout.drew-f39.workers.dev/dip-consumption?days=28';
+  // Per-dip dailyAvg keyed by canonical SKU (DIP_CONFIG keys). Cheese kept
+  // as cheeseFohDailyAvg too for legacy callers; will be removed once all
+  // call sites migrate.
+  let dipDailyAvgs = {};
   let cheeseFohDailyAvg = 0;
 
   // ╔══════════════════════════════════════════════════════════════════════════╗
@@ -2925,40 +2930,48 @@
     </div></div>`;
   }
 
-  // ─── CHEESE TAB ───────────────────────────────────────────────────────────
-  // Manager-facing view of the FOH cheese-dip schedule. Mirrors the iCalendar
-  // feed (same scheduleCheese() output), so what the manager sees here is
-  // exactly what the FOH tablet will see in their calendar.
-  function renderCheeseTab(dateStr) {
-    const report = getInventoryReportLocal();
-    const cheeseSchedule = scheduleCheese({
+  // ─── DIPS TAB ─────────────────────────────────────────────────────────────
+  // Manager-facing view of the FOH dip schedule (cheese + retail dips).
+  // Mirrors the iCalendar feed (same scheduleDip() output per dip), so the
+  // tablet calendar and this view never disagree.
+  //
+  // Per-dip card: today's recommended batch (if any) + stepper + upcoming list.
+  // Stepper logs `cheese_done` rows with {sku, batches, size}; size determines
+  // single vs double crediting in getInventoryReport.
+  function renderDipCard(dipSku, dateStr, report) {
+    const cfg = DIP_CONFIG[dipSku];
+    if (!cfg) return '';
+    const dailyAvg = dipDailyAvgs[dipSku] || (dipSku === CHEESE_KEY ? cheeseFohDailyAvg : 0);
+    const sched = scheduleDip({
+      dipSku,
       deliveries: allDeliveries,
       inventoryReport: report,
-      fohDailyAvg: cheeseFohDailyAvg,
+      fohDailyAvg: dailyAvg,
       today: dateStr,
       skuAliases,
       lookaheadDays: 14,
     });
 
-    // Today's batch (if any) and made count.
-    const todayBatch = cheeseSchedule.batches.find(b => b.date === dateStr);
+    const todayBatch = sched.batches.find(b => b.date === dateStr);
     const dayState = productionState[dateStr] || {};
-    const cheeseDoneList = dayState.cheeseDone || [];
-    const todayMade = cheeseDoneList
-      .filter(c => c.sku === CHEESE_KEY)
-      .reduce((s, c) => s + (Number(c.batches) || 0), 0);
+    const doneList = dayState.cheeseDone || []; // log key stays cheese_done across all dips
+    // todayMadeUnits tallies dips produced today for this SKU (each log entry
+    // contributes batches × singleBatchSize OR doubleBatchSize per its size).
+    const todayMadeUnits = doneList
+      .filter(c => c.sku === dipSku)
+      .reduce((s, c) => {
+        const sz = c.size === 'double' ? cfg.doubleBatchSize : cfg.singleBatchSize;
+        return s + (Number(c.batches) || 0) * sz;
+      }, 0);
 
-    // Mirror scheduleCheese's startInventory: sum cf + fr + oh. Old snapshots
-    // have cheese in fr (pre-Phase-3a); new ones in oh. Both flow through.
-    const effectiveCheese = (report.effective.coldFerment[CHEESE_KEY] || 0)
-      + (report.effective.frozen[CHEESE_KEY] || 0)
-      + (report.effective.onHand?.[CHEESE_KEY] || 0);
-    const fohRate = cheeseFohDailyAvg;
+    const onHand = (report.effective.coldFerment[dipSku] || 0)
+      + (report.effective.frozen[dipSku] || 0)
+      + (report.effective.onHand?.[dipSku] || 0);
 
-    // Today's card
     let todayHtml = '';
     if (todayBatch) {
-      const isDone = todayMade >= 1 - 0.01;
+      const targetUnits = todayBatch.units;
+      const isDone = todayMadeUnits >= targetUnits - 0.01;
       const coversList = todayBatch.covers.length > 0
         ? todayBatch.covers.map(c => `${esc(c.customer)} (${c.qty}p ${appLang === 'es' ? 'para' : 'for'} ${esc(c.deliveryDate)})`).join(', ')
         : (appLang === 'es' ? 'sólo FOH (mostrador)' : 'FOH walk-in only');
@@ -2968,64 +2981,82 @@
       const statusPill = isDone
         ? `<span class="wcard-pill done">✅ ${appLang === 'es' ? 'Hecho' : 'Done'}</span>`
         : (todayBatch.overdue ? overdueTag : `<span class="wcard-pill pending">⏳ ${appLang === 'es' ? 'Pendiente' : 'Pending'}</span>`);
+      const sizeLabel = todayBatch.size === 'double' ? 'double' : 'single';
+      const sizeChip = (cfg.singleBatchSize !== cfg.doubleBatchSize)
+        ? `<span class="wcard-pill" style="background:#f0e8d0;color:#5a4a1a">${sizeLabel} (${todayBatch.units})</span>` : '';
+      // Stepper buttons: cheese has a single +1/-1; retail dips offer single
+      // and double buttons since they're distinct batch sizes.
+      const showDouble = cfg.singleBatchSize !== cfg.doubleBatchSize;
       todayHtml = `
         <div class="wcard ${isDone ? 'status-done' : (todayBatch.overdue ? 'status-overdue' : 'status-pending')}" style="--wcard-stripe:#E5C16A">
           <div class="wcard-head">
             <div>
-              <div class="wcard-name">🧀 ${appLang === 'es' ? 'Hacer 1 tanda de queso' : 'Make 1 batch cheese dip'}</div>
+              <div class="wcard-name">${cfg.emoji} ${appLang === 'es' ? 'Hacer 1 tanda de' : 'Make 1 batch'} ${esc(cfg.label)}</div>
               <div style="font:500 12px 'Manrope',sans-serif;color:var(--gray-3);margin-top:2px">
                 ${esc(coversList)}
               </div>
             </div>
-            ${statusPill}
+            <div style="display:flex;gap:6px;align-items:center">${sizeChip}${statusPill}</div>
           </div>
           <div class="wcard-metrics" style="margin-top:8px">
             <div class="wmetric">
-              <div class="wmetric-label">${appLang === 'es' ? 'TANDAS' : 'BATCHES'}</div>
-              <div class="wmetric-value"><strong>${isDone ? 1 : 0}</strong><span class="of"> / 1</span></div>
+              <div class="wmetric-label">${appLang === 'es' ? 'DIPS HECHOS' : 'DIPS MADE'}</div>
+              <div class="wmetric-value"><strong>${Math.round(todayMadeUnits)}</strong><span class="of"> / ${targetUnits}</span></div>
             </div>
             <div class="wmetric">
-              <div class="wmetric-label">${appLang === 'es' ? 'DIPS' : 'DIPS'}</div>
-              <div class="wmetric-value"><strong>${isDone ? CHEESE_BATCH_SIZE : 0}</strong><span class="of"> / ${CHEESE_BATCH_SIZE}</span></div>
+              <div class="wmetric-label">${appLang === 'es' ? 'INVENTARIO' : 'ON HAND'}</div>
+              <div class="wmetric-value"><strong>${Math.round(onHand)}</strong></div>
             </div>
           </div>
-          <div class="wstepper">
-            <button class="wstep-btn" data-cheese-step data-delta="-1" ${todayMade <= 0 ? 'disabled' : ''}>−</button>
-            <div class="wstep-center">${todayMade.toFixed ? Number(todayMade).toFixed(0) : todayMade} / 1 ${appLang === 'es' ? 'tanda' : 'batch'}</div>
-            <button class="wstep-btn" data-cheese-step data-delta="1" ${isDone ? 'disabled' : ''}>+</button>
+          <div class="wstepper" style="display:flex;gap:6px;flex-wrap:wrap">
+            <button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="single" data-delta="-1" ${todayMadeUnits <= 0 ? 'disabled' : ''}>−</button>
+            <button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="single" data-delta="1">+ ${appLang === 'es' ? 'sencilla' : 'single'} (${cfg.singleBatchSize})</button>
+            ${showDouble ? `<button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="double" data-delta="1">+ ${appLang === 'es' ? 'doble' : 'double'} (${cfg.doubleBatchSize})</button>` : ''}
           </div>
         </div>`;
     } else {
-      todayHtml = `<div class="no-prod" style="padding:32px 20px">
-        🧀 ${appLang === 'es' ? 'Sin tanda de queso programada hoy' : 'No cheese batch scheduled today'}
+      todayHtml = `<div class="no-prod" style="padding:24px 20px">
+        ${cfg.emoji} ${appLang === 'es' ? 'Sin tanda hoy' : 'No batch needed today'} — ${esc(cfg.label)}
         <br><span style="font-size:13px;color:var(--gray-3)">
           ${appLang === 'es' ? 'Inventario: ' : 'On hand: '}
-          ${Math.round(effectiveCheese)} ${appLang === 'es' ? 'dips · consumo FOH ~' : 'dips · FOH walk-in ~'}${fohRate}/${appLang === 'es' ? 'día' : 'day'}
+          ${Math.round(onHand)} ${appLang === 'es' ? 'dips · consumo FOH ~' : 'dips · FOH walk-in ~'}${dailyAvg}/${appLang === 'es' ? 'día' : 'day'}
         </span>
       </div>`;
     }
 
-    // Upcoming batches list
-    const upcoming = cheeseSchedule.batches.filter(b => b.date > dateStr).slice(0, 14);
+    const upcoming = sched.batches.filter(b => b.date > dateStr).slice(0, 8);
     const upcomingHtml = upcoming.length === 0 ? '' : `
-      <div style="margin-top:24px">
-        <div class="status-section-label" style="color:var(--gray-3)">
-          ${appLang === 'es' ? 'PRÓXIMAS TANDAS' : 'UPCOMING BATCHES'}
+      <div style="margin-top:12px">
+        <div class="status-section-label" style="color:var(--gray-3);font-size:11px">
+          ${appLang === 'es' ? 'PRÓXIMAS' : 'UPCOMING'}
         </div>
         ${upcoming.map(b => {
           const dateLabel = `${fmtDay(parseDate(b.date))} ${fmtShort(parseDate(b.date))}`;
-          const coversList = b.covers.length > 0
-            ? b.covers.map(c => `${esc(c.customer)} (${c.qty}p)`).join(', ')
-            : (appLang === 'es' ? 'sólo FOH' : 'FOH walk-in');
           const overdue = b.overdue ? ' 🚨' : '';
-          return `<div style="display:flex;justify-content:space-between;padding:8px 12px;border-bottom:1px solid #eee;font:500 13px 'Manrope',sans-serif">
-            <span><strong>${esc(dateLabel)}</strong>${overdue}</span>
-            <span style="color:var(--gray-3);font-size:12px;text-align:right;max-width:60%">${esc(coversList)}</span>
+          const sizeStr = b.size === 'double' ? ` · double (${b.units})` : ` · ${b.units}`;
+          return `<div style="display:flex;justify-content:space-between;padding:6px 12px;border-bottom:1px solid #eee;font:500 12px 'Manrope',sans-serif">
+            <span><strong>${esc(dateLabel)}</strong>${overdue}${sizeStr}</span>
           </div>`;
         }).join('')}
       </div>`;
 
-    // Subscription URL hint
+    return `<div style="margin-bottom:18px">
+      <div style="margin-bottom:6px">
+        <div style="font:700 14px 'Paytone One',sans-serif;color:var(--dark)">${cfg.emoji} ${esc(cfg.label.charAt(0).toUpperCase() + cfg.label.slice(1))}</div>
+        <div style="font:400 11px 'Manrope',sans-serif;color:var(--gray-3)">
+          ${appLang === 'es' ? 'Inventario' : 'On hand'} ${Math.round(onHand)} · FOH ~${dailyAvg}/${appLang === 'es' ? 'día' : 'day'}
+        </div>
+      </div>
+      ${todayHtml}
+      ${upcomingHtml}
+    </div>`;
+  }
+
+  function renderCheeseTab(dateStr) {
+    // Tab key is still 'cheese' (legacy) but rendered content is now all dips.
+    const report = getInventoryReportLocal();
+    const dipsHtml = Object.keys(DIP_CONFIG).map(sku => renderDipCard(sku, dateStr, report)).join('');
+
     const calUrl = 'https://dpc-catering-checkout.drew-f39.workers.dev/foh-cal.ics';
     const calHint = `
       <div style="margin-top:24px;padding:12px;background:#f8f8f8;border-radius:8px;font:400 11px 'Manrope',sans-serif;color:var(--gray-3)">
@@ -3034,22 +3065,24 @@
       </div>`;
 
     return `<div class="team-card"><div class="team-body">
-      <div style="margin-bottom:8px">
-        <div style="font:800 18px 'Paytone One',sans-serif;color:var(--dark)">🧀 ${appLang === 'es' ? 'Queso' : 'Cheese Dip'}</div>
+      <div style="margin-bottom:16px">
+        <div style="font:800 18px 'Paytone One',sans-serif;color:var(--dark)">${appLang === 'es' ? '🧀 Salsas' : '🧀 Dips'}</div>
         <div style="font:400 12px 'Manrope',sans-serif;color:var(--gray-3)">
-          ${appLang === 'es' ? 'Inventario' : 'On hand'} ${Math.round(effectiveCheese)} ${appLang === 'es' ? 'dips · FOH ~' : 'dips · FOH walk-in ~'}${fohRate}/${appLang === 'es' ? 'día' : 'day'}
+          ${appLang === 'es' ? 'Programación FOH para queso y salsas de menudeo' : 'FOH schedule for cheese + retail dips'}
         </div>
       </div>
-      ${todayHtml}
-      ${upcomingHtml}
+      ${dipsHtml}
       ${calHint}
     </div></div>`;
   }
 
-  // Cheese stepper — increments cheese_done log entries.
-  async function logCheeseDelta(delta) {
+  // Dip stepper — generic across cheese + retail dips. Logs cheese_done
+  // (action name kept for backward-compat) with {sku, batches, size}.
+  // size === 'double' credits doubleBatchSize via getInventoryReport's
+  // updated cheese_done handler.
+  async function logDipDelta(sku, size, delta) {
     const dateStr = toDateStr(currentDate);
-    const completions = JSON.stringify([{ sku: CHEESE_KEY, batches: delta }]);
+    const completions = JSON.stringify([{ sku, batches: delta, size: size || 'single' }]);
     await appendLog(PRODUCTION_LOG, {
       action: 'cheese_done',
       date: dateStr,
@@ -3059,6 +3092,10 @@
     await loadProduction();
     schedule = buildOptimalSchedule();
     render();
+  }
+  // Backward-compat for any remaining cheese-only call sites.
+  async function logCheeseDelta(delta) {
+    return logDipDelta(CHEESE_KEY, 'single', delta);
   }
 
   async function saveStock() {
@@ -3661,7 +3698,16 @@
     document.querySelectorAll('[data-pack-toggle]').forEach(btn => {
       btn.addEventListener('click', () => togglePackedCase(btn));
     });
-    // Cheese tab stepper — single SKU, single batch/day, simpler than shape/bfp.
+    // Dips tab stepper — per-dip, single OR double batches, simpler than shape/bfp.
+    document.querySelectorAll('[data-dip-step]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const sku = btn.dataset.sku;
+        const size = btn.dataset.size || 'single';
+        const delta = parseInt(btn.dataset.delta, 10);
+        logDipDelta(sku, size, delta).catch(err => alert('Error logging dip: ' + err.message));
+      });
+    });
+    // Backward-compat: handle any remaining data-cheese-step buttons.
     document.querySelectorAll('[data-cheese-step]').forEach(btn => {
       btn.addEventListener('click', () => {
         const delta = parseInt(btn.dataset.delta, 10);
@@ -3896,20 +3942,29 @@
     } catch { allSkus = Object.keys(BATCH_SIZES); } // fallback to hardcoded list
   }
 
-  // Pull FOH cheese walk-in rate from the worker (last 28 days of Square
-  // orders → daily average). Best-effort: if the fetch fails the cheese
-  // scheduler falls back to delivery-only demand.
-  async function loadCheeseConsumption() {
+  // Pull per-dip FOH walk-in rates from the worker (last 28 days of Square
+  // orders → daily average per dip). Best-effort: if the fetch fails the
+  // schedulers fall back to delivery-only demand for cheese (0 demand for
+  // retail dips, so they show no upcoming batches until the next refresh).
+  async function loadDipConsumption() {
     try {
-      const r = await fetch(CHEESE_CONSUMPTION_URL);
+      const r = await fetch(DIP_CONSUMPTION_URL);
       if (!r.ok) return;
       const data = await r.json();
-      cheeseFohDailyAvg = Number(data.dailyAvg) || 0;
+      const next = {};
+      Object.entries(data.dips || {}).forEach(([sku, info]) => {
+        next[sku] = Number(info.dailyAvg) || 0;
+      });
+      dipDailyAvgs = next;
+      cheeseFohDailyAvg = next['3oz cheese dip'] || 0;
     } catch (e) {
       // eslint-disable-next-line no-console
-      console.warn('cheese-consumption fetch failed:', e);
+      console.warn('dip-consumption fetch failed:', e);
     }
   }
+  // Backward-compat alias — keep so all four Promise.all sites keep working.
+  // Phase 3d migrates the call sites; remove this in Phase 4 cleanup.
+  const loadCheeseConsumption = loadDipConsumption;
 
   // ─── NAV WIRING ───────────────────────────────────────────────────────────
 

--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1139,6 +1139,13 @@
   const getCaseSize     = sku => (skuConfig[sku]?.caseSize > 0 ? skuConfig[sku].caseSize : 0) || CASE_SIZES[sku] || 0;
   const isFOH           = sku => skuConfig[sku] ? skuConfig[sku].type === 'foh' : FOH_SKUS.has(sku.toLowerCase()) || FOH_SKUS.has(sku);
   const isCoating       = sku => skuConfig[sku] ? skuConfig[sku].type === 'coating' : BAKE_GROUPS.coating.includes(sku);
+  // Lifecycle-less SKUs: tracked production but no dough → bake → freeze
+  // pipeline. Snapshot stock counts go into a third `onHand` bucket instead
+  // of the `frozen` bucket. Phase 3a hardcodes; Phase 3b moves to DIP_CONFIG.
+  const LIFECYCLELESS_SKUS = new Set([
+    '3oz cheese dip',
+    'bulk dangerous dip (25 srv)',
+  ]);
   // Per-SKU stripe color (worker view) — regex priority. Returns CSS color string.
   const getStripeColor = (sku) => {
     const s = (sku || '').toLowerCase();
@@ -2743,9 +2750,13 @@
     allSkus.forEach(sku => {
       if (isFOH(sku)) return; // FOH SKUs aren't part of production forecast
       // Use effective inventory — same numbers as worker card and scheduler.
+      // Sum all three buckets: cf (dough), fr (frozen), oh (on-hand for
+      // lifecycle-less SKUs). For pretzels only cf+fr have values; for
+      // cheese / bulk dip / future retail dips, oh holds the count.
       const doughEff  = report.effective.coldFerment[sku] || 0;
       const frozenEff = report.effective.frozen[sku] || 0;
-      const stock     = doughEff + frozenEff;
+      const onHandEff = report.effective.onHand?.[sku] || 0;
+      const stock     = doughEff + frozenEff + onHandEff;
       const demand    = demandBySku[sku] || 0;
       const net       = stock - demand;
       const cs        = getCaseSize(sku);
@@ -2790,7 +2801,14 @@
 
     const rows = allSkus.map(sku => {
       const isFohSku   = isFOH(sku);
+      // Lifecycle-less SKUs: cheese, bulk dip, and the 4 retail dips coming
+      // in Phase 3b. They have no dough → bake → freeze pipeline; manager
+      // just enters an "on hand" count. Stock tab renders a single onHand
+      // input instead of dough + frozen. (Hardcoded for Phase 3a; Phase 3b
+      // moves this to DIP_CONFIG in inventory.js.)
+      const isLifecycleless = LIFECYCLELESS_SKUS.has(sku);
       const frozenRaw  = inv.frozen[sku] || 0; // raw snapshot value, used only in "(was N)" label
+      const onHandRaw  = inv.onHand?.[sku] || 0;
       const dedAmt     = deducted[sku] || 0;
       const dedDetails = deductDetails[sku] || [];
       // Pre-fill inputs with effective values — same source of truth as worker
@@ -2798,6 +2816,12 @@
       // on physical count rather than retyping from scratch.
       const doughDisplay  = report.effective.coldFerment[sku] || 0;
       const frozenDisplay = report.effective.frozen[sku] || 0;
+      // For lifecycle-less SKUs, the legacy snapshot may have the count in
+      // `frozen` (pre-Phase-3a). Sum both so the input pre-fills with the
+      // total — manager re-saves and it lands in onHand cleanly.
+      const onHandDisplay = isLifecycleless
+        ? (report.effective.onHand?.[sku] || 0) + frozenDisplay
+        : (report.effective.onHand?.[sku] || 0);
       const fc         = forecasts[sku];
       const ageDays    = oldestDoughAge[sku];
 
@@ -2867,12 +2891,19 @@
         }
       }
 
+      // Right-side input is either the frozen count (pretzels) or the
+      // on-hand count (cheese / bulk dip / future retail dips). Both render
+      // in the same column slot — saveStock() reads data-stock-section to
+      // route the value to the correct snapshot field.
+      const rightInput = isLifecycleless
+        ? `<input class="stock-input" type="number" min="0" data-stock-section="onhand" data-sku="${esc(sku)}" value="${onHandDisplay}" placeholder="0" title="On hand">`
+        : `<input class="stock-input" type="number" min="0" data-stock-section="frozen" data-sku="${esc(sku)}" value="${frozenDisplay}" placeholder="0">`;
       return `<div class="stock-row">
         <div><span class="stock-sku">${esc(sku)}</span>${ageBadge}${dedStr}${fcStr}${coverageHtml}</div>
-        ${isFohSku
+        ${(isFohSku || isLifecycleless)
           ? `<span class="stock-na">—</span>`
           : `<input class="stock-input" type="number" min="0" data-stock-section="shape" data-sku="${esc(sku)}" value="${doughDisplay}" placeholder="0">`}
-        <input class="stock-input" type="number" min="0" data-stock-section="frozen" data-sku="${esc(sku)}" value="${frozenDisplay}" placeholder="0">
+        ${rightInput}
       </div>`;
     }).join('');
 
@@ -2917,7 +2948,11 @@
       .filter(c => c.sku === CHEESE_KEY)
       .reduce((s, c) => s + (Number(c.batches) || 0), 0);
 
-    const effectiveCheese = report.effective.coldFerment[CHEESE_KEY] || 0;
+    // Mirror scheduleCheese's startInventory: sum cf + fr + oh. Old snapshots
+    // have cheese in fr (pre-Phase-3a); new ones in oh. Both flow through.
+    const effectiveCheese = (report.effective.coldFerment[CHEESE_KEY] || 0)
+      + (report.effective.frozen[CHEESE_KEY] || 0)
+      + (report.effective.onHand?.[CHEESE_KEY] || 0);
     const fohRate = cheeseFohDailyAvg;
 
     // Today's card
@@ -3033,9 +3068,13 @@
       const section = inp.dataset.stockSection;
       const n   = parseInt(inp.value, 10) || 0;
       if (!sku) return;
-      if (!snaps[sku]) snaps[sku] = { sku, coldFerment: 0, frozen: 0 };
+      if (!snaps[sku]) snaps[sku] = { sku, coldFerment: 0, frozen: 0, onHand: 0 };
       if (section === 'shape')  snaps[sku].coldFerment = n;
       if (section === 'frozen') snaps[sku].frozen      = n;
+      // onhand bucket — for lifecycle-less SKUs (cheese, bulk dip, future
+      // retail dips). Distinct from `frozen` (which is reserved for actually
+      // frozen pretzels) so the cheese row doesn't pollute pretzel forecasts.
+      if (section === 'onhand') snaps[sku].onHand      = n;
     });
     // Save ALL SKUs the user touched, including zeros — clearing an SKU to 0
     // must propagate so getLatestInventory can overwrite older non-zero values.

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1184,6 +1184,29 @@ function buildCheeseEvent({ batch, dtstamp }) {
   return lines.join('\r\n');
 }
 
+// Generic dip-batch event builder — used for the 4 retail dips. Cheese keeps
+// its existing buildCheeseEvent (different UID prefix, different description
+// emphasis on covers + shelf life) for backward compatibility with calendars
+// that already imported those events.
+function buildDipBatchEvent({ dipSku, cfg, batch, dtstamp }) {
+  const uid = `${cfg.key}-batch-${batch.date}@dangpretz`;
+  const sizeStr = batch.size === 'double' ? ' double' : '';
+  const summary = `${cfg.emoji} Make 1${sizeStr} ${cfg.label} batch (${batch.units})${batch.overdue ? ' (overdue!)' : ''}`;
+  const lines = [
+    'BEGIN:VEVENT',
+    icsFold(`UID:${uid}`),
+    `DTSTAMP:${dtstamp}`,
+    `DTSTART;VALUE=DATE:${icsDateAllDay(batch.date)}`,
+    `DTEND;VALUE=DATE:${icsDateAllDay(addOneDay(batch.date))}`,
+    icsFold(`SUMMARY:${icsEscape(summary)}`),
+  ];
+  const desc = `${batch.units} ${cfg.label} dips per batch. Use within ${cfg.shelfLifeDays} days. FOH walk-in average ~${Math.round(batch.foh * 10) / 10} dips/day.`;
+  lines.push(icsFold(`DESCRIPTION:${icsEscape(desc)}`));
+  lines.push(icsFold('URL:https://drewfeller.com/static/production/'));
+  lines.push('END:VEVENT');
+  return lines.join('\r\n');
+}
+
 function addOneDay(yyyymmdd) {
   const [y, m, d] = yyyymmdd.split('-').map(Number);
   const dt = new Date(Date.UTC(y, m - 1, d));
@@ -1261,16 +1284,21 @@ async function handleFohCalendar(request, env) {
     getBatchSize: meta.getBatchSize,
   });
 
-  // Square FOH walk-in rate. Fail-soft: if Square errors, use 0.
-  let dailyAvg = 0;
+  // Per-dip Square consumption (single Square scan returns all 5 dips).
+  // Fail-soft: if Square errors, retail dips fall through to 0/day demand
+  // (no upcoming batches scheduled until next refresh).
+  let dipAvgs = {};
   try {
-    const c = await fetchSquareCheeseConsumption(env, 28);
-    dailyAvg = c.dailyAvg || 0;
+    const dipData = await fetchSquareDipConsumption(env, 28);
+    Object.entries(dipData.dips || {}).forEach(([sku, info]) => {
+      dipAvgs[sku] = Number(info.dailyAvg) || 0;
+    });
   } catch (_) { /* best-effort */ }
+  const dailyAvg = dipAvgs[CHEESE_KEY] || 0; // legacy alias for cheese-only callers
 
   const today = todayMountain();
 
-  // Cheese batches.
+  // Cheese batches (kept on existing buildCheeseEvent for UID continuity).
   const cheese = scheduleCheese({
     deliveries: allDeliveries,
     inventoryReport,
@@ -1278,6 +1306,24 @@ async function handleFohCalendar(request, env) {
     today,
     skuAliases: prod.skuAliases,
     lookaheadDays: 14,
+  });
+
+  // 4 retail dips — same scheduleDip per dip, emitted via buildDipBatchEvent.
+  const retailDipBatches = [];
+  Object.entries(DIP_CONFIG).forEach(([dipSku, cfg]) => {
+    if (dipSku === CHEESE_KEY) return; // cheese already scheduled above
+    const sched = scheduleDip({
+      dipSku,
+      deliveries: allDeliveries,
+      inventoryReport,
+      fohDailyAvg: dipAvgs[dipSku] || 0,
+      today,
+      skuAliases: prod.skuAliases,
+      lookaheadDays: 14,
+    });
+    sched.batches.forEach((batch) => {
+      retailDipBatches.push({ dipSku, cfg, batch });
+    });
   });
 
   // Upcoming catering deliveries (next 30 days, scheduled status).
@@ -1297,6 +1343,7 @@ async function handleFohCalendar(request, env) {
   const dtstamp = icsDateUTC(new Date());
   const events = [
     ...cheese.batches.map((batch) => buildCheeseEvent({ batch, dtstamp })),
+    ...retailDipBatches.map(({ dipSku, cfg, batch }) => buildDipBatchEvent({ dipSku, cfg, batch, dtstamp })),
     ...cateringDeliveries.map((delivery) => buildCateringEvent({ delivery, dtstamp })),
   ];
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -16,9 +16,11 @@ import {
   getInventoryReport,
   makeSkuMeta,
   scheduleCheese,
+  scheduleDip,
   CHEESE_BATCH_SIZE,
   CHEESE_KEY,
   CHEESE_MAX_LEAD,
+  DIP_CONFIG,
 } from '../../scripts/inventory.js';
 
 const SQUARE_BASE = 'https://connect.squareup.com/v2';
@@ -1005,6 +1007,109 @@ async function handleCheeseConsumption(request, env) {
   });
 }
 
+/**
+ * Single Square scan that counts ALL configured dips (cheese + 4 retail dips)
+ * in one pagination loop. Cheaper than 5 separate /cheese-consumption-style
+ * fetches. Per-dip match patterns come from DIP_CONFIG.squareNames +
+ * .squareModifiers — keep those in sync as the Square catalog evolves.
+ *
+ * Returns { daysSampled, dips: { [dipSku]: { unitsSold, dailyAvg, namesSeen, modifiersSeen } } }.
+ */
+async function fetchSquareDipConsumption(env, daysSampled = 28) {
+  const locationId = env.SQUARE_LOCATION_ID || 'LEJ3PDZ9V6NYN';
+  const startAt = new Date(Date.now() - daysSampled * 86400e3).toISOString();
+  const orders = [];
+  let cursor;
+  let pageCount = 0;
+  do {
+    const res = await fetch(`${SQUARE_BASE}/orders/search`, {
+      method: 'POST',
+      headers: {
+        'Square-Version': '2025-01-23',
+        Authorization: `Bearer ${env.SQUARE_ACCESS_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        location_ids: [locationId],
+        query: {
+          filter: {
+            date_time_filter: { created_at: { start_at: startAt } },
+            state_filter: { states: ['OPEN', 'COMPLETED'] }, // skip CANCELED — wasn't consumed
+          },
+          sort: { sort_field: 'CREATED_AT', sort_order: 'DESC' },
+        },
+        limit: 500,
+        cursor,
+      }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(`Square search failed: ${JSON.stringify(data).slice(0, 300)}`);
+    orders.push(...(data.orders || []));
+    cursor = data.cursor;
+    pageCount += 1;
+    if (pageCount > 20) break;
+  } while (cursor);
+
+  // Build per-dip accumulators from DIP_CONFIG
+  const dips = {};
+  Object.keys(DIP_CONFIG).forEach((sku) => {
+    dips[sku] = {
+      units: 0,
+      namesSeen: new Set(),
+      modifiersSeen: new Set(),
+    };
+  });
+
+  orders.forEach((o) => {
+    (o.line_items || []).forEach((li) => {
+      const name = (li.name || '').trim();
+      const qty = parseInt(li.quantity, 10) || 0;
+      // Direct line-item match per dip
+      Object.entries(DIP_CONFIG).forEach(([sku, cfg]) => {
+        if (cfg.squareNames.some((re) => re.test(name)) && qty > 0) {
+          dips[sku].namesSeen.add(name);
+          dips[sku].units += qty;
+        }
+      });
+      // Modifier match — each modifier instance = parent qty units of that dip
+      (li.modifiers || []).forEach((mod) => {
+        const mname = (mod.name || '').trim();
+        Object.entries(DIP_CONFIG).forEach(([sku, cfg]) => {
+          if (cfg.squareModifiers.some((re) => re.test(mname))) {
+            dips[sku].modifiersSeen.add(mname);
+            dips[sku].units += qty;
+          }
+        });
+      });
+    });
+  });
+
+  const out = { daysSampled, ordersScanned: orders.length, dips: {} };
+  Object.entries(dips).forEach(([sku, agg]) => {
+    out.dips[sku] = {
+      unitsSold: agg.units,
+      dailyAvg: daysSampled > 0 ? Math.round((agg.units / daysSampled) * 10) / 10 : 0,
+      namesSeen: [...agg.namesSeen],
+      modifiersSeen: [...agg.modifiersSeen],
+    };
+  });
+  return out;
+}
+
+async function handleDipConsumption(request, env) {
+  const url = new URL(request.url);
+  const days = Math.max(1, Math.min(90, parseInt(url.searchParams.get('days'), 10) || 28));
+  const result = await fetchSquareDipConsumption(env, days);
+  return new Response(JSON.stringify(result), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      ...CORS_HEADERS,
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}
+
 // ─── iCalendar feed for FOH ──────────────────────────────────────────────
 
 // Today as 'YYYY-MM-DD' in Mountain TZ (matches the production app).
@@ -1698,6 +1803,14 @@ export default {
         // eslint-disable-next-line no-console -- worker diagnostics
         console.error('Cheese consumption error:', err);
         return json({ error: err.message || 'Cheese consumption failed' }, 500);
+      }
+    }
+    if (url.pathname === '/dip-consumption' && request.method === 'GET') {
+      try { return await handleDipConsumption(request, env); }
+      catch (err) {
+        // eslint-disable-next-line no-console -- worker diagnostics
+        console.error('Dip consumption error:', err);
+        return json({ error: err.message || 'Dip consumption failed' }, 500);
       }
     }
     if (url.pathname === '/foh-cal.ics' && request.method === 'GET') {


### PR DESCRIPTION
## Summary

Adds par-driven batch planning + FOH calendar surfacing for the 4 retail dips (hot ranch, sweet cream, house mustard, honey mustard) alongside cheese. Plus an `onHand` snapshot bucket so lifecycle-less SKUs don't piggyback on `frozen` anymore.

## Live verification

**Worker `/dip-consumption?days=28`** (1042 orders scanned):
```
3oz cheese dip:    32.4/day
sweet cream dip:   10.6/day
honey mustard dip:  5.7/day
hot ranch dip:      5.6/day
house mustard dip:  5.6/day
```

**Worker `/foh-cal.ics`** (deployed version `d58b9ff8`):
- 🧀 `Make 1 batch cheese dip`
- 🌶 `Make 1 hot ranch batch (35)`
- 🥛 `Make 1 sweet cream batch (35)`
- 💛 `Make 1 house mustard batch (35)`
- 🍯 `Make 1 honey mustard batch (35)`
- 🥨 catering pickups (unchanged)

**Production app Dips tab** (verified in preview):
- 5 cards (cheese + 4 retail) with on-hand + FOH rate per dip
- Cheese: `+ single (150)` only (single===double for cheese)
- Retail dips: `+ single (35)` and `+ double (70)` buttons
- Stable UIDs `{dip-key}-batch-YYYY-MM-DD@dangpretz` for in-place calendar updates

## Phasing (5 commits, each green-on-its-own)

| # | Commit | What |
|---|---|---|
| 3a | `cfb9634` | Add `onHand` snapshot bucket + Stock-tab UI for lifecycle-less SKUs |
| 3b | `84470c9` | Generalize `scheduleCheese` → `scheduleDip` with `DIP_CONFIG` |
| 3c | `34733b8` | Worker `/dip-consumption` endpoint (single Square scan, all 5 dips) |
| 3d | `15f499c` | Production app Dips tab: 5 cards with steppers, dip_done log via `cheese_done` action + `size` field |
| 3e | `3a1d86f` | Worker iCal feed emits per-dip batch events |

## Test plan

- [ ] After merge + AEM auto-deploy, visit production app `/static/production/index.html` → Cheese tab shows 5 dip cards
- [ ] Tap `+ single` on hot ranch → log row appears with `cheese_done` action + `{sku: 'hot ranch dip', batches: 1, size: 'single'}`. On-hand goes from 0 to 35. Scheduler reflows.
- [ ] Stock tab: cheese row shows single On Hand input (220 dips), bulk dip same, pretzel rows unchanged dough+frozen
- [ ] FOH tablet (myecalendar): on next URL poll, retail dip batches appear alongside cheese batches

## Files

- `scripts/inventory.js` — `DIP_CONFIG` + `scheduleDip` + `onHand` bucket + `cheese_done` size handling
- `static/production/index.html` — Dips tab with renderDipCard loop, logDipDelta, On Hand stock-tab column
- `worker/src/index.js` — `fetchSquareDipConsumption` + `/dip-consumption` route + `buildDipBatchEvent` + handleFohCalendar emits all 5 dips

## Deferred follow-ups

- Box-mapping UI tab (Phase 2c — manager self-service for catering box → pretzel expansion); hardcoded mappings still cover Lindsay/Libby today
- coldFerment-on-confirm for shape-only deliveries (still deducts from `frozen`)
- Stock-tab section header (currently says "Frozen" for the on-hand column on cheese/dip rows; minor visual polish)
- Shelf-life alert per-dip (currently uses 5-day pretzel default for all; retail dips configured 7 days in DIP_CONFIG but DOUGH_AGE_WARN_DAYS is global)

Generated with [Claude Code](https://claude.com/claude-code)
