### PR TITLE
FOH role link (?role=foh) + Dips tab UI cleanup

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -231,13 +231,15 @@ export const FOH_PLACEHOLDER_NAME = 'FOH Placeholder';
 // hasn't been written to skuConfig yet. Manager can override via the
 // production app's "Box mapping" tab — those entries take priority.
 //
-// User-confirmed mappings (2026-05-05):
-//   Catering: Salty Pretzel Box   → 15 × 6.5oz plain
-//   Catering: BBK Pretzel Box - 15 → 15 × 6.5oz bbk
-// Saint, Swell Cream, and dip-box mappings TBD (manager configures).
+// User-confirmed mappings:
+//   Catering: Salty Pretzel Box      → 15 × 6.5oz plain  (2026-05-05)
+//   Catering: BBK Pretzel Box - 15   → 15 × 6.5oz bbk    (2026-05-05)
+//   Catering: Saint Pretzel Box      → 15 × 6.5oz plain  (2026-05-07; topped w/ cinn sugar by FOH)
+// Swell Cream and dip-box mappings TBD (manager configures).
 export const DEFAULT_BOX_EXPANSIONS = {
   'Catering: Salty Pretzel Box': [{ sku: '6.5oz plain', multiplier: 15 }],
   'Catering: BBK Pretzel Box - 15': [{ sku: '6.5oz bbk', multiplier: 15 }],
+  'Catering: Saint Pretzel Box': [{ sku: '6.5oz plain', multiplier: 15 }],
 };
 
 /**

--- a/static/delivery-planner/index.html
+++ b/static/delivery-planner/index.html
@@ -954,7 +954,7 @@
       isShapeOnlyDelivery,
       expandBoxLineItems,
       caseSizeOptionsFor,
-    } from '../../scripts/inventory.js?v=2026-05-07-pack-list-shape-only';
+    } from '../../scripts/inventory.js?v=2026-05-07-saint-box-mapping';
 
     // Shape-only catering + box expansion. ENABLED BY DEFAULT — kept in
     // sync with production app via the same localStorage key.

--- a/static/production/index.html
+++ b/static/production/index.html
@@ -553,6 +553,11 @@
     /* When body has role-shape or role-bfp, hide manager chrome */
     body.role-worker .topnav { display: none; }
     body.role-worker .tab-bar { display: none !important; }
+    /* FOH role is a worker that DOES need tab navigation (Dips ↔ Stock).
+       Override the tab-bar hide above, then hide just Shape + BFP. */
+    body.role-foh .tab-bar { display: flex !important; }
+    body.role-foh .tab-btn[data-tab="shape"],
+    body.role-foh .tab-btn[data-tab="bfp"] { display: none !important; }
 
     /* Worker header — two rows: identity on top, date nav below */
     .worker-header {
@@ -1058,7 +1063,7 @@
     getInventoryReport, attributeDeliveryCoverage,
     scheduleCheese, scheduleDip,
     isShapeOnlyDelivery,
-  } from '../../scripts/inventory.js?v=2026-05-08-followups';
+  } from '../../scripts/inventory.js?v=2026-05-07-saint-box-mapping';
 
   // Shape-only catering + box expansion. ENABLED BY DEFAULT — catering
   // boxes (Catering: ...) and FOH Placeholder deliveries skip BFP and
@@ -1559,14 +1564,20 @@
     return (Math.round(n * 10) / 10).toFixed(1);
   };
 
-  // Role from ?role=shape | ?role=bfp | (default = manager). Used to scope the
-  // UI so the dough team and BFP team can't see/edit each other's schedule.
+  // Role from ?role=shape | ?role=bfp | ?role=foh | (default = manager).
+  // Used to scope the UI so each team only sees their own surface:
+  //   shape → only Shape tab
+  //   bfp   → only BFP tab
+  //   foh   → only Dips (Cheese tab) + Stock tabs — FOH manages dip
+  //           production and on-hand counts; doesn't touch shape/BFP.
   const _roleParam = new URLSearchParams(window.location.search).get('role');
   const userRole   = _roleParam === 'shape' ? 'shape'
                   : _roleParam === 'bfp'   ? 'bfp'
+                  : _roleParam === 'foh'   ? 'foh'
                   : 'manager';
   if (userRole === 'shape')      document.title = appLang === 'es' ? 'Formar · Producción' : 'Shape · Production';
   else if (userRole === 'bfp')   document.title = appLang === 'es' ? 'HCE · Producción'    : 'BFP · Production';
+  else if (userRole === 'foh')   document.title = appLang === 'es' ? 'FOH · Salsas'        : 'FOH · Dips';
   else                            document.title = appLang === 'es' ? 'Producción' : 'Production';
 
   // Set body class for role-aware CSS hiding (handled in stylesheet).
@@ -1582,7 +1593,9 @@
     else document.addEventListener('DOMContentLoaded', setBody);
   }
 
-  let dayTab = userRole === 'bfp' ? 'bfp' : 'shape'; // 'shape' | 'bfp' | 'stock' (manager only)
+  let dayTab = userRole === 'bfp' ? 'bfp'
+             : userRole === 'foh' ? 'cheese' // Dips tab (renamed) is FOH's home
+             : 'shape'; // 'shape' | 'bfp' | 'stock' | 'cheese' (cheese/stock visible per role rules)
 
   // Inline logging state
   // loggedPretzels[type][dateStr][sku] = current pretzel count (local, mid-edit)
@@ -2640,9 +2653,10 @@
 
   function renderDayView() {
     const dateStr    = toDateStr(currentDate);
-    // Stock + Cheese tabs are manager-only; force back to the role's home tab
-    // if a team role somehow lands there.
-    if ((dayTab === 'stock' || dayTab === 'cheese') && userRole !== 'manager') {
+    // Stock + Cheese (Dips) tabs are visible to manager + FOH; shape/BFP get
+    // forced back to their team's home tab if they somehow land there.
+    const isAllowedStockCheese = userRole === 'manager' || userRole === 'foh';
+    if ((dayTab === 'stock' || dayTab === 'cheese') && !isAllowedStockCheese) {
       dayTab = userRole === 'bfp' ? 'bfp' : 'shape';
     }
     if (dayTab === 'stock')  return renderStockTab();
@@ -3056,20 +3070,46 @@
               <div class="wmetric-value"><strong>${Math.round(onHand)}</strong></div>
             </div>
           </div>
-          <div class="wstepper" style="display:flex;gap:6px;flex-wrap:wrap">
-            <button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="single" data-delta="-1" ${todayMadeUnits <= 0 ? 'disabled' : ''}>−</button>
-            <button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="single" data-delta="1">+ ${appLang === 'es' ? 'sencilla' : 'single'} (${cfg.singleBatchSize})</button>
-            ${showDouble ? `<button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="double" data-delta="1">+ ${appLang === 'es' ? 'doble' : 'double'} (${cfg.doubleBatchSize})</button>` : ''}
+          <div class="wstepper" style="display:flex;gap:6px;flex-wrap:nowrap;overflow-x:auto">
+            <button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="single" data-delta="-1" ${todayMadeUnits <= 0 ? 'disabled' : ''} style="min-width:44px;white-space:nowrap;font-size:14px">−</button>
+            <button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="single" data-delta="1" style="flex:1;white-space:nowrap;font-size:13px;padding:8px 10px">+ ${appLang === 'es' ? 'sencilla' : 'single'} (${cfg.singleBatchSize})</button>
+            ${showDouble ? `<button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="double" data-delta="1" style="flex:1;white-space:nowrap;font-size:13px;padding:8px 10px">+ ${appLang === 'es' ? 'doble' : 'double'} (${cfg.doubleBatchSize})</button>` : ''}
           </div>
         </div>`;
     } else {
-      todayHtml = `<div class="no-prod" style="padding:24px 20px">
-        ${cfg.emoji} ${appLang === 'es' ? 'Sin tanda hoy' : 'No batch needed today'} — ${esc(cfg.label)}
-        <br><span style="font-size:13px;color:var(--gray-3)">
-          ${appLang === 'es' ? 'Inventario: ' : 'On hand: '}
-          ${Math.round(onHand)} ${appLang === 'es' ? 'dips · consumo FOH ~' : 'dips · FOH walk-in ~'}${dailyAvg}/${appLang === 'es' ? 'día' : 'day'}
-        </span>
-      </div>`;
+      // No-batch-needed card uses the same wcard chrome as the batch-needed
+      // case so all 5 dip cards align visually. Green stripe + "✅ Stocked"
+      // pill make it obvious at a glance which dips are good to go.
+      const runwayDays = dailyAvg > 0 ? Math.round(onHand / dailyAvg) : null;
+      const runwayLabel = runwayDays != null
+        ? `${runwayDays} ${appLang === 'es' ? 'días' : 'days'}`
+        : '—';
+      todayHtml = `
+        <div class="wcard status-done" style="--wcard-stripe:#b9d4a8">
+          <div class="wcard-head">
+            <div>
+              <div class="wcard-name">${cfg.emoji} ${esc(cfg.label.charAt(0).toUpperCase() + cfg.label.slice(1))}</div>
+              <div style="font:500 12px 'Manrope',sans-serif;color:var(--gray-3);margin-top:2px">
+                ${appLang === 'es' ? 'Sin tanda hoy — bien abastecido' : 'No batch needed today — well stocked'}
+              </div>
+            </div>
+            <span class="wcard-pill done">✅ ${appLang === 'es' ? 'Abastecido' : 'Stocked'}</span>
+          </div>
+          <div class="wcard-metrics" style="margin-top:8px">
+            <div class="wmetric">
+              <div class="wmetric-label">${appLang === 'es' ? 'INVENTARIO' : 'ON HAND'}</div>
+              <div class="wmetric-value"><strong>${Math.round(onHand)}</strong></div>
+            </div>
+            <div class="wmetric">
+              <div class="wmetric-label">${appLang === 'es' ? 'FOH / DÍA' : 'FOH / DAY'}</div>
+              <div class="wmetric-value"><strong>${dailyAvg}</strong></div>
+            </div>
+            <div class="wmetric">
+              <div class="wmetric-label">${appLang === 'es' ? 'ALCANZA' : 'RUNWAY'}</div>
+              <div class="wmetric-value"><strong>${runwayLabel}</strong></div>
+            </div>
+          </div>
+        </div>`;
     }
 
     const upcoming = sched.batches.filter(b => b.date > dateStr).slice(0, 8);
@@ -3088,13 +3128,10 @@
         }).join('')}
       </div>`;
 
+    // No per-dip section heading above the card — the card itself shows
+    // the dip name + emoji + status pill + on-hand metric. Adding a
+    // duplicate heading line outside the card was redundant noise.
     return `<div style="margin-bottom:18px">
-      <div style="margin-bottom:6px">
-        <div style="font:700 14px 'Paytone One',sans-serif;color:var(--dark)">${cfg.emoji} ${esc(cfg.label.charAt(0).toUpperCase() + cfg.label.slice(1))}</div>
-        <div style="font:400 11px 'Manrope',sans-serif;color:var(--gray-3)">
-          ${appLang === 'es' ? 'Inventario' : 'On hand'} ${Math.round(onHand)} · FOH ~${dailyAvg}/${appLang === 'es' ? 'día' : 'day'}
-        </div>
-      </div>
       ${todayHtml}
       ${upcomingHtml}
     </div>`;
@@ -3703,9 +3740,12 @@
       : '';
     document.getElementById('alert-area').innerHTML = alertHtml;
 
-    // Tab bar — manager only (team roles see only their own card)
+    // Tab bar — manager + FOH (shape/BFP see only their own card; FOH still
+    // needs to switch between Dips and Stock).
     const tabBar = document.getElementById('tab-bar');
-    tabBar.style.display = (viewMode === 'week' || userRole !== 'manager') ? 'none' : 'flex';
+    const tabBarVisible = viewMode !== 'week'
+      && (userRole === 'manager' || userRole === 'foh');
+    tabBar.style.display = tabBarVisible ? 'flex' : 'none';
     document.querySelectorAll('.tab-btn').forEach(btn =>
       btn.classList.toggle('active', btn.dataset.tab === dayTab));
 


### PR DESCRIPTION
## Summary

Two parallel improvements: clean up the Dips tab visual bugs, and add a `?role=foh` URL so the FOH team gets a focused view (Dips + Stock only, no Shape/BFP).

## What FOH gets

**Link to share:**
```
https://www.dangerouspretzel.com/static/production/index.html?role=foh
```

When opened:
- Title bar: "FOH · Dips"
- Only 🧀 Dips + 📦 Stock tabs visible
- Lands on Dips tab by default
- Tap Stock to update on-hand counts (cheese + retail dips show in the new "On Hand" column)
- Same content + math as the manager view; just hides Shape + BFP

## Dips tab UI fixes

| Before | After |
|---|---|
| Stepper buttons wrapped — `+ single` on one line, `(150)` on next | Single-line buttons; row scrolls horizontally on narrow viewports |
| Each dip rendered two "On hand" lines (subtitle + card metric) | One source of truth — the card body's ON HAND metric |
| "No batch needed today" looked different from "today's batch" cards | Both use the same `wcard` chrome; "no batch" version has a green stripe + ✅ Stocked pill + ON HAND / FOH per day / RUNWAY days metrics |

## Implementation (~5 small edits across 2 files)

### `static/production/index.html`
- **A. Stepper** (`renderDipCard` ~line 3059): `flex-wrap:nowrap`, `white-space:nowrap` on labels, `flex:1` on the two `+` buttons, `overflow-x:auto` for narrow viewports
- **A. Subtitle dedupe** (~line 3091): removed the duplicate `On hand X · FOH ~Y/day` line above the card; the wcard metrics show this once
- **A. No-batch card** (~line 3066): rebuilt as a `wcard status-done` with 3 metrics (ON HAND, FOH/DAY, RUNWAY)
- **B. Role parser** (~line 1565): recognize `?role=foh`
- **B. Tab default** (~line 1585): FOH defaults to 'cheese' (Dips tab)
- **B. Tab bar CSS** (~line 553): `body.role-foh .tab-bar` restored to flex; Shape + BFP buttons hidden
- **B. Tab bar render** (~line 3744): tab bar visible for manager OR FOH
- **B. Route guard** (~line 2658): cheese/stock accessible to manager OR FOH

### `scripts/inventory.js` (small companion change)
- Added Saint Pretzel Box → 15 × 6.5oz plain to `DEFAULT_BOX_EXPANSIONS` (topped with cinnamon sugar by FOH at fulfillment)

## Test plan

- [ ] After merge + AEM auto-deploy:
- [ ] Open `?role=foh` URL → only Dips + Stock tabs; lands on Dips
- [ ] All 5 dip cards align (cheese + 4 retail) — no duplicate "On hand" lines
- [ ] Stepper buttons single-line each
- [ ] "No batch needed today" cards (any dip that's well-stocked) show with green stripe + Stocked pill
- [ ] Manager view (no `?role=`) unchanged — all 4 tabs
- [ ] `?role=shape` and `?role=bfp` unchanged (no regression)
- [ ] FOH bookmarks the URL on their tablet → opens straight to Dips tab on next session

## Out of scope (next PRs)

- Per-dip config UI (currently DIP_CONFIG hardcoded for lead times / batch sizes)
- Auto-deploy worker on merge (`.github/workflows/deploy-worker.yaml`)
- Box mappings the manager needs to add via the new UI: Swell Cream Box, dip boxes

Generated with [Claude Code](https://claude.com/claude-code)
