### PR TITLE
Simplify stock edit to direct quantity entry; add new ingredient form

### DIFF
--- a/static/inventory-forecast/index.html
+++ b/static/inventory-forecast/index.html
@@ -102,6 +102,19 @@
     .btn-par-cancel { background: none; border: none; color: #bbb; font-size: 17px; cursor: pointer; padding: 0 2px; line-height: 1; }
     .btn-par-cancel:hover { color: #555; }
 
+    /* Stock adj inline widget */
+    .btn-stock-adj { background: none; border: none; cursor: pointer; color: #ccc; font-size: 12px; padding: 2px 4px; line-height: 1; transition: color .15s; vertical-align: middle; }
+    .btn-stock-adj:hover { color: #C41E1E; }
+    .stock-adj-wrap { display: flex; align-items: center; gap: 5px; }
+    .stock-adj-input { width: 66px; font: 400 13px 'Manrope', sans-serif; padding: 4px 7px; border: 2px solid #C41E1E; border-radius: 5px; outline: none; color: #1A1A1A; background: #fff; -moz-appearance: textfield; }
+    .stock-adj-input::-webkit-outer-spin-button,
+    .stock-adj-input::-webkit-inner-spin-button { -webkit-appearance: none; }
+    .btn-stock-save { background: #C41E1E; color: #fff; font: 700 11px 'Manrope', sans-serif; border: none; border-radius: 5px; padding: 4px 9px; cursor: pointer; white-space: nowrap; }
+    .btn-stock-save:hover { background: #a01818; }
+    .btn-stock-save:disabled { background: #ccc; cursor: not-allowed; }
+    .btn-adj-cancel { background: none; border: none; color: #bbb; font-size: 17px; cursor: pointer; padding: 0 2px; line-height: 1; }
+    .btn-adj-cancel:hover { color: #555; }
+
     /* ════════════════════════════════════
        SLIDE-OUT PANEL
     ════════════════════════════════════ */
@@ -567,9 +580,10 @@
         const belowPar    = par !== null && stock < par;
         const stockClass  = belowPar ? 'val-short' : (stock <= 0 ? 'val-short' : 'val-neutral');
         const needQty     = belowPar ? (par - stock) : 0;
-        const stockCell   = belowPar
+        const stockInner  = belowPar
           ? `${stock}<span class="stock-need">buy ${needQty} more</span>`
           : `${stock}`;
+        const stockCell   = `<div class="stock-cell" style="display:flex;align-items:center;gap:5px;" data-product-id="${escapeHtml(productId)}"><span class="${stockClass}">${stockInner}</span><button class="btn-stock-adj" data-product-id="${escapeHtml(productId)}" title="Adjust stock">±</button></div>`;
         const expDisplay  = hasRecipe ? fmt2(expectedUsage) : '—';
         const projDisplay = hasRecipe ? fmt2(projectedRemaining) : '—';
         const parDisplay  = par !== null ? String(par) : '—';
@@ -577,7 +591,7 @@
         return `<tr class="${rowClass}" data-product-id="${escapeHtml(productId)}">
           <td>${escapeHtml(productName)}</td>
           <td>${escapeHtml(innerUnitLabel)}</td>
-          <td class="${stockClass}">${stockCell}</td>
+          <td>${stockCell}</td>
           <td>${expDisplay}</td>
           <td class="${projClass}">${projDisplay}</td>
           <td class="par-cell">${parDisplay} <button class="btn-par-edit" data-product-id="${escapeHtml(productId)}" title="Edit PAR">✏</button></td>
@@ -595,6 +609,9 @@
 
       // Wire PAR edit buttons
       tbody.querySelectorAll('.btn-par-edit').forEach(wireParEdit);
+
+      // Wire stock adj buttons
+      tbody.querySelectorAll('.btn-stock-adj').forEach(wireStockAdj);
 
       statusEl.hidden = true;
       wrapEl.hidden = false;
@@ -761,6 +778,70 @@
             cell.innerHTML = originalHtml;
             wireParEdit(cell.querySelector('.btn-par-edit'));
             showToast('Failed to save PAR: ' + (err.message || 'error'), 'error');
+          }
+        }
+
+        saveBtn.addEventListener('click', (e) => { e.stopPropagation(); doSave(); });
+        input.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter')  { e.preventDefault(); doSave(); }
+          if (e.key === 'Escape') cancelBtn.click();
+        });
+      });
+    }
+
+    // ── Stock inline adjust ──────────────────────────────────────────────────
+    function wireStockAdj(btn) {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const productId    = btn.dataset.productId;
+        const cell         = btn.closest('.stock-cell');
+        const currentStock = inventoryMap.get(productId)?.stock ?? 0;
+        const originalHtml = cell.innerHTML;
+
+        cell.innerHTML = `<div class="stock-adj-wrap">
+  <input type="number" class="stock-adj-input" min="0" step="1" value="${currentStock}">
+  <button class="btn-stock-save">Save</button>
+  <button class="btn-adj-cancel">&times;</button>
+</div>`;
+
+        const input     = cell.querySelector('.stock-adj-input');
+        const saveBtn   = cell.querySelector('.btn-stock-save');
+        const cancelBtn = cell.querySelector('.btn-adj-cancel');
+
+        input.focus(); input.select();
+
+        cancelBtn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          cell.innerHTML = originalHtml;
+          wireStockAdj(cell.querySelector('.btn-stock-adj'));
+        });
+
+        async function doSave() {
+          const newVal = parseInt(input.value, 10);
+          if (isNaN(newVal) || newVal < 0) {
+            showToast('Enter a valid quantity', 'error');
+            input.focus();
+            return;
+          }
+          const delta = newVal - currentStock;
+          saveBtn.disabled = true;
+          saveBtn.textContent = 'Saving…';
+          try {
+            await appendLog(INVENTORY_PATH, {
+              action:    'adjust',
+              productId,
+              quantity:  String(delta),
+              timeStamp: new Date().toISOString(),
+              note:      'inline stock set',
+            });
+            if (inventoryMap.has(productId)) inventoryMap.get(productId).stock = newVal;
+            forecastMap = computeForecast(resolveDeliveries(allDeliveryLogs), recipeMap, scaleMap, inventoryMap);
+            renderForecastTable();
+            showToast(`Stock set to ${newVal}`, 'success');
+          } catch (err) {
+            cell.innerHTML = originalHtml;
+            wireStockAdj(cell.querySelector('.btn-stock-adj'));
+            showToast('Failed to save: ' + (err.message || 'unknown error'), 'error');
           }
         }
 

--- a/static/inventory/index.html
+++ b/static/inventory/index.html
@@ -153,6 +153,19 @@
     .btn-par-cancel { background: none; border: none; color: #bbb; font-size: 18px; cursor: pointer; padding: 0 2px; line-height: 1; }
     .btn-par-cancel:hover { color: #555; }
 
+    /* Stock adj inline widget */
+    .btn-stock-adj { background: none; border: none; cursor: pointer; color: #ccc; font-size: 13px; padding: 2px 4px; line-height: 1; transition: color 0.15s; flex-shrink: 0; }
+    .btn-stock-adj:hover { color: #C41E1E; }
+    .stock-adj-wrap { display: flex; align-items: center; gap: 6px; }
+    .stock-adj-input { width: 72px; font: 400 14px 'Manrope', sans-serif; padding: 5px 8px; border: 2px solid #C41E1E; border-radius: 5px; outline: none; color: #1A1A1A; background: #fff; -moz-appearance: textfield; }
+    .stock-adj-input::-webkit-outer-spin-button,
+    .stock-adj-input::-webkit-inner-spin-button { -webkit-appearance: none; }
+    .btn-stock-save { background: #C41E1E; color: #fff; font: 700 11px 'Manrope', sans-serif; border: none; border-radius: 5px; padding: 5px 10px; cursor: pointer; white-space: nowrap; }
+    .btn-stock-save:hover { background: #a01818; }
+    .btn-stock-save:disabled { background: #ccc; cursor: not-allowed; }
+    .btn-adj-cancel { background: none; border: none; color: #bbb; font-size: 18px; cursor: pointer; padding: 0 2px; line-height: 1; }
+    .btn-adj-cancel:hover { color: #555; }
+
     .table-status { text-align: center; padding: 40px 20px; font: 400 14px 'Manrope', sans-serif; color: #888; }
     .table-status.error { color: #C41E1E; font-weight: 700; }
 
@@ -379,6 +392,33 @@
         </div>
       </div>
 
+      <!-- ── Add New Ingredient (collapsible) ── -->
+      <div class="collapsible-wrap" id="new-ingredient-collapsible">
+        <div class="collapsible-header" id="new-ingredient-toggle">
+          <h3>Add New Ingredient</h3>
+          <span class="collapsible-icon">⌄</span>
+        </div>
+        <div class="collapsible-body">
+          <div class="card card-dark">
+            <div class="adjust-grid" style="margin-bottom:14px;">
+              <div class="field-group span-2" style="margin-bottom:0;">
+                <label for="new-ing-name">Ingredient Name</label>
+                <input type="text" id="new-ing-name" placeholder="e.g. Butter, Salted Solid AA" autocomplete="off">
+              </div>
+              <div class="field-group" style="margin-bottom:0;">
+                <label for="new-ing-code">US Foods Code <span style="font-weight:400;color:#888">(optional)</span></label>
+                <input type="text" id="new-ing-code" placeholder="e.g. 1008416" autocomplete="off">
+              </div>
+              <div class="field-group" style="margin-bottom:0;">
+                <label for="new-ing-pack">Pack Size <span style="font-weight:400;color:#888">(optional)</span></label>
+                <input type="text" id="new-ing-pack" placeholder="e.g. 1/50/LB or 4/1/GAL" autocomplete="off">
+              </div>
+            </div>
+            <button class="btn-submit" id="new-ing-submit-btn" disabled>Add Ingredient</button>
+          </div>
+        </div>
+      </div>
+
     </div>
   </div>
 
@@ -584,6 +624,7 @@
       } else {
         tbody.innerHTML = rows.map(buildTableRow).join('');
         tbody.querySelectorAll('.btn-par-edit').forEach(wireParEdit);
+        tbody.querySelectorAll('.btn-stock-adj').forEach(wireStockAdj);
       }
 
       statusEl.hidden = true;
@@ -609,10 +650,15 @@
         <button class="btn-par-edit" title="Edit PAR" data-product-id="${escapeHtml(productId)}">✏</button>
       </div>`;
 
+      const stockCell = `<div style="display:flex;align-items:center;gap:6px;" class="stock-cell" data-product-id="${escapeHtml(productId)}">
+        <span class="${stockClass}">${stock}</span>
+        <button class="btn-stock-adj" title="Adjust stock" data-product-id="${escapeHtml(productId)}">±</button>
+      </div>`;
+
       return `<tr class="${isLow ? 'low-stock' : ''}" data-product-id="${escapeHtml(productId)}">
         <td>${escapeHtml(productName)}</td>
         <td>${escapeHtml(innerUnitLabel)}</td>
-        <td class="${stockClass}">${stock}</td>
+        <td>${stockCell}</td>
         <td>${parCell}</td>
         <td>${statusBadge}</td>
         <td>${formatDate(lastReceived)}</td>
@@ -671,6 +717,67 @@
             cell.innerHTML = originalHtml;
             wireParEdit(cell.querySelector('.btn-par-edit'));
             showToast('Failed to save PAR: ' + (err.message || 'unknown error'), 'error');
+          }
+        }
+
+        saveBtn.addEventListener('click', doSave);
+        input.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter')  { e.preventDefault(); doSave(); }
+          if (e.key === 'Escape') cancelBtn.click();
+        });
+      });
+    }
+
+    // ── Stock inline adjust ───────────────────────────────────────────────────
+    function wireStockAdj(btn) {
+      btn.addEventListener('click', () => {
+        const productId    = btn.dataset.productId;
+        const cell         = btn.closest('.stock-cell');
+        const currentStock = inventoryMap.get(productId)?.stock ?? 0;
+        const originalHtml = cell.innerHTML;
+
+        cell.innerHTML = `<div class="stock-adj-wrap">
+  <input type="number" class="stock-adj-input" min="0" step="1" value="${currentStock}">
+  <button class="btn-stock-save">Save</button>
+  <button class="btn-adj-cancel">&times;</button>
+</div>`;
+
+        const input     = cell.querySelector('.stock-adj-input');
+        const saveBtn   = cell.querySelector('.btn-stock-save');
+        const cancelBtn = cell.querySelector('.btn-adj-cancel');
+
+        input.focus(); input.select();
+
+        cancelBtn.addEventListener('click', () => {
+          cell.innerHTML = originalHtml;
+          wireStockAdj(cell.querySelector('.btn-stock-adj'));
+        });
+
+        async function doSave() {
+          const newVal = parseInt(input.value, 10);
+          if (isNaN(newVal) || newVal < 0) {
+            showToast('Enter a valid quantity', 'error');
+            input.focus();
+            return;
+          }
+          const delta = newVal - currentStock;
+          saveBtn.disabled = true;
+          saveBtn.textContent = 'Saving…';
+          try {
+            await appendLog(INVENTORY_PATH, {
+              action:    'adjust',
+              productId,
+              quantity:  String(delta),
+              timeStamp: new Date().toISOString(),
+              note:      'inline stock set',
+            });
+            if (inventoryMap.has(productId)) inventoryMap.get(productId).stock = newVal;
+            renderTable();
+            showToast(`Stock set to ${newVal}`, 'success');
+          } catch (err) {
+            cell.innerHTML = originalHtml;
+            wireStockAdj(cell.querySelector('.btn-stock-adj'));
+            showToast('Failed to save: ' + (err.message || 'unknown error'), 'error');
           }
         }
 
@@ -978,6 +1085,68 @@
         btn.disabled = false;
       } finally {
         btn.textContent = 'Save Adjustment';
+      }
+    });
+
+    // ════════════════════════════════════════
+    // ADD NEW INGREDIENT
+    // ════════════════════════════════════════
+    document.getElementById('new-ingredient-toggle').addEventListener('click', () => {
+      document.getElementById('new-ingredient-collapsible').classList.toggle('collapsible-open');
+    });
+
+    function updateNewIngBtn() {
+      const name = document.getElementById('new-ing-name').value.trim();
+      document.getElementById('new-ing-submit-btn').disabled = !name;
+    }
+
+    document.getElementById('new-ing-name').addEventListener('input', updateNewIngBtn);
+
+    document.getElementById('new-ing-submit-btn').addEventListener('click', async () => {
+      const btn      = document.getElementById('new-ing-submit-btn');
+      const name     = document.getElementById('new-ing-name').value.trim();
+      let   code     = document.getElementById('new-ing-code').value.trim();
+      const packSize = document.getElementById('new-ing-pack').value.trim();
+
+      if (!name) return;
+      if (!code) code = `custom-${Date.now()}`;
+
+      btn.disabled = true;
+      btn.textContent = 'Adding…';
+      try {
+        await appendLog(RECEIVING_PATH, {
+          action:      'new_product',
+          productName: name,
+          usFoodsCode: code,
+          packSize,
+          timeStamp:   new Date().toISOString(),
+        });
+
+        const newId = `new-${code}`;
+        PRODUCTS.push({ id: newId, name, packSize, usFoodsCode: code });
+        inventoryMap.set(newId, {
+          productId:    newId,
+          productName:  name,
+          packSize,
+          stock:        0,
+          par:          null,
+          lastReceived: null,
+          lastUsed:     null,
+        });
+
+        renderTable();
+        showToast(`'${name}' added to inventory`, 'success');
+
+        document.getElementById('new-ing-name').value = '';
+        document.getElementById('new-ing-code').value = '';
+        document.getElementById('new-ing-pack').value = '';
+        updateNewIngBtn();
+      } catch (err) {
+        showToast('Failed to add ingredient: ' + (err.message || 'unknown error'), 'error');
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Add Ingredient';
+        updateNewIngBtn();
       }
     });
 


### PR DESCRIPTION
## Summary
- **Stock adjustment simplified**: clicking `±` now opens an input pre-filled with the current stock value — type the new total and press Save (or Enter). The old separate `+ Add` / `− Remove` buttons are gone.
- **New ingredient form**: a collapsible "Add New Ingredient" section on the inventory page lets you add any new ingredient by name, with optional US Foods code and pack size. It's written to the receiving log and appears in the inventory table immediately.

## Preview
https://feature-stock-edit-and-new-ingredient--website--dangpretz.aem.page/static/inventory/
https://feature-stock-edit-and-new-ingredient--website--dangpretz.aem.page/static/inventory-forecast/

## Test plan
- [ ] Inventory: click `±` on a row → input appears pre-filled with current stock value
- [ ] Type a new number, press Save → toast "Stock set to N", cell updates
- [ ] Press Enter instead of clicking Save → same result
- [ ] Press Escape or `×` → closes without saving
- [ ] Forecast: same `±` behaviour works on the In Stock column
- [ ] Inventory: scroll down past Manual Adjustment → "Add New Ingredient" collapsible appears
- [ ] Enter a name only (no code or pack size) → Add Ingredient button enables → click → ingredient appears in table with stock 0
- [ ] Enter name + US Foods code + pack size → submits correctly, appears in table
- [ ] Reload page → added ingredient still present (persisted in receiving log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)