### PR TITLE
Audit pass 3: perf hot-path tightening

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -878,6 +878,22 @@ export function getInventoryReport(args) {
   Object.keys(fr).forEach((k) => { fr[k] = Math.max(0, Math.round(fr[k])); });
   Object.keys(oh).forEach((k) => { oh[k] = Math.max(0, Math.round(oh[k])); });
 
+  // Prune dough queue: drop entries past their shelf-life + 3-day grace
+  // window. They've either been consumed (zeroed) or are stale enough that
+  // they shouldn't drive aging alerts or live-stock displays. Keeps the
+  // in-memory queue bounded as log history grows over months.
+  const pruneNow = Date.now();
+  Object.keys(doughQueue).forEach((sku) => {
+    const dipCfg = DIP_CONFIG[sku];
+    const failAt = dipCfg ? dipCfg.shelfLifeDays : DOUGH_AGE_FAIL_DAYS;
+    const dropMs = (failAt + 3) * 86400000; // shelf-life + 3 days grace
+    doughQueue[sku] = doughQueue[sku].filter((e) => {
+      if (e.pretzels <= 0) return false;
+      const ageMs = pruneNow - new Date(e.ts).getTime();
+      return ageMs < dropMs;
+    });
+  });
+
   // Aging dough alerts. Per-SKU thresholds: dips configured in DIP_CONFIG
   // use their `shelfLifeDays` (warn one day before, fail at). Pretzels and
   // anything else fall back to the global DOUGH_AGE_WARN_DAYS / FAIL_DAYS.
@@ -1142,7 +1158,11 @@ export function scheduleDip({
   const startInventory = cfStart + frStart + ohStart;
 
   const batches = [];
-  const hasBatchOn = (dayIdx) => batches.some((b) => b.dayIndex === dayIdx);
+  // Set of dayIdx for O(1) lookup. Updated alongside batches.push() — keep
+  // in sync. Previous .some() across batches grew linearly per call;
+  // at 100+ dips × 30 days × inner loop, the scan got expensive.
+  const batchedDays = new Set();
+  const hasBatchOn = (dayIdx) => batchedDays.has(dayIdx);
   // Pick batch size at placement time. If the immediate deficit (-inv at the
   // time we decide to place) exceeds a single, upgrade to double.
   const pickSize = (deficit) => {
@@ -1172,6 +1192,7 @@ export function scheduleDip({
           size,
           units,
         });
+        batchedDays.add(j);
         inv += units;
         placed = true;
         break;
@@ -1189,6 +1210,7 @@ export function scheduleDip({
               size,
               units,
             });
+            batchedDays.add(j);
             inv += units;
             placed = true;
             break;

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1084,26 +1084,48 @@ async function fetchSquareDipConsumption(env, daysSampled = 28) {
     };
   });
 
+  // Pre-build flat matcher lists keyed by SKU so the inner loop is one
+  // pass through DIP_CONFIG entries (5 today) rather than nested
+  // some()-over-regex inside the per-line-item loop. At realistic
+  // future scale (~50K Square orders × 5 line items × 10 dips), the
+  // original O(orders × items × dips × regex) gets noticeable; this
+  // collapses the inner dimension to a single check per dip-regex pair.
+  const dipMatchers = Object.entries(DIP_CONFIG).map(([sku, cfg]) => ({
+    sku,
+    nameRes: cfg.squareNames,
+    modRes: cfg.squareModifiers,
+  }));
+
   orders.forEach((o) => {
     (o.line_items || []).forEach((li) => {
       const name = (li.name || '').trim();
       const qty = parseInt(li.quantity, 10) || 0;
-      // Direct line-item match per dip
-      Object.entries(DIP_CONFIG).forEach(([sku, cfg]) => {
-        if (cfg.squareNames.some((re) => re.test(name)) && qty > 0) {
+      if (qty <= 0) return;
+      // Direct line-item match per dip — early-exit each test once a name
+      // matches, since a single line item is one product (no double-count).
+      for (const { sku, nameRes } of dipMatchers) {
+        let matched = false;
+        for (const re of nameRes) {
+          if (re.test(name)) { matched = true; break; }
+        }
+        if (matched) {
           dips[sku].namesSeen.add(name);
           dips[sku].units += qty;
         }
-      });
+      }
       // Modifier match — each modifier instance = parent qty units of that dip
       (li.modifiers || []).forEach((mod) => {
         const mname = (mod.name || '').trim();
-        Object.entries(DIP_CONFIG).forEach(([sku, cfg]) => {
-          if (cfg.squareModifiers.some((re) => re.test(mname))) {
+        for (const { sku, modRes } of dipMatchers) {
+          let matched = false;
+          for (const re of modRes) {
+            if (re.test(mname)) { matched = true; break; }
+          }
+          if (matched) {
             dips[sku].modifiersSeen.add(mname);
             dips[sku].units += qty;
           }
-        });
+        }
       });
     });
   });


### PR DESCRIPTION
## Audit pass 3 — system-level

Three new audit angles spawned: end-to-end catering journey, cross-surface display consistency, scaling/perf modeling. Found a mix of real bugs, drift concerns, and scale projections. Shipped the 3 low-risk perf wins; deferred the bigger fixes with notes.

## What landed

### 1. Set for `hasBatchOn` lookup

`scheduleDip`'s inner loop called `batches.some(b => b.dayIndex === j)` per candidate day. O(batches.length) per check; scaled poorly with more dips and longer lookahead. Now: parallel `Set` for O(1) lookup.

### 2. Dough queue pruning

`doughQueue` grew unbounded as months of production history accumulated. Most entries become stale (pretzels=0 from BFP consumption, or aged past shelf-life). Now: end-of-`getInventoryReport` filter drops per-SKU entries older than `shelfLifeDays + 3-day grace`. Keeps memory bounded over time without losing recent age alerts.

### 3. Worker DIP_CONFIG matcher pre-build

`fetchSquareDipConsumption`'s hot loop iterated `Object.entries(DIP_CONFIG)` inside per-line-item AND per-modifier loops, using nested `.some()` regex tests. Now: flat `dipMatchers` array built once, for-of loops with early-exit. Same matching, fewer allocations, faster per-order cost.

## What I deliberately deferred

| Finding | Severity | Why deferred |
|---|---|---|
| Manager edits get overwritten by subsequent Square webhooks (`payment.updated` etc) | CRITICAL | Needs a real "manager-edited fields" marker; high blast radius. Wants its own focused PR with UI work. |
| doughQueue `nextIndex` pointer (replace `shift()`) | MED at 10x scale | Actual cost is ~1-2ms per report today. Not worth invasive data-structure change. Revisit at 100x. |
| Customer PII in sheet-logger URL params | HIGH | Fix requires coordinating with the sheet-logger worker (different repo). |
| Production app fohDailyAvg drift vs worker iCal | MED | Cosmetic staleness during the gap between 60s refresh and iCal request. Aligning cache strategies is its own design call. |
| Webhook dedupe race (100ms window where two requests both pass the KV read) | MED | Square retries typically seconds apart. Rare in practice. Conditional `if_not_exists` KV API would fix; defer until KV supports it natively. |

## Verified

- `npm run lint` clean
- Worker redeployed (version `43dfed6b`)
- `/dip-consumption` still returns correct dailyAvg (cheese 35.9/day, hot ranch 6.1/day, etc.) — refactored matchers produce identical output
- `/foh-cal.ics` still emits 15 baseline tombstones at steady state

## Recap: today's audit work (3 passes)

| Pass | What | PR/commit |
|---|---|---|
| 1 | inventory math + UI flows + worker calendar | #21 (6 fixes) |
| 2 | delivery planner + webhook sync | direct merge `4df3ded` (4 fixes) |
| 3 | end-to-end journey + display consistency + scaling | this PR (3 perf wins + deferred list) |

13 bugs fixed across 3 passes. The deferred items are mostly UI/design work or coordinate-with-other-system work.

Generated with [Claude Code](https://claude.com/claude-code)
