### PR TITLE
Phase 4: 5 follow-up cleanups (Stock label, Box list, Tombstones, Per-dip shelf life, coldFerment-on-confirm)

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -729,17 +729,41 @@ export function getInventoryReport(args) {
       let items = [];
       try { items = JSON.parse(delivery.lineItems || '[]'); } catch {}
       const cust = delivery.customer || delivery.location || '?';
+      // Shape-only deliveries (catering boxes, FOH Placeholder) leave the
+      // pipeline at the dough stage — FOH bakes them fresh from coldFerment
+      // at fulfillment, so deduct from `cf` instead of `fr`. Frozen never
+      // had these pretzels, so the fr deduction would be a no-op anyway,
+      // but we skip it to keep flow accounting clean.
+      const isShapeOnly = !!delivery._shapeOnly;
       items.forEach(({ sku, quantity }) => {
         let key = sku?.trim();
         if (!key) return;
         if (skuAliases[key]) key = skuAliases[key];
         const qty = Number(quantity) || 0;
         if (qty <= 0) return;
-        if (fr[key] != null) fr[key] = Math.max(0, fr[key] - qty);
+        if (isShapeOnly) {
+          // Deduct from cf FIFO (matches BFP-done's consumption pattern).
+          if (cf[key] != null) cf[key] = Math.max(0, cf[key] - qty);
+          if (doughQueue[key]) {
+            let toConsume = qty;
+            while (toConsume > 0 && doughQueue[key].length > 0) {
+              const oldest = doughQueue[key][0];
+              const take = Math.min(oldest.pretzels, toConsume);
+              oldest.pretzels -= take;
+              toConsume -= take;
+              if (oldest.pretzels <= 0) doughQueue[key].shift();
+            }
+          }
+        } else if (fr[key] != null) {
+          fr[key] = Math.max(0, fr[key] - qty);
+        }
         // onHand bucket: lifecycle-less SKUs (cheese, dips) live here.
-        // Until the first post-Phase-3a snapshot lands, oh[cheese] is
-        // undefined and fr deduction handles it. Once oh is populated,
-        // fr[cheese] = 0 so the fr line is a harmless no-op.
+        // Independent of shape-only — a delivery with cheese in line items
+        // consumes onHand whether it's a shape-only catering box or a
+        // regular catering invoice. Pre-Phase-3a snapshots had cheese in
+        // fr; the fr branch above handles the legacy case for non-shape-only
+        // (and shape-only catering boxes don't usually contain cheese SKUs
+        // directly anyway).
         if (oh[key] != null) oh[key] = Math.max(0, oh[key] - qty);
         if (!flowDelivered[key]) flowDelivered[key] = [];
         flowDelivered[key].push({ customer: cust, qty, confirmedAt: delivery._confirmedAt || '' });
@@ -750,20 +774,26 @@ export function getInventoryReport(args) {
   Object.keys(fr).forEach((k) => { fr[k] = Math.max(0, Math.round(fr[k])); });
   Object.keys(oh).forEach((k) => { oh[k] = Math.max(0, Math.round(oh[k])); });
 
-  // Aging dough alerts
+  // Aging dough alerts. Per-SKU thresholds: dips configured in DIP_CONFIG
+  // use their `shelfLifeDays` (warn one day before, fail at). Pretzels and
+  // anything else fall back to the global DOUGH_AGE_WARN_DAYS / FAIL_DAYS.
   const now = Date.now();
   const agingDough = [];
   Object.entries(doughQueue).forEach(([sku, queue]) => {
+    const dipCfg = DIP_CONFIG[sku];
+    const failAt = dipCfg ? dipCfg.shelfLifeDays : DOUGH_AGE_FAIL_DAYS;
+    const warnAt = dipCfg ? Math.max(1, dipCfg.shelfLifeDays - 1) : DOUGH_AGE_WARN_DAYS;
     queue.forEach((entry) => {
       if (entry.pretzels <= 0) return;
       const ageMs = now - new Date(entry.ts).getTime();
       const ageDays = ageMs / 86400000;
-      if (ageDays >= DOUGH_AGE_WARN_DAYS) {
+      if (ageDays >= warnAt) {
         agingDough.push({
           sku,
           ageDays: Math.floor(ageDays),
           pretzels: Math.round(entry.pretzels),
-          critical: ageDays >= DOUGH_AGE_FAIL_DAYS,
+          critical: ageDays >= failAt,
+          shelfLifeDays: failAt,
         });
       }
     });

--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1052,13 +1052,13 @@
     BATCH_SIZES, CASE_SIZES, TRAY_SIZES, FOH_SKUS, BAKE_GROUPS,
     DOUGH_AGE_WARN_DAYS, DOUGH_AGE_FAIL_DAYS,
     CHEESE_BATCH_SIZE, CHEESE_KEY, CHEESE_MAX_LEAD,
-    DIP_CONFIG,
+    DIP_CONFIG, DEFAULT_BOX_EXPANSIONS,
     makeSkuMeta,
     resolveDeliveries, resolveProductionLogs,
     getInventoryReport, attributeDeliveryCoverage,
     scheduleCheese, scheduleDip,
     isShapeOnlyDelivery,
-  } from '../../scripts/inventory.js?v=2026-05-08-dips';
+  } from '../../scripts/inventory.js?v=2026-05-08-followups';
 
   // Shape-only catering + box expansion. ENABLED BY DEFAULT — catering
   // boxes (Catering: ...) and FOH Placeholder deliveries skip BFP and
@@ -1315,7 +1315,7 @@
       reduced_for:    ({n}) => ` · ${n} SKU${n > 1 ? 's' : ''} reduced for deliveries since count`,
       sku_col:        'SKU',
       dough_col:      '🧊 Dough',
-      frozen_col:     '❄️ Frozen',
+      frozen_col:     '❄️ Frozen / 📦 On hand',
       since_today:    'today',
       since_yest:     'since yesterday',
       since_date:     ({d}) => `since ${d}`,
@@ -1463,7 +1463,7 @@
       reduced_for:    ({n}) => ` · ${n} producto${n > 1 ? 's' : ''} reducido${n > 1 ? 's' : ''} por entregas`,
       sku_col:        'Producto',
       dough_col:      '🧊 Masa',
-      frozen_col:     '❄️ Congelado',
+      frozen_col:     '❄️ Congelado / 📦 Inventario',
       since_today:    'hoy',
       since_yest:     'desde ayer',
       since_date:     ({d}) => `desde ${d}`,
@@ -2924,6 +2924,41 @@
       </div>`;
     }).join('');
 
+    // Box mappings list — surfaces all catering box → SKU expansions so
+    // the manager can see what's wired up at a glance and jump back into
+    // edit mode for any of them. Includes both manager-saved configs
+    // (skuConfig.type === 'box') and the hardcoded fallbacks
+    // (DEFAULT_BOX_EXPANSIONS, marked "default" since no override exists).
+    const customBoxes = Object.entries(skuConfig)
+      .filter(([, cfg]) => cfg.type === 'box' && Array.isArray(cfg.expandsTo) && cfg.expandsTo.length > 0)
+      .map(([box, cfg]) => ({ box, expansions: cfg.expandsTo, isDefault: false }));
+    const customBoxNames = new Set(customBoxes.map((b) => b.box));
+    const defaultBoxes = Object.entries(DEFAULT_BOX_EXPANSIONS || {})
+      .filter(([box]) => !customBoxNames.has(box))
+      .map(([box, expansions]) => ({ box, expansions, isDefault: true }));
+    const boxEntries = [...customBoxes, ...defaultBoxes].sort((a, b) => a.box.localeCompare(b.box));
+    const boxMappingsHtml = boxEntries.length === 0 ? '' : `
+      <div style="margin-top:24px;padding-top:16px;border-top:1px solid #eee">
+        <div style="font:700 13px 'Manrope',sans-serif;color:var(--gray-3);margin-bottom:8px;text-transform:uppercase;letter-spacing:0.5px">
+          ${appLang === 'es' ? '📦 Cajas configuradas' : '📦 Box mappings'} (${boxEntries.length})
+        </div>
+        ${boxEntries.map(({ box, expansions, isDefault }) => {
+          const expansionsStr = expansions
+            .map(e => `${e.multiplier} × ${esc(e.sku)}`)
+            .join(', ');
+          const defaultTag = isDefault
+            ? `<span style="font-size:10px;background:#eee;color:var(--gray-3);padding:2px 6px;border-radius:8px;margin-left:6px">default</span>`
+            : '';
+          return `<div class="box-mapping-row" data-box-edit="${esc(box)}" style="display:flex;justify-content:space-between;padding:8px 12px;border-bottom:1px solid #f3f3f3;font:500 13px 'Manrope',sans-serif;cursor:pointer;align-items:center" title="Click to edit">
+            <span style="flex:1;min-width:0">
+              <strong style="color:var(--dark)">${esc(box)}</strong>${defaultTag}
+              <div style="color:var(--gray-3);font-size:12px;margin-top:2px">→ ${expansionsStr}</div>
+            </span>
+            <span style="color:var(--gray-3);font-size:12px;margin-left:8px">${appLang === 'es' ? 'Editar' : 'Edit'} →</span>
+          </div>`;
+        }).join('')}
+      </div>`;
+
     return `<div class="team-card"><div class="team-body">
       <div class="stock-tab-header">
         <div>
@@ -2939,6 +2974,7 @@
       </div>
       ${rows}
       <button class="btn-primary" id="stock-save" style="margin-top:20px">${t('save_stock')}</button>
+      ${boxMappingsHtml}
     </div></div>`;
   }
 
@@ -3754,6 +3790,10 @@
     });
     const stockSaveBtn = document.getElementById('stock-save');
     if (stockSaveBtn) stockSaveBtn.addEventListener('click', saveStock);
+    // Stock tab → Box mappings list — click a row to re-open its config sheet.
+    document.querySelectorAll('[data-box-edit]').forEach(row => {
+      row.addEventListener('click', () => openCfgSheet(row.dataset.boxEdit));
+    });
     document.querySelectorAll('[data-goto]').forEach(row => {
       row.addEventListener('click', () => {
         currentDate = parseDate(row.dataset.goto);

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1184,6 +1184,27 @@ function buildCheeseEvent({ batch, dtstamp }) {
   return lines.join('\r\n');
 }
 
+// Tombstone VEVENT for a UID that's no longer in the live schedule. Some
+// calendar clients (myecalendar in particular) keep events in the calendar
+// after they drop out of the subscribed feed. Emitting an explicit
+// STATUS:CANCELLED VEVENT with the same UID for a few days post-occurrence
+// gives those clients a clear signal to remove. Idempotent — clients that
+// already removed the event treat the cancel as a no-op.
+function buildBatchCancelEvent({ uid, date, dtstamp, summary }) {
+  const lines = [
+    'BEGIN:VEVENT',
+    icsFold(`UID:${uid}`),
+    `DTSTAMP:${dtstamp}`,
+    `DTSTART;VALUE=DATE:${icsDateAllDay(date)}`,
+    `DTEND;VALUE=DATE:${icsDateAllDay(addOneDay(date))}`,
+    'STATUS:CANCELLED',
+    'SEQUENCE:1',
+    icsFold(`SUMMARY:${icsEscape(summary || '(cancelled)')}`),
+    'END:VEVENT',
+  ];
+  return lines.join('\r\n');
+}
+
 // Generic dip-batch event builder — used for the 4 retail dips. Cheese keeps
 // its existing buildCheeseEvent (different UID prefix, different description
 // emphasis on covers + shelf life) for backward compatibility with calendars
@@ -1341,10 +1362,37 @@ async function handleFohCalendar(request, env) {
 
   // Build .ics body
   const dtstamp = icsDateUTC(new Date());
+
+  // Tombstones for past 3 days × every dip type. Calendar clients that
+  // imported a batch on (today-1) and now don't see it in the live feed
+  // will receive STATUS:CANCELLED for that UID and remove. Idempotent —
+  // clients with no matching event treat as no-op. Cheap (15 small events).
+  const tombstoneEvents = [];
+  for (let i = 1; i <= 3; i++) {
+    const date = (() => {
+      const dt = new Date(today);
+      dt.setUTCDate(dt.getUTCDate() - i);
+      return dt.toISOString().slice(0, 10);
+    })();
+    Object.entries(DIP_CONFIG).forEach(([dipSku, cfg]) => {
+      // Cheese uses its own UID prefix; retail dips use cfg.key
+      const uid = dipSku === CHEESE_KEY
+        ? `cheese-batch-${date}@dangpretz`
+        : `${cfg.key}-batch-${date}@dangpretz`;
+      tombstoneEvents.push(buildBatchCancelEvent({
+        uid,
+        date,
+        dtstamp,
+        summary: `(cancelled) ${cfg.label} batch`,
+      }));
+    });
+  }
+
   const events = [
     ...cheese.batches.map((batch) => buildCheeseEvent({ batch, dtstamp })),
     ...retailDipBatches.map(({ dipSku, cfg, batch }) => buildDipBatchEvent({ dipSku, cfg, batch, dtstamp })),
     ...cateringDeliveries.map((delivery) => buildCateringEvent({ delivery, dtstamp })),
+    ...tombstoneEvents,
   ];
 
   const ics = [


### PR DESCRIPTION
## Summary

Five small follow-ups bundled into one PR. Each is independent of the others and verifiable in isolation.

### 1. Stock-tab column header → 'Frozen / On Hand'

Single column slot serves both pretzel rows (Frozen) and lifecycle-less rows (On Hand). Header now reflects that. EN + ES.

### 2. Box mappings list (Stock tab)

New section at the bottom of the Stock tab. Lists every catering box with an expansion — both manager-saved configs and the hardcoded `DEFAULT_BOX_EXPANSIONS` (Salty + BBK pretzel boxes, tagged "default"). Click any row to re-open the config sheet for editing.

### 3. Stale-event cleanup in `/foh-cal.ics`

Tombstone VEVENTs (`STATUS:CANCELLED`, `SEQUENCE:1`) for past 3 days × 5 dip types = 15 cancellations on every refresh. Calendar clients that imported a UID and don't see it in the live feed receive an explicit cancel signal. Fixes the "overdue events linger" symptom on myecalendar without unsubscribe+resub. Idempotent for clients with no matching event.

Verified live (worker version `53c78693`):
```
$ curl /foh-cal.ics | grep STATUS:CANCELLED | wc -l
15
```

### 4. Per-dip shelf-life alerts

`DIP_CONFIG.shelfLifeDays` now drives the aging-dough alert per-SKU. Cheese stays 5 days, retail dips 7. Pretzels keep the existing global threshold. Each `agingDough` record now carries `shelfLifeDays` so UI can label "X days, fails at 7" etc.

### 5. coldFerment deduction on shape-only confirm

Confirmed delivered/picked-up shape-only deliveries (catering boxes, FOH Placeholder) now deduct from `cf` (via doughQueue FIFO, same pattern as `bfp_done`) instead of `fr`. Pretzel deliveries on regular orders unchanged. Fixes the residual "inventory math drift on catering pickups" deferred from PR #6.

## Test plan

- [ ] After merge + AEM auto-deploy, refresh production app
- [ ] Stock tab → header reads "❄️ Frozen / 📦 On hand"
- [ ] Stock tab → bottom section "📦 Box mappings (2)" with Salty + BBK both tagged "default"
- [ ] Tap any box mapping → config sheet opens in box mode for editing
- [ ] Confirm a shape-only catering pickup in the planner → cf decreases for that SKU; fr unchanged
- [ ] FOH tablet on next myecalendar poll: stale "overdue!" events from prior days disappear

## Files

- `scripts/inventory.js` — per-dip shelf-life, shape-only cf deduction
- `static/production/index.html` — Stock tab column label, box mappings list, cache-bust
- `worker/src/index.js` — buildBatchCancelEvent + tombstone wiring in handleFohCalendar

Generated with [Claude Code](https://claude.com/claude-code)
