### PR TITLE
Add ability to remove inventory items

### DIFF
--- a/static/inventory-forecast/index.html
+++ b/static/inventory-forecast/index.html
@@ -351,10 +351,18 @@
 
     // ── Dynamic products (new_product entries from receiving log) ────────────
     function buildDynamicProducts(receivingLogs) {
+      const archived = new Set(
+        receivingLogs.filter((r) => r.action === 'archive_product').map((r) => r.productId),
+      );
+      for (let i = PRODUCTS.length - 1; i >= 0; i--) {
+        if (archived.has(PRODUCTS[i].id)) PRODUCTS.splice(i, 1);
+      }
       receivingLogs.filter((r) => r.action === 'new_product').forEach((r) => {
         if (!r.usFoodsCode || !r.productName) return;
-        if (PRODUCTS.some((p) => p.id === `new-${r.usFoodsCode}`)) return;
-        PRODUCTS.push({ id: `new-${r.usFoodsCode}`, name: r.productName, packSize: r.packSize || '' });
+        const dynamicId = `new-${r.usFoodsCode}`;
+        if (archived.has(dynamicId)) return;
+        if (PRODUCTS.some((p) => p.id === dynamicId)) return;
+        PRODUCTS.push({ id: dynamicId, name: r.productName, packSize: r.packSize || '' });
       });
     }
 

--- a/static/inventory/index.html
+++ b/static/inventory/index.html
@@ -126,6 +126,14 @@
     .inv-table td { font: 400 14px 'Manrope', sans-serif; color: #1A1A1A; padding: 11px 16px; border-bottom: 1px solid #f5f5f5; vertical-align: middle; }
     .inv-table tr:last-child td { border-bottom: none; }
     .inv-table tr.low-stock { background: #fff8f8; }
+    .inv-table th.col-actions, .inv-table td.col-actions { width: 32px; padding: 0 8px; text-align: center; }
+    .btn-row-delete { background: none; border: none; cursor: pointer; color: #ddd; font-size: 14px; padding: 4px; line-height: 1; transition: color .15s; }
+    .btn-row-delete:hover { color: #C41E1E; }
+    .remove-confirm { display: flex; align-items: center; gap: 6px; white-space: nowrap; font: 600 12px 'Manrope', sans-serif; color: #C41E1E; }
+    .btn-remove-yes { background: #C41E1E; color: #fff; font: 700 11px 'Manrope', sans-serif; border: none; border-radius: 5px; padding: 3px 9px; cursor: pointer; }
+    .btn-remove-yes:hover { background: #a01818; }
+    .btn-remove-no  { background: none; border: none; color: #aaa; font-size: 16px; cursor: pointer; padding: 0 2px; line-height: 1; }
+    .btn-remove-no:hover { color: #555; }
     .inv-table tbody tr:hover td { background: #faf8f5; }
     .inv-table tbody tr.low-stock:hover td { background: #fdf2f2; }
 
@@ -271,6 +279,7 @@
               <th>Status</th>
               <th>Last Received</th>
               <th>Last Used</th>
+              <th class="col-actions"></th>
             </tr>
           </thead>
           <tbody id="inv-tbody"></tbody>
@@ -517,18 +526,28 @@
 
     // ── Dynamic products (from new_product receiving entries) ─────────────────
     function buildDynamicProducts(receivingLogs) {
+      // Build set of archived product IDs
+      const archived = new Set(
+        receivingLogs.filter((r) => r.action === 'archive_product').map((r) => r.productId),
+      );
+      // Remove archived hardcoded products (iterate backwards to splice safely)
+      for (let i = PRODUCTS.length - 1; i >= 0; i--) {
+        if (archived.has(PRODUCTS[i].id)) PRODUCTS.splice(i, 1);
+      }
+      // Add dynamic products that aren't archived
       receivingLogs
         .filter((r) => r.action === 'new_product')
         .forEach((r) => {
-          const exists = PRODUCTS.some((p) => p.usFoodsCode === r.usFoodsCode);
-          if (!exists && r.usFoodsCode && r.productName) {
-            PRODUCTS.push({
-              id: `new-${r.usFoodsCode}`,
-              name: r.productName,
-              packSize: r.packSize || '',
-              usFoodsCode: r.usFoodsCode,
-            });
-          }
+          if (!r.usFoodsCode || !r.productName) return;
+          const dynamicId = `new-${r.usFoodsCode}`;
+          if (archived.has(dynamicId)) return;
+          if (PRODUCTS.some((p) => p.usFoodsCode === r.usFoodsCode)) return;
+          PRODUCTS.push({
+            id: dynamicId,
+            name: r.productName,
+            packSize: r.packSize || '',
+            usFoodsCode: r.usFoodsCode,
+          });
         });
     }
 
@@ -639,11 +658,12 @@
       }
 
       if (!rows.length) {
-        tbody.innerHTML = `<tr><td colspan="7" class="table-status">${showLowOnly ? 'No low-stock items.' : 'No inventory data.'}</td></tr>`;
+        tbody.innerHTML = `<tr><td colspan="8" class="table-status">${showLowOnly ? 'No low-stock items.' : 'No inventory data.'}</td></tr>`;
       } else {
         tbody.innerHTML = rows.map(buildTableRow).join('');
         tbody.querySelectorAll('.btn-par-edit').forEach(wireParEdit);
         tbody.querySelectorAll('.btn-stock-adj').forEach(wireStockAdj);
+        tbody.querySelectorAll('.btn-row-delete').forEach(wireDeleteBtn);
       }
 
       statusEl.hidden = true;
@@ -683,6 +703,7 @@
         <td>${statusBadge}</td>
         <td>${formatDate(lastReceived)}</td>
         <td>${formatDate(lastUsed)}</td>
+        <td class="col-actions"><button class="btn-row-delete" data-product-id="${escapeHtml(productId)}" data-product-name="${escapeHtml(productName)}" title="Remove ingredient">🗑</button></td>
       </tr>`;
     }
 
@@ -805,6 +826,52 @@
         input.addEventListener('keydown', (e) => {
           if (e.key === 'Enter')  { e.preventDefault(); doSave(); }
           if (e.key === 'Escape') cancelBtn.click();
+        });
+      });
+    }
+
+    // ── Remove ingredient ────────────────────────────────────────────────────
+    function wireDeleteBtn(btn) {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const productId   = btn.dataset.productId;
+        const productName = btn.dataset.productName;
+        const cell        = btn.closest('td');
+
+        cell.innerHTML = `<div class="remove-confirm">
+          Remove?
+          <button class="btn-remove-yes">Yes</button>
+          <button class="btn-remove-no">&times;</button>
+        </div>`;
+
+        cell.querySelector('.btn-remove-no').addEventListener('click', (ev) => {
+          ev.stopPropagation();
+          cell.innerHTML = `<button class="btn-row-delete" data-product-id="${escapeHtml(productId)}" data-product-name="${escapeHtml(productName)}" title="Remove ingredient">🗑</button>`;
+          wireDeleteBtn(cell.querySelector('.btn-row-delete'));
+        });
+
+        cell.querySelector('.btn-remove-yes').addEventListener('click', async (ev) => {
+          ev.stopPropagation();
+          cell.querySelector('.btn-remove-yes').disabled = true;
+          cell.querySelector('.btn-remove-yes').textContent = '…';
+          try {
+            await appendLog(RECEIVING_PATH, {
+              action: 'archive_product',
+              productId,
+              productName,
+              timeStamp: new Date().toISOString(),
+            });
+            // Remove from in-memory PRODUCTS and inventoryMap
+            const idx = PRODUCTS.findIndex((p) => p.id === productId);
+            if (idx !== -1) PRODUCTS.splice(idx, 1);
+            inventoryMap.delete(productId);
+            renderTable();
+            showToast(`${productName} removed`, 'success');
+          } catch (err) {
+            showToast('Failed to remove: ' + (err.message || 'error'), 'error');
+            cell.innerHTML = `<button class="btn-row-delete" data-product-id="${escapeHtml(productId)}" data-product-name="${escapeHtml(productName)}" title="Remove ingredient">🗑</button>`;
+            wireDeleteBtn(cell.querySelector('.btn-row-delete'));
+          }
         });
       });
     }


### PR DESCRIPTION
## Summary
- Each row in the inventory table has a 🗑 trash button in a new slim actions column
- Clicking shows an inline **Remove? [Yes] [×]** confirmation — no accidental deletions
- Confirming writes an `action:'archive_product'` entry to the receiving log, removes the row immediately, and persists across reloads
- Works for both hardcoded products and ingredients added via "Add New Ingredient"
- The forecast page also respects archived items — they won't appear there on next load

## Preview
https://feature-archive-inventory-item--website--dangpretz.aem.page/static/inventory/

## Test plan
- [ ] Click 🗑 on any row → "Remove? Yes ×" confirmation appears inline
- [ ] Click × → confirmation dismisses, row remains
- [ ] Click Yes → row disappears, toast "X removed"
- [ ] Reload page → removed item is still gone
- [ ] Forecast page reload → removed item no longer appears in forecast table

🤖 Generated with [Claude Code](https://claude.com/claude-code)