### PR TITLE
FOH dough-pull audit: 4 gap fixes (cf→fr fallback, bombs tray size, input wipe, toast)

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -205,7 +205,10 @@ export const TRAY_SIZES = {
   '4oz twist bbk': 12,
   '4oz twist spicy bee': 12,
   'bees bats': 6,
-  'plain bombs': 0,
+  // 54 bombs per sheet pan (confirmed by FOH May 2026). Sold as 6/order
+  // regular or 18/order party, but both pull from the same 54-per-sheet
+  // dough inventory.
+  'plain bombs': 54,
 };
 
 // SKUs that aren't produced in-house (front-of-house pre-made / sourced).
@@ -674,6 +677,10 @@ export function getInventoryReport(args) {
   // cold-ferment inventory said existed. Surfaces snapshot inaccuracies
   // before they silently warp the shape team's schedule.
   const bfpOverbakeEvents = [];
+  // Audit trail of FOH speed-rack pulls that exceeded cold-ferment + frozen
+  // combined. Like overbake: clamps at 0 but records the deficit so the
+  // manager can reconcile (typo on input vs. truly missing inventory).
+  const fohOverPullEvents = [];
 
   // Walk events in TIMESTAMP order (defensive against out-of-order log writes)
   const sortedLogs = [...(productionLogs || [])].sort(
@@ -799,11 +806,13 @@ export function getInventoryReport(args) {
     } else if (row.action === 'foh_transfer') {
       // FOH stocked the in-store speed rack from the wholesale walk-in.
       // Sheets are measured in BFP-tray units (one sheet = one tray of
-      // pretzels). Deduct from cold-ferment FIFO (oldest first — same
-      // physics as bfp_done) but DO NOT credit frozen: the dough is leaving
-      // the wholesale accounting universe entirely. The raw log row
-      // preserves the requested sheet count even if it exceeded available
-      // cf (cap at 0 here), so the audit trail still shows what FOH took.
+      // pretzels). The dough leaves the wholesale accounting universe
+      // entirely (no frozen credit). Deduction order: cold-ferment FIFO
+      // first (matches FOH's mental model — they grab thawed dough off
+      // the rack), then frozen for any remainder. If the pull exceeds
+      // cf+fr combined, record the deficit in fohOverPullEvents so the
+      // manager can reconcile (typo vs. real inventory drift). The raw
+      // log row always preserves the requested sheet count.
       let xfers = []; try { xfers = JSON.parse(row.transfers || '[]'); } catch {}
       xfers.forEach((x) => {
         let key = (x.sku || '').trim();
@@ -813,11 +822,30 @@ export function getInventoryReport(args) {
         if (!ts2) return;
         const sheets = Number(x.sheets) || 0;
         if (!sheets) return;
-        const p = sheets * ts2;
-        cf[key] = Math.max(0, (cf[key] || 0) - p);
+        const needed = sheets * ts2;
+        const cfAvail = Math.max(0, cf[key] || 0);
+        const frAvail = Math.max(0, fr[key] || 0);
+        const fromCf = Math.min(cfAvail, needed);
+        const fromFr = Math.min(frAvail, needed - fromCf);
+        const deficit = needed - fromCf - fromFr;
+        cf[key] = cfAvail - fromCf;
+        fr[key] = frAvail - fromFr;
         flowFoh[key] = (flowFoh[key] || 0) + sheets;
+        if (deficit > 0) {
+          fohOverPullEvents.push({
+            sku: key,
+            sheets,
+            requestedPretzels: needed,
+            availableCf: cfAvail,
+            availableFr: frAvail,
+            deficitPretzels: deficit,
+            ts: ts || '',
+          });
+        }
+        // FIFO-consume the dough-age queue for the cf portion only. Frozen
+        // pretzels don't carry an age queue (shelf life resets at freeze).
         if (!doughQueue[key]) doughQueue[key] = [];
-        let toConsume = p;
+        let toConsume = fromCf;
         while (toConsume > 0 && doughQueue[key].length > 0) {
           const oldest = doughQueue[key][0];
           const take = Math.min(oldest.pretzels, toConsume);
@@ -965,7 +993,7 @@ export function getInventoryReport(args) {
     flowsSinceSnapshot: {
       shape: flowShape, bfp: flowBfp, foh: flowFoh, delivered: flowDelivered,
     },
-    alerts: { agingDough, bfpOverbake: bfpOverbakeEvents },
+    alerts: { agingDough, bfpOverbake: bfpOverbakeEvents, fohOverPull: fohOverPullEvents },
     snapshot: { date: latestInvDate, timestamp: latestInventoryTs, raw: snapshotRaw },
   };
 }

--- a/static/delivery-planner/index.html
+++ b/static/delivery-planner/index.html
@@ -955,7 +955,7 @@
       isShapeOnlyDelivery,
       expandBoxLineItems,
       caseSizeOptionsFor,
-    } from '../../scripts/inventory.js?v=2026-05-12-foh-dough-transfer';
+    } from '../../scripts/inventory.js?v=2026-05-12-foh-dough-audit-1';
 
     // Shape-only catering + box expansion. ENABLED BY DEFAULT — kept in
     // sync with production app via the same localStorage key.

--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1061,7 +1061,7 @@
     getInventoryReport, attributeDeliveryCoverage,
     scheduleCheese, scheduleDip,
     isShapeOnlyDelivery,
-  } from '../../scripts/inventory.js?v=2026-05-12-foh-dough-transfer';
+  } from '../../scripts/inventory.js?v=2026-05-12-foh-dough-audit-1';
 
   // Shape-only catering + box expansion. ENABLED BY DEFAULT — catering
   // boxes (Catering: ...) and FOH Placeholder deliveries skip BFP and
@@ -3322,25 +3322,36 @@
   // bundles every non-zero input. Inputs reset on successful save.
   function renderFohDoughSection(report) {
     const cf = report?.effective?.coldFerment || {};
+    const fr = report?.effective?.frozen || {};
     const rows = FOH_DOUGH_SKUS.map((sku) => {
       const ts = getTraySize(sku) || 0;
-      const pretzels = Math.max(0, cf[sku] || 0);
+      // "Sheets ready" aggregates cf + fr — FOH pulls from whichever the
+      // walk-in has. Cf-only would understate available stock once cf
+      // drains below an order's needs but fr still has trays.
+      const pretzels = Math.max(0, cf[sku] || 0) + Math.max(0, fr[sku] || 0);
       const sheetsReady = ts > 0 ? Math.floor(pretzels / ts) : 0;
       const label = sku; // intentionally raw — FOH knows their SKU names
       const readyTxt = ts > 0
         ? `${sheetsReady} ${appLang === 'es' ? (sheetsReady === 1 ? 'hoja lista' : 'hojas listas') : (sheetsReady === 1 ? 'sheet ready' : 'sheets ready')}`
-        : (appLang === 'es' ? 'sin tamaño de bandeja' : 'no tray size');
+        : (appLang === 'es' ? '⚠️ sin tamaño de bandeja — avisa al gerente' : '⚠️ tray size unset — tell manager');
+      // Defense-in-depth: if a new SKU lands in FOH_DOUGH_SKUS without a
+      // TRAY_SIZES entry, disable its input rather than silently swallowing
+      // FOH's pull (foh_transfer handler bails on `if (!ts2) return;`).
+      const disabled = ts > 0 ? '' : 'disabled';
+      const inputStyle = ts > 0
+        ? 'width:64px;padding:8px;border:2px solid var(--gray-1);border-radius:8px;font:700 16px \'Manrope\',sans-serif;text-align:center;color:var(--dark)'
+        : 'width:64px;padding:8px;border:2px dashed var(--gray-2);border-radius:8px;font:700 16px \'Manrope\',sans-serif;text-align:center;color:var(--gray-3);background:var(--gray-1);cursor:not-allowed';
       return `
         <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 12px;border-bottom:1px solid var(--gray-1)">
           <div style="flex:1;min-width:0">
             <div style="font:700 15px 'Manrope',sans-serif;color:var(--dark);text-transform:capitalize">${label}</div>
-            <div style="font:400 12px 'Manrope',sans-serif;color:var(--gray-3)">${readyTxt}</div>
+            <div style="font:400 12px 'Manrope',sans-serif;color:${ts > 0 ? 'var(--gray-3)' : '#A32D2D'}">${readyTxt}</div>
           </div>
           <label style="display:flex;align-items:center;gap:8px;font:600 12px 'Manrope',sans-serif;color:var(--gray-3)">
             <span>${appLang === 'es' ? 'Sacadas' : 'Pulled'}</span>
             <input type="number" inputmode="numeric" min="0" step="1" value="0"
-                   data-foh-transfer-sheets data-sku="${sku}"
-                   style="width:64px;padding:8px;border:2px solid var(--gray-1);border-radius:8px;font:700 16px 'Manrope',sans-serif;text-align:center;color:var(--dark)">
+                   data-foh-transfer-sheets data-sku="${sku}" ${disabled}
+                   style="${inputStyle}">
           </label>
         </div>`;
     }).join('');
@@ -3387,6 +3398,13 @@
       await loadProduction();
       schedule = buildOptimalSchedule();
       render();
+      // Success feedback — inputs reset on render(), so without this toast
+      // FOH has no signal that the save actually went through (was: only
+      // an alert() on failure, silence on success).
+      try {
+        const totalSheets = transfers.reduce((acc, t) => acc + (Number(t.sheets) || 0), 0);
+        showFohTransferToast(totalSheets);
+      } catch (toastErr) { console.warn('foh toast skipped:', toastErr); }
     } catch (err) {
       // appendLog now throws on non-2xx — surface to the user instead of
       // silently failing (the whole point of the recent sheet-logger
@@ -3568,6 +3586,29 @@
     toast.addEventListener('click', remove);
     const ttl = (perDay.length === 0 && newOverdue.length === 0) ? 2500 : 6000;
     setTimeout(remove, ttl);
+  }
+
+  // FOH dough-pull confirmation. Reuses the schedule-diff-toast CSS so no
+  // new styling surface needed. ~3s TTL — long enough to read, short
+  // enough to not pile up if FOH saves twice.
+  function showFohTransferToast(sheetsTotal) {
+    document.querySelectorAll('.schedule-diff-toast').forEach(n => n.remove());
+    const toast = document.createElement('div');
+    toast.className = 'schedule-diff-toast unchanged';
+    const sheetWord = appLang === 'es'
+      ? (sheetsTotal === 1 ? 'hoja transferida' : 'hojas transferidas')
+      : (sheetsTotal === 1 ? 'sheet transferred' : 'sheets transferred');
+    const title = appLang === 'es'
+      ? `✓ Guardado · ${sheetsTotal} ${sheetWord}`
+      : `✓ Saved · ${sheetsTotal} ${sheetWord}`;
+    const dismiss = appLang === 'es' ? 'Toca para cerrar' : 'Tap to dismiss';
+    toast.innerHTML = `
+      <div class="schedule-diff-toast-title">${title}</div>
+      <div class="schedule-diff-toast-dismiss">${dismiss}</div>`;
+    document.body.appendChild(toast);
+    const remove = () => toast.remove();
+    toast.addEventListener('click', remove);
+    setTimeout(remove, 3000);
   }
 
   // ─── INLINE LOGGER (TAP +/- ON SKU ROW) ───────────────────────────────────
@@ -4644,9 +4685,12 @@
   // Auto-refresh — visibility regain + soft 60s interval. Both gated by
   // active input focus + pending save (so we don't clobber typing).
   // .inline-onhand-edit is the dynamic input from the Dips-tab ON HAND
-  // editor; without it softRefresh would erase the input mid-type.
+  // editor; without it softRefresh would erase the input mid-type. Same
+  // story for [data-foh-transfer-sheets] on the FOH home page — without
+  // it, FOH could be partway through typing "5" when the 60s interval
+  // fires and rebuilds the dough section back to 0.
   const _isInputBusy = () =>
-    document.activeElement?.matches?.('[data-log-input], [data-stock-section], [data-log-step], #extra-val, .inline-onhand-edit')
+    document.activeElement?.matches?.('[data-log-input], [data-stock-section], [data-log-step], #extra-val, .inline-onhand-edit, [data-foh-transfer-sheets]')
     || Object.keys(saveTimers || {}).some(k => saveTimers[k] != null);
 
   // Track when the current worker session started so we don't toast diffs


### PR DESCRIPTION
## Summary

Audit pass on the FOH dough-pull tracker (which was already built end-to-end). Found four real gaps and closed them. No new feature — defect & UX cleanup.

### What landed

| Gap | Fix |
|---|---|
| Mid-type input wipe (softRefresh every 60s/visibilitychange clobbered the dough section if FOH was typing) | Added `[data-foh-transfer-sheets]` to `_isInputBusy` selector |
| Plain bombs entries silently dropped (TRAY_SIZES['plain bombs'] = 0, handler bailed on `if (!ts2) return;`) | Set to **54 bombs/sheet** (confirmed). Defense-in-depth: any future SKU with tray size 0 now renders disabled + red "tray size unset — tell manager" hint instead of accepting unrecoverable input |
| Cf-only deduction; pulls beyond cf silently disappeared | Cf → fr fallback. Pulls exceeding cf+fr land in `report.alerts.fohOverPull` for manager reconciliation |
| No success feedback (only error alert) | New `showFohTransferToast` — reuses the schedule-diff-toast CSS, ~3s auto-dismiss |

Also: "N sheets ready" hint now reads cf+fr (matches the new fallback math).

### Deferred (called out in audit, not in this PR)

- Manager-visible UI banner for `fohOverPull` events (data is captured, surfacing comes next)
- Undo button on dough section (mirror dip "Recent batches ↩ undo" pattern)
- Worker attribution on `foh_transfer` rows
- Backdated transfers (cross-midnight correction)
- "Stock the rack" FOH iCal reminder

## Test plan

- [x] `npm run lint` clean
- [ ] After deploy with `?role=foh`: type a sheet count, wait 60s — input keeps the typed value
- [ ] Plain bombs: enter 1 sheet → save → manager Stock tab shows -54 pretzels of plain bombs
- [ ] Cf=0, fr>0, enter 1 sheet of a SKU → save → frozen deducts, no deficit logged
- [ ] Cf=0, fr=0, enter 1 sheet → save → `report.alerts.fohOverPull` has one entry (inspect via console)
- [ ] After successful save: green "✓ Saved · N sheets transferred" toast appears for ~3s

Generated with [Claude Code](https://claude.com/claude-code)
