### PR TITLE
Audit fixes: 6 real bugs found + fixed

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -470,21 +470,23 @@ export function resolveProductionLogs(logs) {
     const s = state[date];
 
     if (action === 'inventory') {
+      // Per-SKU merge into the day's state. Multiple inventory rows on the
+      // same date (e.g. Stock-tab Save All in the morning, then a per-dip
+      // saveDipOnHand at noon) each update only their own SKUs without
+      // wiping unrelated ones. Each SKU's value is still last-write-wins
+      // across rows; rows just don't blow each other away.
       try {
         const snaps = JSON.parse(row.snapshots || '[]');
-        const cf = {};
-        const fr = {};
-        const oh = {}; // on-hand bucket — for SKUs with no dough/bake lifecycle (cheese, dips)
+        if (!s.coldFerment) s.coldFerment = {};
+        if (!s.frozen) s.frozen = {};
+        if (!s.onHand) s.onHand = {};
         snaps.forEach((sn) => {
           const k = canonicalSku(sn.sku);
           if (!k) return;
-          cf[k] = Number(sn.coldFerment) || 0;
-          fr[k] = Number(sn.frozen) || 0;
-          oh[k] = Number(sn.onHand) || 0;
+          s.coldFerment[k] = Number(sn.coldFerment) || 0;
+          s.frozen[k] = Number(sn.frozen) || 0;
+          s.onHand[k] = Number(sn.onHand) || 0;
         });
-        s.coldFerment = cf;
-        s.frozen = fr;
-        s.onHand = oh;
       } catch {}
       if (row.timeStamp && (!latestInventoryTs || row.timeStamp > latestInventoryTs)) {
         latestInventoryTs = row.timeStamp;
@@ -759,7 +761,14 @@ export function getInventoryReport(args) {
           bs = c.size === 'double' ? cfg.doubleBatchSize : cfg.singleBatchSize;
         } else {
           bs = getBatchSize(key);
-          if (!bs) return;
+          if (!bs) {
+            // Unconfigured SKU — neither DIP_CONFIG nor BATCH_SIZES knows
+            // its yield. Warn so this isn't silently lost. Manager should
+            // add the SKU to DIP_CONFIG or skuConfig before logging more.
+            // eslint-disable-next-line no-console
+            console.warn(`cheese_done: unconfigured SKU "${key}" — batch not credited (add to DIP_CONFIG or sku_config).`);
+            return;
+          }
         }
         const batches = Number(c.batches) || 0;
         const p = batches * bs;
@@ -850,7 +859,18 @@ export function getInventoryReport(args) {
         }
 
         if (!flowDelivered[key]) flowDelivered[key] = [];
-        flowDelivered[key].push({ customer: cust, qty, confirmedAt: delivery._confirmedAt || '' });
+        flowDelivered[key].push({
+          customer: cust,
+          qty,
+          fulfilled: qty - remaining,
+          // shortage > 0 means the delivery shipped without enough on-hand
+          // inventory to cover it — useful signal for the coverage UI and
+          // future "delivery audit" reports. Today the cascade caps at 0
+          // per bucket, so nothing goes negative; we just track that there
+          // was a gap.
+          shortage: remaining,
+          confirmedAt: delivery._confirmedAt || '',
+        });
       });
     });
 

--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1578,7 +1578,9 @@
   //   bfp   → only BFP tab
   //   foh   → only Dips (Cheese tab) + Stock tabs — FOH manages dip
   //           production and on-hand counts; doesn't touch shape/BFP.
-  const _roleParam = new URLSearchParams(window.location.search).get('role');
+  // Normalize to lowercase so ?role=FOH / ?role=Shape / etc. all work the
+  // same. Unknown values fall through to 'manager'.
+  const _roleParam = (new URLSearchParams(window.location.search).get('role') || '').toLowerCase().trim();
   const userRole   = _roleParam === 'shape' ? 'shape'
                   : _roleParam === 'bfp'   ? 'bfp'
                   : _roleParam === 'foh'   ? 'foh'
@@ -3978,6 +3980,9 @@
         input.type = 'number';
         input.min = '0';
         input.value = currentText;
+        // Class is picked up by _isInputBusy so a softRefresh tick can't
+        // erase the input mid-type.
+        input.className = 'inline-onhand-edit';
         input.style.cssText = 'width:80px;padding:4px 6px;border:1.5px solid var(--gray-2);border-radius:6px;font:700 18px "Manrope",sans-serif;text-align:center;color:var(--dark)';
         metricEl.innerHTML = '';
         metricEl.appendChild(input);
@@ -4498,8 +4503,10 @@
 
   // Auto-refresh — visibility regain + soft 60s interval. Both gated by
   // active input focus + pending save (so we don't clobber typing).
+  // .inline-onhand-edit is the dynamic input from the Dips-tab ON HAND
+  // editor; without it softRefresh would erase the input mid-type.
   const _isInputBusy = () =>
-    document.activeElement?.matches?.('[data-log-input], [data-stock-section], [data-log-step], #extra-val')
+    document.activeElement?.matches?.('[data-log-input], [data-stock-section], [data-log-step], #extra-val, .inline-onhand-edit')
     || Object.keys(saveTimers || {}).some(k => saveTimers[k] != null);
 
   // Track when the current worker session started so we don't toast diffs

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1360,7 +1360,9 @@ async function handleFohCalendar(request, env) {
       skuAliases: prod.skuAliases,
       lookaheadDays: 14,
     });
-    sched.batches.forEach((batch) => {
+    // Defensive: scheduleDip returns {batches: []} for SKUs missing from
+    // DIP_CONFIG (PR #18). Don't assume `.batches` is iterable.
+    (sched?.batches || []).forEach((batch) => {
       retailDipBatches.push({ dipSku, cfg, batch });
     });
   });


### PR DESCRIPTION
## Audit summary

Spawned 3 Explore agents to audit inventory math, production-app UI flows, and worker iCal/KV logic. Found 6 real bugs worth fixing now; rejected ~20 other "concerns" that turned out to be either correct-by-design, harmless, or so unlikely they're not worth code today.

## The 6 fixes (in order of severity)

### 1. Same-date inventory snapshots clobber each other ⚠️ HIGH

`scripts/inventory.js` inventory action handler was replacing `s.coldFerment`, `s.frozen`, `s.onHand` wholesale per log row. With PR #20's `saveDipOnHand` single-SKU snapshots, this meant:

- 10am: saveDipOnHand cheese=200 → `state[today].onHand = {cheese: 200}`
- 11am: saveDipOnHand hot ranch=50 → `state[today].onHand = {'hot ranch': 50}` — cheese dropped!

If cheese had no prior date snapshot, `getLatestInventory` lost the cheese value entirely. Now: per-SKU merge into `state[date]`. Multiple same-date rows compose correctly.

### 2. softRefresh erases inline ON HAND editor mid-type ⚠️ HIGH

The dynamic `<input>` from the Dips-tab click-to-edit had no `data-*` attribute matching `_isInputBusy`'s selector. Every 60s softRefresh would call `render()`, wiping the input mid-type. User's value lost silently.

Fix: input now has class `inline-onhand-edit`; `_isInputBusy` includes that class.

### 3. cheese_done for unconfigured SKU silently no-ops [MED]

If a typo / future SKU lands in a `cheese_done` log and matches neither DIP_CONFIG nor BATCH_SIZES, the credit silently vanished. Now logs a `console.warn` so the missed credit is visible.

### 4. Delivery cascade shortage tracking [MED]

When a confirmed delivery wants more dips than total on-hand, the cascade correctly caps each bucket at 0 — but the gap was silent. `flowDelivered` records now include `{fulfilled, shortage}` per consumption event so future coverage UI can surface "this delivery shipped short by N".

### 5. Role parser case-insensitive [MED]

`?role=FOH` previously fell through to manager. Now lowercase-normalized + trimmed. Any casing of the role param works.

### 6. Worker scheduleDip empty-result guard [LOW]

For SKUs not in DIP_CONFIG, scheduleDip returns `{batches: []}` defensively (PR #18). Worker call site assumed `.batches` was always iterable. Defensive `?.batches || []` guard.

## What I deliberately didn't ship

Agents flagged ~10 other "concerns" that I reviewed and rejected:

| Item | Why not |
|---|---|
| KV write race | Idempotent. Both racing requests compute the same diff. Calendar dedupes on UID. |
| KV TTL drift (30d) | Acceptable; FOH calendar hits hourly. |
| isCateringDelivery regex too strict | Matches current Square data. Revisit if box naming changes. |
| Box expansion alias dedupe ordering | No aliases in production yet. Defer until needed. |
| `getLatestInventory` date-sort zero-pad | All dates are ISO-padded today. No real occurrences. |
| Memory leak from re-renders | Theoretical only. innerHTML replacement clears the old subtree; GC handles detached nodes. No leak with current event-listener patterns. |
| Catering event with empty lineItems → blank SUMMARY | Cosmetic, graceful fallback. |
| `/admin/foh-cal-test` dead code | Harmless. Could remove in cleanup PR. |

## Verified

- Worker redeployed (version `8963757e`); `/foh-cal.ics` still emits 15 tombstones (baseline past-3-day belt, no false-positive future tombstones)
- `npm run lint` clean
- No worker errors after deploy

## Files

- `scripts/inventory.js` — fixes #1, #2, #3
- `static/production/index.html` — fixes #4, #5
- `worker/src/index.js` — fix #6

Generated with [Claude Code](https://claude.com/claude-code)
