### PR TITLE
Batch tracking: mobile layout fixes

### DIFF
--- a/static/batch-tracking/index.html
+++ b/static/batch-tracking/index.html
@@ -151,9 +151,13 @@
       .nav-links { gap: 14px; }
       .nav-links a { font-size: 13px; }
 
-      /* Hero */
-      .hero h1 { font-size: 28px; }
-      .lang-toggle { top: -4px; }
+      /* Hero — flex row: title left, toggle right */
+      .hero > div { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+      .hero h1 { font-size: 28px; text-align: left; flex: 1; }
+      .lang-toggle { position: static; flex-shrink: 0; }
+
+      /* Date input — prevent overflow beyond card */
+      #batch-date { max-width: 100%; }
 
       /* Sections */
       .section-cream, .section-dark { padding: 24px 4%; }
@@ -224,7 +228,7 @@
 
 <section class="hero">
   <div style="position:relative; max-width:1100px; margin:0 auto; padding:0 5%;">
-    <h1 data-i18n="hero">PRODUCTION.</h1>
+    <h1 data-i18n="hero">PRODUCTION</h1>
     <div class="lang-toggle">
       <button id="lang-en" class="lang-btn active">EN</button>
       <span class="lang-sep">|</span>
@@ -339,7 +343,7 @@
   // ── i18n ──────────────────────────────────────────────────────────────────────
   const STRINGS = {
     en: {
-      hero: 'PRODUCTION.',
+      hero: 'PRODUCTION',
       labelProduct: 'Product',
       selectProduct: 'Select a product…',
       labelDate: 'Date',
@@ -363,7 +367,7 @@
       deleteYes: 'Yes, delete',
     },
     es: {
-      hero: 'PRODUCCIÓN.',
+      hero: 'PRODUCCIÓN',
       labelProduct: 'Producto',
       selectProduct: 'Seleccionar producto…',
       labelDate: 'Fecha',


### PR DESCRIPTION
## Summary
- **EN/ES toggle no longer overlaps the title** on mobile — hero switches to a flex row with title on the left and toggle pinned to the right
- **Date input stays within the card** — `max-width: 100%` prevents it bleeding past the card edge
- **Period removed** from PRODUCTION / PRODUCCIÓN heading

## Preview
https://feature-batch-tracking-mobile-fixes--website--dangpretz.aem.page/static/batch-tracking/

## Test plan
- [ ] On mobile: hero shows title left, EN/ES toggle right — no overlap
- [ ] Date picker fits within the cream card with no overflow
- [ ] Page heading reads "PRODUCTION" (EN) / "PRODUCCIÓN" (ES) without trailing period

🤖 Generated with [Claude Code](https://claude.com/claude-code)