### PR TITLE
Rename batch tracking hero title

### DIFF
--- a/static/batch-tracking/index.html
+++ b/static/batch-tracking/index.html
@@ -232,7 +232,7 @@
 
 <section class="hero">
   <div style="position:relative; max-width:1100px; margin:0 auto; padding:0 5%;">
-    <h1 data-i18n="hero">PRODUCTION</h1>
+    <h1 data-i18n="hero">BATCH TRACKING</h1>
     <div class="lang-toggle">
       <button id="lang-en" class="lang-btn active">EN</button>
       <span class="lang-sep">|</span>
@@ -347,7 +347,7 @@
   // ── i18n ──────────────────────────────────────────────────────────────────────
   const STRINGS = {
     en: {
-      hero: 'PRODUCTION',
+      hero: 'BATCH TRACKING',
       labelProduct: 'Product',
       selectProduct: 'Select a product…',
       labelDate: 'Date',
@@ -371,7 +371,7 @@
       deleteYes: 'Yes, delete',
     },
     es: {
-      hero: 'PRODUCCIÓN',
+      hero: 'RASTREO DE LOTES',
       labelProduct: 'Producto',
       selectProduct: 'Seleccionar producto…',
       labelDate: 'Fecha',


### PR DESCRIPTION
## Summary
- EN: `PRODUCTION` → `BATCH TRACKING`
- ES: `PRODUCCIÓN` → `RASTREO DE LOTES`

## Preview
https://feature-batch-tracking-title--website--dangpretz.aem.page/static/batch-tracking/

## Test plan
- [ ] Page loads showing "BATCH TRACKING" in English
- [ ] Switch to ES → shows "RASTREO DE LOTES"

🤖 Generated with [Claude Code](https://claude.com/claude-code)