### PR TITLE
Highlight In Stock below PAR with buy quantity

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -1005,7 +1005,9 @@ export function getInventoryReport(args) {
         shortage: remaining,
         confirmedAt: delivery._confirmedAt || '',
       });
-      itemTrail.push({ sku: key, qty, fromOh, fromCf, fromFr, shortage: remaining });
+      itemTrail.push({
+        sku: key, qty, fromOh, fromCf, fromFr, shortage: remaining,
+      });
     });
     deductionExplanations.push({
       deliveryId: delivery.deliveryId || '',

--- a/static/inventory-forecast/index.html
+++ b/static/inventory-forecast/index.html
@@ -76,6 +76,7 @@
     .val-low      { color: #b07000; font-weight: 700; }
     .val-ok       { color: #2a7a2a; font-weight: 700; }
     .val-neutral  { color: #1A1A1A; }
+    .stock-need   { display: block; font: 600 11px 'Manrope', sans-serif; color: #C41E1E; margin-top: 2px; white-space: nowrap; }
 
     .status-badge { display: inline-block; font: 700 10px 'Manrope', sans-serif; padding: 3px 10px; border-radius: 20px; text-transform: uppercase; letter-spacing: .4px; white-space: nowrap; }
     .status-badge.short  { background: #fde8e8; color: #C41E1E; }
@@ -563,7 +564,12 @@
           statusClass = 'ok'; statusLabel = 'OK'; rowClass = ''; projClass = 'val-ok';
         }
 
-        const stockClass = hasRecipe ? (stock <= 0 ? 'val-short' : 'val-neutral') : 'val-neutral';
+        const belowPar    = par !== null && stock < par;
+        const stockClass  = belowPar ? 'val-short' : (stock <= 0 ? 'val-short' : 'val-neutral');
+        const needQty     = belowPar ? (par - stock) : 0;
+        const stockCell   = belowPar
+          ? `${stock}<span class="stock-need">buy ${needQty} more</span>`
+          : `${stock}`;
         const expDisplay  = hasRecipe ? fmt2(expectedUsage) : '—';
         const projDisplay = hasRecipe ? fmt2(projectedRemaining) : '—';
         const parDisplay  = par !== null ? String(par) : '—';
@@ -571,7 +577,7 @@
         return `<tr class="${rowClass}" data-product-id="${escapeHtml(productId)}">
           <td>${escapeHtml(productName)}</td>
           <td>${escapeHtml(innerUnitLabel)}</td>
-          <td class="${stockClass}">${stock}</td>
+          <td class="${stockClass}">${stockCell}</td>
           <td>${expDisplay}</td>
           <td class="${projClass}">${projDisplay}</td>
           <td class="par-cell">${parDisplay} <button class="btn-par-edit" data-product-id="${escapeHtml(productId)}" title="Edit PAR">✏</button></td>


### PR DESCRIPTION
## Summary
- When the **In Stock** value is below the PAR value, the stock cell turns red
- A "buy N more" line appears beneath the quantity showing exactly how many units need to be purchased to reach PAR
- Works live — if you edit a PAR value inline, the stock cell updates immediately

## Preview
https://feature-forecast-stock-below-par--website--dangpretz.aem.page/static/inventory-forecast/

## Test plan
- [ ] Set a PAR value higher than the current stock for any ingredient
- [ ] Stock cell turns red and shows `buy N more` beneath the number
- [ ] Edit PAR inline to a value at or below stock — red highlight and "buy" hint disappear
- [ ] Ingredients with no PAR set are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)