### PR TITLE
Add catering dip box SKUs to inventory forecast

### DIFF
--- a/static/inventory-forecast/index.html
+++ b/static/inventory-forecast/index.html
@@ -296,7 +296,7 @@
       '6.5oz spicy bee', '4oz twist plain', '4oz twist bbk',
       '4oz twist spicy bee', '3oz cheese dip',
       'bulk dangerous dip (25 srv)', 'plain bombs', 'bees bats',
-      'Dangerous Dip Box', 'Honey Mustard Dip Box', 'Hot Ranch Dip Box',
+      'Dangerous Dip Box', 'Honey Mustard Dip Box', 'Hot Ranch Dip Box', 'Sweet Cream Dip Box',
     ];
 
     // ── Product catalog ──────────────────────────────────────────────────────

--- a/static/inventory-forecast/index.html
+++ b/static/inventory-forecast/index.html
@@ -296,6 +296,7 @@
       '6.5oz spicy bee', '4oz twist plain', '4oz twist bbk',
       '4oz twist spicy bee', '3oz cheese dip',
       'bulk dangerous dip (25 srv)', 'plain bombs', 'bees bats',
+      'Dangerous Dip Box', 'Honey Mustard Dip Box', 'Hot Ranch Dip Box',
     ];
 
     // ── Product catalog ──────────────────────────────────────────────────────

--- a/static/inventory-forecast/index.html
+++ b/static/inventory-forecast/index.html
@@ -15,11 +15,11 @@
     a { color: inherit; text-decoration: none; }
 
     /* ── Nav ── */
-    .site-nav { background: #1A1A1A; padding: 14px 5%; position: sticky; top: 0; z-index: 400; border-bottom: 1px solid #333; }
-    .nav-wrap { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; }
-    .nav-logo { height: 46px; }
-    .nav-links { display: flex; align-items: center; gap: 20px; flex-wrap: wrap; }
-    .nav-links a { color: #fff; font: 400 15px/1 'Manrope', sans-serif; transition: color 0.2s; }
+    .site-nav { background: #1A1A1A; padding: 14px 5%; position: sticky; top: 0; z-index: 400; border-bottom: 1px solid #333; overflow-x: auto; }
+    .nav-wrap { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; min-width: max-content; }
+    .nav-logo { height: 46px; flex-shrink: 0; }
+    .nav-links { display: flex; align-items: center; gap: 20px; flex-wrap: nowrap; margin-left: 20px; }
+    .nav-links a { color: #fff; font: 400 15px/1 'Manrope', sans-serif; transition: color 0.2s; white-space: nowrap; }
     .nav-links a:hover { color: #C41E1E; }
 
     /* ── Hero ── */
@@ -178,13 +178,22 @@
 
     /* ── Mobile ── */
     @media (max-width: 640px) {
+      /* Forecast table: hide Expected Use (4), PAR (6), Unit (2) — keep Ingredient, In Stock, Projected, Status */
+      .forecast-table th:nth-child(2),
+      .forecast-table td:nth-child(2),
       .forecast-table th:nth-child(4),
       .forecast-table td:nth-child(4),
       .forecast-table th:nth-child(6),
       .forecast-table td:nth-child(6) { display: none; }
+      /* Recipe editor: single-column grid, hide auto-calc columns */
       .sku-grid { grid-template-columns: 1fr; }
       .scale-row { grid-template-columns: 1fr 1fr; }
       .scale-row .auto-col { display: none; }
+      /* Hide per-tray and per-pretzel auto columns in ingredient table */
+      .recipe-ing-table th:nth-child(3),
+      .recipe-ing-table td:nth-child(3),
+      .recipe-ing-table th:nth-child(4),
+      .recipe-ing-table td:nth-child(4) { display: none; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- Adds `Dangerous Dip Box`, `Honey Mustard Dip Box`, `Hot Ranch Dip Box`, and `Sweet Cream Dip Box` to the `SKUS` array in the inventory forecast page
- These match the `data-name` values on catering order cards — the exact names the Square sync worker stores as delivery line item SKUs
- Enables recipe definitions (ingredients per batch) for all four dip flavors in the forecast recipe editor
- Fixes mobile layout: nav scrolls horizontally, fewer table columns on small screens

## Test URL
https://feature-dip-sku-recipes--website--dangpretz.aem.page/static/inventory-forecast/

## Test plan
- [ ] Open test URL → click "Edit Recipes" → confirm four new dip SKU cards appear (Dangerous Dip Box, Honey Mustard Dip Box, Hot Ranch Dip Box, Sweet Cream Dip Box)
- [ ] On mobile: nav scrolls horizontally, forecast table fits without horizontal overflow
- [ ] Enter scale + ingredient quantities for a dip → Save → forecast table updates
- [ ] Reload page → dip recipe values persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)