### PR TITLE
KV-backed future-event tombstones + FOH-scoped Stock tab

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -206,13 +206,12 @@ export const TRAY_SIZES = {
 
 // SKUs that aren't produced in-house (front-of-house pre-made / sourced).
 // Note: `3oz cheese dip` USED to be here but is now tracked production
-// (FOH makes it on-site in batches of 150). Bulk pre-mixed dip + individual
-// catering-portion dips (dangerous, sweet cream) are FOH — they're
-// portioned fresh during fulfillment, no production scheduling.
+// (FOH makes it on-site in batches of 150). Only the bulk pre-mixed dip
+// is still FOH-external. Individual dip portions (cheese / sweet cream /
+// hot ranch / mustards) live in DIP_CONFIG and are production-scheduled
+// so FOH gets lead-time visibility for catering events.
 export const FOH_SKUS = new Set([
   'bulk dangerous dip (25 srv)',
-  '3oz dangerous dip',
-  '3oz sweet cream dip',
 ]);
 
 // SKUs that need a coating step at BFP (cheese on top during bake).
@@ -235,17 +234,17 @@ export const FOH_PLACEHOLDER_NAME = 'FOH Placeholder';
 // production app's "Box mapping" tab — those entries take priority.
 //
 // User-confirmed mappings:
-//   Catering: Salty Pretzel Box      → 15 × 6.5oz plain         (2026-05-05)
-//   Catering: BBK Pretzel Box - 15   → 15 × 6.5oz bbk           (2026-05-05)
-//   Catering: Saint Pretzel Box      → 15 × 6.5oz plain         (2026-05-07; FOH tops w/ cinn sugar)
-//   Catering: Dangerous Dip Box      → 15 × 3oz dangerous dip   (2026-05-07; FOH portions fresh)
-//   Catering: Swell Cream Box - 15   → 15 × 3oz sweet cream dip (2026-05-07; FOH portions fresh)
+//   Catering: Salty Pretzel Box      → 15 × 6.5oz plain     (2026-05-05)
+//   Catering: BBK Pretzel Box - 15   → 15 × 6.5oz bbk       (2026-05-05)
+//   Catering: Saint Pretzel Box      → 15 × 6.5oz plain     (2026-05-07; FOH tops w/ cinn sugar)
+//   Catering: Dangerous Dip Box      → 15 × 3oz cheese dip  (2026-05-07; "dangerous dip" is the external name for the internal cheese-dip SKU)
+//   Catering: Swell Cream Box - 15   → 15 × sweet cream dip (2026-05-07; production-tracked via DIP_CONFIG so FOH gets lead-time visibility)
 export const DEFAULT_BOX_EXPANSIONS = {
   'Catering: Salty Pretzel Box': [{ sku: '6.5oz plain', multiplier: 15 }],
   'Catering: BBK Pretzel Box - 15': [{ sku: '6.5oz bbk', multiplier: 15 }],
   'Catering: Saint Pretzel Box': [{ sku: '6.5oz plain', multiplier: 15 }],
-  'Catering: Dangerous Dip Box': [{ sku: '3oz dangerous dip', multiplier: 15 }],
-  'Catering: Swell Cream Box - 15': [{ sku: '3oz sweet cream dip', multiplier: 15 }],
+  'Catering: Dangerous Dip Box': [{ sku: '3oz cheese dip', multiplier: 15 }],
+  'Catering: Swell Cream Box - 15': [{ sku: 'sweet cream dip', multiplier: 15 }],
 };
 
 /**

--- a/static/delivery-planner/index.html
+++ b/static/delivery-planner/index.html
@@ -954,7 +954,7 @@
       isShapeOnlyDelivery,
       expandBoxLineItems,
       caseSizeOptionsFor,
-    } from '../../scripts/inventory.js?v=2026-05-07-audit-fixes-round2';
+    } from '../../scripts/inventory.js?v=2026-05-07-dip-catering-route';
 
     // Shape-only catering + box expansion. ENABLED BY DEFAULT — kept in
     // sync with production app via the same localStorage key.

--- a/static/delivery-planner/skus.json
+++ b/static/delivery-planner/skus.json
@@ -11,8 +11,10 @@
   "4oz twist bbk",
   "4oz twist spicy bee",
   "3oz cheese dip",
-  "3oz dangerous dip",
-  "3oz sweet cream dip",
+  "sweet cream dip",
+  "hot ranch dip",
+  "house mustard dip",
+  "honey mustard dip",
   "bulk dangerous dip (25 srv)",
   "plain bombs",
   "bees bats"

--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1063,7 +1063,7 @@
     getInventoryReport, attributeDeliveryCoverage,
     scheduleCheese, scheduleDip,
     isShapeOnlyDelivery,
-  } from '../../scripts/inventory.js?v=2026-05-07-audit-fixes-round2';
+  } from '../../scripts/inventory.js?v=2026-05-11-foh-stock';
 
   // Shape-only catering + box expansion. ENABLED BY DEFAULT — catering
   // boxes (Catering: ...) and FOH Placeholder deliveries skip BFP and
@@ -1167,6 +1167,14 @@
   const LIFECYCLELESS_SKUS = new Set([
     '3oz cheese dip',
     'bulk dangerous dip (25 srv)',
+    // Retail + catering-portion dips (DIP_CONFIG entries) — produced in
+    // batches but no dough/bake lifecycle, so stock is a single on-hand
+    // count. Catering boxes (Dangerous Dip Box, Swell Cream Box) expand
+    // to these same SKUs so we don't need separate "portion" SKUs.
+    'hot ranch dip',
+    'sweet cream dip',
+    'house mustard dip',
+    'honey mustard dip',
   ]);
   // Per-SKU stripe color (worker view) — regex priority. Returns CSS color string.
   const getStripeColor = (sku) => {
@@ -2839,7 +2847,12 @@
       if (ageDays >= DOUGH_AGE_WARN_DAYS) oldestDoughAge[sku] = ageDays;
     });
 
-    const rows = allSkus.map(sku => {
+    // FOH role: Stock tab is filtered to dip rows only. They manage dip
+    // on-hand counts, not pretzel inventory. Manager sees everything.
+    const stockSkus = userRole === 'foh'
+      ? allSkus.filter(sku => LIFECYCLELESS_SKUS.has(sku) || isFOH(sku))
+      : allSkus;
+    const rows = stockSkus.map(sku => {
       const isFohSku   = isFOH(sku);
       // Lifecycle-less SKUs: cheese, bulk dip, and the 4 retail dips coming
       // in Phase 3b. They have no dough → bake → freeze pipeline; manager
@@ -2982,14 +2995,20 @@
         }).join('')}
       </div>`;
 
+    // FOH role: simpler chrome. No forecast summary (pretzel-focused), no
+    // dough-aging banners. Stock-tab title swapped to dip-specific label.
+    const isFohRole = userRole === 'foh';
+    const tabTitle = isFohRole
+      ? (appLang === 'es' ? 'Salsas en inventario' : 'Dips on hand')
+      : t('stock_title');
     return `<div class="team-card"><div class="team-body">
       <div class="stock-tab-header">
         <div>
-          <div class="stock-tab-title">${t('stock_title')}</div>
+          <div class="stock-tab-title">${esc(tabTitle)}</div>
           <div class="stock-tab-note">${esc(lastSavedStr)}${esc(deductNote)}</div>
         </div>
       </div>
-      ${summaryHtml}
+      ${isFohRole ? '' : summaryHtml}
       <div class="stock-col-head">
         <span>${t('sku_col')}</span>
         <span style="text-align:center">${t('dough_col')}</span>
@@ -2997,7 +3016,7 @@
       </div>
       ${rows}
       <button class="btn-primary" id="stock-save" style="margin-top:20px">${t('save_stock')}</button>
-      ${boxMappingsHtml}
+      ${isFohRole ? '' : boxMappingsHtml}
     </div></div>`;
   }
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1184,6 +1184,24 @@ function buildCheeseEvent({ batch, dtstamp }) {
   return lines.join('\r\n');
 }
 
+// Read the UID set we emitted last time from KV. Used to diff against the
+// current live set so future-date batches that no longer apply get an
+// explicit STATUS:CANCELLED tombstone (the "I added inventory, why is the
+// batch still on the calendar" symptom). Returns an empty Set if KV isn't
+// bound or the key doesn't exist (first run / TTL expired).
+async function kvGetUidSet(env) {
+  if (!env.FOH_CAL_STATE) return new Set();
+  try {
+    const raw = await env.FOH_CAL_STATE.get('last-live-uids');
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw);
+    return new Set(Array.isArray(arr) ? arr : []);
+  } catch (err) {
+    console.warn('FOH cal KV get failed:', err.message);
+    return new Set();
+  }
+}
+
 // Tombstone VEVENT for a UID that's no longer in the live schedule. Some
 // calendar clients (myecalendar in particular) keep events in the calendar
 // after they drop out of the subscribed feed. Emitting an explicit
@@ -1363,11 +1381,56 @@ async function handleFohCalendar(request, env) {
   // Build .ics body
   const dtstamp = icsDateUTC(new Date());
 
-  // Tombstones for past 3 days × every dip type. Calendar clients that
-  // imported a batch on (today-1) and now don't see it in the live feed
-  // will receive STATUS:CANCELLED for that UID and remove. Idempotent —
-  // clients with no matching event treat as no-op. Cheap (15 small events).
-  const tombstoneEvents = [];
+  // Collect the live event set as (uid, date, summary) records so we can
+  // both emit them AND diff against previously-emitted UIDs in KV.
+  const liveRecords = [];
+  cheese.batches.forEach((batch) => {
+    liveRecords.push({
+      uid: `cheese-batch-${batch.date}@dangpretz`,
+      date: batch.date,
+      summary: `🧀 cheese dip batch`,
+      ics: buildCheeseEvent({ batch, dtstamp }),
+    });
+  });
+  retailDipBatches.forEach(({ dipSku, cfg, batch }) => {
+    liveRecords.push({
+      uid: `${cfg.key}-batch-${batch.date}@dangpretz`,
+      date: batch.date,
+      summary: `${cfg.label} batch`,
+      ics: buildDipBatchEvent({ dipSku, cfg, batch, dtstamp }),
+    });
+  });
+  cateringDeliveries.forEach((delivery) => {
+    liveRecords.push({
+      uid: `catering-${delivery.deliveryId}@dangpretz`,
+      date: delivery.date,
+      summary: `catering for ${delivery.customer || '?'}`,
+      ics: buildCateringEvent({ delivery, dtstamp }),
+    });
+  });
+  const currentUids = new Set(liveRecords.map((r) => r.uid));
+
+  // Diff against the last-emitted set in KV. Any UID that WAS in the feed
+  // last time but ISN'T now gets a STATUS:CANCELLED tombstone — fixes the
+  // "I added inventory so the future batch is no longer needed, but the
+  // calendar still shows it" symptom for myecalendar.
+  const previousUids = await kvGetUidSet(env);
+  const disappearedUids = [...previousUids].filter((uid) => !currentUids.has(uid));
+
+  // Tombstones for disappeared UIDs. Each gets a generic cancel event with
+  // the same UID — calendars match on UID and remove.
+  const tombstoneEvents = disappearedUids.map((uid) => buildBatchCancelEvent({
+    uid,
+    // DTSTART is required for STATUS:CANCELLED in some parsers — use today
+    // as a placeholder; the receiving calendar matches on UID anyway.
+    date: today,
+    dtstamp,
+    summary: '(cancelled)',
+  }));
+
+  // Belt-and-suspenders: also keep emitting past-3-day tombstones for every
+  // dip-type slot. Catches calendars whose UID-match was off, or KV first-
+  // request cases where previousUids is empty. Cheap (15 small events).
   for (let i = 1; i <= 3; i++) {
     const date = (() => {
       const dt = new Date(today);
@@ -1375,10 +1438,12 @@ async function handleFohCalendar(request, env) {
       return dt.toISOString().slice(0, 10);
     })();
     Object.entries(DIP_CONFIG).forEach(([dipSku, cfg]) => {
-      // Cheese uses its own UID prefix; retail dips use cfg.key
       const uid = dipSku === CHEESE_KEY
         ? `cheese-batch-${date}@dangpretz`
         : `${cfg.key}-batch-${date}@dangpretz`;
+      // Don't double up if this UID is also in the disappeared set
+      if (currentUids.has(uid)) return;
+      if (disappearedUids.includes(uid)) return;
       tombstoneEvents.push(buildBatchCancelEvent({
         uid,
         date,
@@ -1388,10 +1453,17 @@ async function handleFohCalendar(request, env) {
     });
   }
 
+  // Persist the current live-UID set for next time's diff. Don't block the
+  // response on the KV write — Cloudflare KV is eventually consistent and
+  // a missed write just delays the future-tombstone signal by one cycle.
+  if (env.FOH_CAL_STATE) {
+    env.FOH_CAL_STATE
+      .put('last-live-uids', JSON.stringify([...currentUids]), { expirationTtl: 60 * 60 * 24 * 30 })
+      .catch((err) => console.warn('FOH cal KV put failed:', err.message));
+  }
+
   const events = [
-    ...cheese.batches.map((batch) => buildCheeseEvent({ batch, dtstamp })),
-    ...retailDipBatches.map(({ dipSku, cfg, batch }) => buildDipBatchEvent({ dipSku, cfg, batch, dtstamp })),
-    ...cateringDeliveries.map((delivery) => buildCateringEvent({ delivery, dtstamp })),
+    ...liveRecords.map((r) => r.ics),
     ...tombstoneEvents,
   ];
 


### PR DESCRIPTION
## Two related improvements

### Section A: future-event tombstones via KV diff

**Problem.** Today's tombstone logic only covered the past 3 days. When the manager added inventory (tapped "+ batch" or saved a stock count) such that a *future* scheduled batch was no longer needed, the batch UID simply dropped out of the live `/foh-cal.ics` feed. myecalendar would keep showing the now-stale event because no explicit `STATUS:CANCELLED` was broadcast for that UID.

**Fix.** Worker now uses the existing `FOH_CAL_STATE` KV namespace to track the live UID set across requests:

```
1. Compute current live UIDs (cheese + retail dip batches + catering deliveries)
2. Read previous UIDs from KV
3. (previous − current) = disappeared → emit STATUS:CANCELLED for each
4. Emit live + delta tombstones + existing past-3-day belt
5. Fire-and-forget KV write with 30d TTL
```

Verified live (worker version `cecd0b9c`): steady state emits 15 tombstones (past-3-day belt only — no false-positive future tombstones for unchanged schedule). KV writes settle in ~50ms.

### Section B: FOH-scoped Stock tab

**Problem.** `?role=foh` (from PR #17) gave FOH access to the Stock tab, but it showed all SKUs including pretzels. FOH only manages dips.

**Fix.**
- Expanded `LIFECYCLELESS_SKUS` to include the 4 retail dips so they render with a single "On Hand" input
- When `userRole === 'foh'`, filter Stock tab rows to lifecycle-less + FOH SKUs only (pretzels hidden)
- Hide forecast summary + box-mappings list for FOH (both are pretzel-pipeline concepts)
- Swap title from generic "Stock count" to "Dips on hand" / "Salsas en inventario"

Verified in preview (`?role=foh`):

| Row | Shows |
|---|---|
| 3oz cheese dip | On hand input |
| sweet cream dip | On hand input |
| hot ranch dip | On hand input |
| house mustard dip | On hand input |
| honey mustard dip | On hand input |
| bulk dangerous dip (25 srv) | On hand input |

Pretzel SKUs hidden. Manager view (no `?role=`) unchanged.

## Companion changes (manager updated during my work)

- **Catering box mapping refactor**: Dangerous Dip Box now expands to `3oz cheese dip` (the production SKU itself); Swell Cream Box to `sweet cream dip`. No separate "portion" SKUs — FOH gets lead-time visibility through the same dip schedule.
- **`skus.json`** drops the 2 catering-portion SKUs and adds the 4 retail dips so they appear in the planner SKU dropdown for wholesale line items.

## Files

- `worker/src/index.js` — KV diff logic + helper
- `static/production/index.html` — LIFECYCLELESS_SKUS expansion, Stock-tab role filter, chrome hide for FOH, title swap, cache-bust
- `scripts/inventory.js` — FOH_SKUS + DEFAULT_BOX_EXPANSIONS refactor
- `static/delivery-planner/index.html` — cache-bust
- `static/delivery-planner/skus.json` — retail dip additions, portion removals

## Test plan

- [ ] After merge + AEM auto-deploy:
- [ ] Open `?role=foh` → Stock tab shows 6 dip rows only, "Dips on hand" title
- [ ] Tap "+ single" on a hot ranch batch → tomorrow's batch (if no longer needed) disappears from feed → next `/foh-cal.ics` shows a tombstone for that UID
- [ ] Manager view: 4-tab nav, full Stock tab with pretzels + forecast + box mappings list
- [ ] FOH tablet sync: stale future events should clear on next poll once a tombstone fires

Generated with [Claude Code](https://claude.com/claude-code)
