### PR TITLE
Restore production page (accidentally overwritten in PR 35)

### DIFF
--- a/static/production/index.html
+++ b/static/production/index.html
@@ -3,693 +3,5240 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Production | Dangerous Pretzel Co.</title>
+  <title>Production | DPC</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700;800&family=Paytone+One&display=swap" rel="stylesheet">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#18181a">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="DPC Pretzels">
+  <link rel="apple-touch-icon" href="icon-192.png">
   <style>
-    /* ── Reset ── */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    [hidden] { display: none !important; }
-    body { font-family: 'Manrope', sans-serif; color: #1A1A1A; background: #1A1A1A; -webkit-font-smoothing: antialiased; }
-    a { color: inherit; text-decoration: none; }
+    :root {
+      --red: #C41E1E; --red-dk: #8B0000;
+      --dark: #1A1A1A; --amber: #f0ad4e; --green: #2a7a2a;
+      --white: #ffffff;
+      --gray-1: #f5f5f5; --gray-2: #e8e8e8; --gray-3: #999999; --gray-4: #666666;
+    }
+    html { background: var(--dark); }
+    body { font-family: 'Manrope', sans-serif; background: var(--dark); color: var(--dark); min-height: 100vh; }
 
-    /* ── Nav ── */
-    .site-nav { background: #1A1A1A; padding: 14px 5%; position: sticky; top: 0; z-index: 400; border-bottom: 1px solid #333; overflow-x: auto; }
-    .nav-wrap { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; min-width: max-content; }
-    .nav-logo { height: 46px; flex-shrink: 0; }
-    .nav-links { display: flex; align-items: center; gap: 20px; flex-wrap: nowrap; margin-left: 20px; }
-    .nav-links a { color: #fff; font: 400 15px/1 'Manrope', sans-serif; transition: color 0.2s; white-space: nowrap; }
-    .nav-links a:hover { color: #C41E1E; }
+    /* iOS zoom fix */
+    input, select, textarea { font-size: 16px !important; }
 
-    /* ── Hero ── */
-    .hero { background: #1A1A1A; text-align: center; padding: clamp(30px,4vw,50px) 5% clamp(16px,3vw,28px); }
-    .hero h1 { font: 900 italic clamp(32px,5vw,52px)/1.05 Georgia, serif; color: #fff; }
+    /* ── Top nav ─────────────────────────────────── */
+    .topnav {
+      position: sticky; top: 0; z-index: 100; background: var(--dark);
+      border-bottom: 2px solid var(--red);
+      display: flex; align-items: center; height: 60px;
+    }
+    .nav-arrow {
+      width: 56px; height: 60px; border: none; background: none;
+      color: var(--white); font-size: 32px; font-weight: 700; cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+      -webkit-tap-highlight-color: transparent; flex-shrink: 0;
+    }
+    .nav-arrow:active { background: rgba(255,255,255,0.08); }
+    .date-display {
+      flex: 1; text-align: center; cursor: pointer; padding: 4px 0;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .date-label {
+      display: block; font-family: 'Paytone One', sans-serif;
+      font-size: 17px; color: var(--white); line-height: 1.2;
+    }
+    .date-label.is-today { color: var(--amber); }
+    .date-sub { display: block; font-size: 12px; color: var(--gray-3); margin-top: 1px; }
+    .week-toggle {
+      height: 60px; padding: 0 16px; border: none; background: none;
+      color: var(--gray-3); font: 700 12px 'Manrope', sans-serif;
+      text-transform: uppercase; letter-spacing: 0.5px; cursor: pointer;
+      -webkit-tap-highlight-color: transparent; flex-shrink: 0;
+    }
+    .week-toggle.active { color: var(--amber); }
+    /* ── Day tab bar ───────────────────────────── */
+    .tab-bar {
+      display: flex; background: var(--gray-1);
+      border-radius: 10px; padding: 3px; margin-bottom: 12px; gap: 3px;
+    }
+    .tab-btn {
+      flex: 1; padding: 10px 6px; border: none; border-radius: 8px;
+      background: none; font: 700 13px 'Manrope', sans-serif;
+      color: var(--gray-4); cursor: pointer; white-space: nowrap;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .tab-btn.active { background: var(--white); color: var(--dark); box-shadow: 0 1px 4px rgba(0,0,0,0.10); }
 
-    /* ── Sections ── */
-    .section-cream { background: #F5F0E8; padding: clamp(32px,5vw,60px) 5%; }
-    .section-dark  { background: #1A1A1A; padding: clamp(32px,5vw,60px) 5%; }
-    .section-dark h2 { font: 900 italic clamp(24px,3vw,36px)/1.05 Georgia, serif; color: #fff; margin-bottom: 24px; }
-    .max-800  { max-width: 800px;  margin: 0 auto; }
-    .max-1100 { max-width: 1100px; margin: 0 auto; }
+    /* ── Stock tab ─────────────────────────────── */
+    .stock-tab-header {
+      padding: 6px 0 14px; border-bottom: 2px solid var(--gray-2); margin-bottom: 6px;
+    }
+    .stock-tab-title { font-family: 'Paytone One', sans-serif; font-size: 18px; color: var(--dark); }
+    .stock-tab-note  { font: 400 12px 'Manrope', sans-serif; color: var(--gray-4); margin-top: 2px; }
+    .stock-col-head  {
+      display: grid; grid-template-columns: 1fr 76px 76px;
+      gap: 8px; padding: 8px 0 6px;
+      font: 700 11px 'Manrope', sans-serif; color: var(--gray-3);
+      text-transform: uppercase; letter-spacing: 0.5px;
+      border-bottom: 1px solid var(--gray-2);
+    }
+    .stock-row {
+      display: grid; grid-template-columns: 1fr 76px 76px;
+      gap: 8px; align-items: center;
+      padding: 10px 0; border-bottom: 1px solid var(--gray-2);
+    }
+    .stock-row:last-of-type { border-bottom: none; }
+    .stock-sku   { font: 600 14px 'Manrope', sans-serif; color: var(--dark); }
+    .stock-input {
+      width: 100%; padding: 9px 6px; text-align: center;
+      border: 1.5px solid var(--gray-2); border-radius: 8px;
+      font: 700 15px 'Manrope', sans-serif !important; color: var(--dark);
+    }
+    .stock-na    { font: 400 13px 'Manrope', sans-serif; color: var(--gray-3); text-align: center; }
+    .stock-deduct { font: 400 11px 'Manrope', sans-serif; color: var(--green); }
+    .stock-deduct-list { font: 400 11px 'Manrope', sans-serif; color: var(--gray-4); margin-top: 1px; line-height: 1.3; }
+    /* Aging dough indicator (5+ days) */
+    .stock-aging {
+      display: inline-block; margin-left: 6px;
+      font: 700 11px 'Manrope', sans-serif;
+      color: #856404; background: #fff3cd; border-radius: 4px;
+      padding: 1px 6px;
+    }
+    .stock-aging.critical { color: var(--red); background: #FCEBEB; }
 
-    /* ── Cards ── */
-    .card { background: #fff; border-radius: 10px; padding: 22px 24px; margin-bottom: 20px; box-shadow: 0 1px 4px rgba(0,0,0,.07); }
-    .card-dark { background: #2e2e2e; box-shadow: none; }
+    /* Per-delivery coverage list (expandable under each stock row) */
+    .coverage-details {
+      margin-top: 6px;
+      font: 400 11px 'Manrope', sans-serif;
+      color: var(--gray-4);
+    }
+    .coverage-details > summary {
+      cursor: pointer; user-select: none;
+      font: 600 11px 'Manrope', sans-serif;
+      color: var(--gray-3);
+      padding: 2px 0;
+    }
+    .coverage-details[open] > summary { color: var(--dark); }
+    .coverage-list { margin: 4px 0 0; padding: 0; list-style: none; }
+    .coverage-row {
+      display: grid; grid-template-columns: 60px 1fr auto;
+      gap: 8px; align-items: center;
+      padding: 3px 0; border-top: 1px solid #f0f0f0;
+      font: 500 11px 'Manrope', sans-serif;
+    }
+    .coverage-row:first-child { border-top: none; }
+    .coverage-row .cov-date  { color: var(--gray-3); }
+    .coverage-row .cov-cust  { color: var(--dark); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .coverage-row .cov-state { font: 700 10px 'Manrope', sans-serif; padding: 2px 7px; border-radius: 10px; white-space: nowrap; }
+    .coverage-row.cov-ready     .cov-state { background: #d4edda; color: #155724; }
+    .coverage-row.cov-baking    .cov-state { background: #fff3cd; color: #856404; }
+    .coverage-row.cov-partial   .cov-state { background: #cce5ff; color: #004085; }
+    .coverage-row.cov-unstarted .cov-state { background: #f8d7da; color: #721c24; }
 
-    /* ── Form fields ── */
-    .field-group { display: flex; flex-direction: column; gap: 5px; margin-bottom: 16px; }
-    .field-group label { font: 700 11px 'Manrope', sans-serif; color: #888; letter-spacing: 0.8px; text-transform: uppercase; }
-    .field-group input,
-    .field-group select {
-      font: 400 14px 'Manrope', sans-serif;
-      padding: 9px 12px;
-      border: 2px solid #e8e0d5;
+    /* Forecast badge per SKU row */
+    .stock-forecast {
+      display: block; font: 600 11px 'Manrope', sans-serif;
+      margin-top: 3px; line-height: 1.3;
+    }
+    .stock-forecast.short   { color: var(--red); }
+    .stock-forecast.tight   { color: #856404; }
+    .stock-forecast.surplus { color: var(--green); }
+    .stock-forecast.none    { color: var(--gray-3); }
+
+    /* Summary card at top of stock tab */
+    .stock-summary {
+      display: flex; flex-direction: column; gap: 4px;
+      padding: 12px 14px; margin: 6px 0 14px;
+      background: var(--gray-1); border-radius: 10px;
+    }
+    .stock-summary-title {
+      font: 700 11px 'Manrope', sans-serif; color: var(--gray-3);
+      text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 2px;
+    }
+    .stock-summary-line {
+      font: 600 13px 'Manrope', sans-serif; color: var(--dark);
+    }
+    .stock-summary-line.short   { color: var(--red); }
+    .stock-summary-line.surplus { color: var(--green); }
+    .stock-summary-line.none    { color: var(--gray-4); }
+
+    /* ── Page content ──────────────────────────── */
+    .content { padding: 12px 12px 100px; max-width: 640px; margin: 0 auto; }
+
+    /* ── Banners ───────────────────────────────── */
+    .alert-banner {
+      background: #fff3cd; color: #856404;
+      border-radius: 10px; padding: 12px 16px;
+      font: 600 14px 'Manrope', sans-serif; margin-bottom: 10px;
+    }
+    .alert-banner a { color: #856404; }
+    .overdue-banner {
+      background: #fff0f0; color: var(--red); border: 1px solid #ffcccc;
+      border-radius: 10px; padding: 12px 16px;
+      font: 600 14px 'Manrope', sans-serif; margin-bottom: 10px;
+    }
+
+    /* ── Team card ─────────────────────────────── */
+    .team-card {
+      background: var(--white); border-radius: 14px;
+      margin-bottom: 12px; overflow: hidden;
+    }
+    .team-header {
+      padding: 14px 16px 12px; border-bottom: 1px solid var(--gray-2);
+      display: flex; align-items: flex-start; justify-content: space-between; gap: 8px;
+    }
+    .team-name { font-family: 'Paytone One', sans-serif; font-size: 19px; color: var(--dark); line-height: 1.2; }
+    .team-date { font: 400 13px 'Manrope', sans-serif; color: var(--gray-4); margin-top: 3px; }
+    .team-body { padding: 14px 16px; }
+
+    /* ── Status badge ──────────────────────────── */
+    .status-badge {
+      flex-shrink: 0; padding: 5px 10px; border-radius: 20px;
+      font: 700 12px 'Manrope', sans-serif; white-space: nowrap;
+    }
+    .badge-none    { background: var(--gray-2); color: var(--gray-4); }
+    .badge-partial { background: #fff3cd; color: #856404; }
+    .badge-done    { background: #d4edda; color: #155724; }
+    .badge-over    { background: #fff0f0; color: var(--red); }
+
+    /* ── Workers row ───────────────────────────── */
+    .workers-row {
+      display: flex; align-items: center; justify-content: space-between;
+      margin-bottom: 14px; padding-bottom: 12px; border-bottom: 1px solid var(--gray-2);
+    }
+    .workers-label { font: 700 14px 'Manrope', sans-serif; color: var(--dark); }
+    .workers-sub { font: 400 12px 'Manrope', sans-serif; color: var(--gray-4); display: block; margin-top: 2px; }
+    .stepper-inline {
+      display: flex; align-items: center;
+      border: 1.5px solid var(--gray-2); border-radius: 8px; overflow: hidden;
+    }
+    .stepper-btn {
+      width: 44px; height: 44px; border: none; background: var(--gray-1);
+      font-size: 20px; font-weight: 700; color: var(--dark); cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .stepper-btn:active { background: var(--gray-2); }
+    .stepper-val {
+      min-width: 42px; text-align: center;
+      font: 800 17px 'Manrope', sans-serif; color: var(--dark);
+      border-left: 1.5px solid var(--gray-2); border-right: 1.5px solid var(--gray-2);
+      line-height: 44px;
+    }
+
+    /* ── SKU list ──────────────────────────────── */
+    .section-label {
+      font: 700 11px 'Manrope', sans-serif; color: var(--gray-3);
+      text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px;
+    }
+    .sku-row {
+      padding: 10px 0; border-bottom: 1px solid var(--gray-2);
+      display: flex; flex-direction: column; gap: 3px;
+    }
+    .sku-row:last-child { border-bottom: none; }
+    .sku-name { font: 700 17px 'Manrope', sans-serif; color: var(--dark); }
+    .sku-detail { font: 400 14px 'Manrope', sans-serif; color: var(--gray-4); }
+    .sku-detail strong { color: var(--dark); font-weight: 800; }
+    .sku-delivery { font: 400 12px 'Manrope', sans-serif; color: var(--gray-3); }
+    .sku-customers { font: 400 12px 'Manrope', sans-serif; color: var(--gray-3); }
+    .inv-badge {
+      display: inline-block; font: 600 11px 'Manrope', sans-serif;
+      color: var(--green); background: #e8f5e8;
+      padding: 2px 7px; border-radius: 4px; margin-top: 1px;
+    }
+
+    /* ── Urgency tags ──────────────────────────── */
+    .sku-tag {
+      display: inline-block; font: 700 11px 'Manrope', sans-serif;
+      padding: 2px 7px; border-radius: 4px; margin-top: 1px;
+    }
+    .sku-tag-urgent { background: #fff0f0; color: var(--red); }
+    .sku-tag-ahead  { background: #fff3cd; color: #856404; }
+
+    /* ── Group label (BFP coating) ─────────────── */
+    .group-label {
+      font: 700 11px 'Manrope', sans-serif; color: var(--red);
+      text-transform: uppercase; letter-spacing: 0.5px;
+      margin: 14px 0 4px; padding-top: 8px; border-top: 1px dashed var(--gray-2);
+    }
+
+    /* ── Batch total ───────────────────────────── */
+    .batch-total {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 10px 12px; border-radius: 10px; margin: 12px 0;
+    }
+    .batch-total.ok   { background: #f0f8f0; }
+    .batch-total.over { background: #fff0f0; }
+    .batch-total.zero { background: var(--gray-1); }
+    .batch-total-left { display: flex; flex-direction: column; gap: 2px; }
+    .batch-total-num { font: 800 28px 'Manrope', sans-serif; color: var(--dark); line-height: 1; }
+    .batch-total-lbl { font: 400 13px 'Manrope', sans-serif; color: var(--gray-4); }
+    .batch-status { font: 700 14px 'Manrope', sans-serif; }
+    .status-ok   { color: var(--green); }
+    .status-over { color: var(--red); }
+    .workers-cap { font: 400 12px 'Manrope', sans-serif; color: var(--gray-4); margin-top: 3px; }
+
+    /* ── Inventory strip ───────────────────────── */
+    .inv-strip {
+      background: var(--gray-1); border-radius: 8px; padding: 10px 12px; margin: 10px 0;
+    }
+    .inv-strip-header {
+      display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px;
+    }
+    .inv-strip-items { font: 400 13px 'Manrope', sans-serif; color: var(--gray-4); }
+    .inv-strip-empty { font: 400 13px 'Manrope', sans-serif; color: var(--gray-3); }
+    .btn-link {
+      background: none; border: none; color: var(--red);
+      font: 600 13px 'Manrope', sans-serif; cursor: pointer; padding: 0;
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    /* ── Completed strip ───────────────────────── */
+    .completed-strip {
+      background: #e8f5e8; border-radius: 8px; padding: 10px 12px; margin: 10px 0;
+    }
+    .completed-strip-header {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 8px; margin-bottom: 6px; flex-wrap: wrap;
+    }
+    .completed-strip-lbl { font: 700 13px 'Manrope', sans-serif; color: var(--green); }
+    .completed-pills { display: flex; flex-wrap: wrap; gap: 5px; }
+    .completed-pill {
+      font: 600 12px 'Manrope', sans-serif; color: var(--green);
+      background: var(--white); border-radius: 6px; padding: 3px 9px;
+    }
+    .progress-short { font: 700 13px 'Manrope', sans-serif; color: var(--red); }
+    .progress-done  { font: 700 13px 'Manrope', sans-serif; color: var(--green); }
+
+    /* ── FOH note ──────────────────────────────── */
+    .foh-note {
+      font: 400 12px 'Manrope', sans-serif; color: var(--gray-3);
+      margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--gray-2);
+    }
+
+    /* ── Log & extra buttons ───────────────────── */
+    .log-btn {
+      display: block; width: 100%; min-height: 54px;
+      background: var(--red); color: var(--white); border: none;
+      border-radius: 10px; font: 700 16px 'Manrope', sans-serif; cursor: pointer;
+      margin-top: 14px; -webkit-tap-highlight-color: transparent;
+    }
+    .log-btn:active { background: var(--red-dk); }
+    .log-btn.logged { background: var(--green); }
+    .log-btn.logged:active { background: #1e5c1e; }
+    .log-btn-extra {
+      display: block; width: 100%; min-height: 44px;
+      background: none; border: 1.5px solid var(--gray-2);
+      border-radius: 10px; font: 600 14px 'Manrope', sans-serif;
+      color: var(--dark); cursor: pointer; margin-top: 8px;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .log-btn-extra:active { background: var(--gray-1); }
+
+    /* ── Week view ─────────────────────────────── */
+    .week-section-lbl {
+      font: 700 11px 'Manrope', sans-serif; color: var(--gray-3);
+      text-transform: uppercase; letter-spacing: 0.5px;
+      padding: 14px 4px 6px;
+    }
+    .week-row {
+      background: var(--white); border-radius: 12px;
+      padding: 14px 16px; margin-bottom: 8px;
+      display: flex; align-items: center; gap: 12px; min-height: 64px;
+      cursor: pointer; -webkit-tap-highlight-color: transparent;
+    }
+    .week-row:active { background: var(--gray-1); }
+    .week-row.is-today { border-left: 4px solid var(--red); padding-left: 12px; }
+    .week-row.is-empty { opacity: 0.45; }
+    .week-row-date { flex: 1; }
+    .week-row-day { font: 700 17px 'Manrope', sans-serif; color: var(--dark); }
+    .week-row-sub { font: 400 12px 'Manrope', sans-serif; color: var(--gray-4); margin-top: 3px; }
+    .week-row-right { display: flex; flex-direction: column; align-items: flex-end; gap: 3px; }
+    .week-team-line { font: 600 12px 'Manrope', sans-serif; color: var(--gray-4); }
+    .week-chevron { font: 400 20px 'Manrope', sans-serif; color: var(--gray-3); margin-top: 2px; }
+
+    /* ── No production ─────────────────────────── */
+    .no-prod {
+      text-align: center; color: var(--gray-3);
+      font: 400 15px 'Manrope', sans-serif; padding: 48px 20px;
+    }
+
+    /* ── Load error ────────────────────────────── */
+    .load-error {
+      background: #fff0f0; border-radius: 12px; padding: 24px 20px;
+      text-align: center; font: 600 15px 'Manrope', sans-serif; color: var(--red);
+    }
+
+    /* ── Bottom sheet ──────────────────────────── */
+    .sheet-overlay {
+      display: none; position: fixed; inset: 0;
+      background: rgba(0,0,0,0.6); z-index: 200;
+      align-items: flex-end; justify-content: center;
+    }
+    .sheet-overlay.open { display: flex; }
+    .sheet {
+      background: var(--white); border-radius: 18px 18px 0 0;
+      width: 100%; max-width: 640px; max-height: 92vh; overflow-y: auto;
+      padding-bottom: env(safe-area-inset-bottom, 0);
+    }
+    .sheet-handle {
+      width: 40px; height: 4px; background: var(--gray-2);
+      border-radius: 2px; margin: 12px auto 16px;
+    }
+    .sheet-header { padding: 0 20px 16px; border-bottom: 1px solid var(--gray-2); }
+    .sheet-title { font-family: 'Paytone One', sans-serif; font-size: 20px; color: var(--dark); }
+    .sheet-sub { font: 400 13px 'Manrope', sans-serif; color: var(--gray-4); margin-top: 3px; }
+    .sheet-body { padding: 0 20px; }
+    .sheet-footer { padding: 12px 20px 20px; border-top: 1px solid var(--gray-2); }
+
+    /* ── Sheet workers row ─────────────────────── */
+    .sheet-workers-row {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 16px 0; border-bottom: 1px solid var(--gray-2);
+    }
+    .sheet-workers-lbl { font: 700 16px 'Manrope', sans-serif; color: var(--dark); }
+    .sheet-workers-sub { font: 400 12px 'Manrope', sans-serif; color: var(--gray-4); display: block; margin-top: 2px; }
+
+    /* ── Sheet steppers ────────────────────────── */
+    .stepper-lg { display: flex; align-items: center; }
+    .step-btn {
+      width: 48px; height: 48px; border: 1.5px solid var(--gray-2); border-radius: 8px;
+      background: var(--gray-1); font-size: 24px; font-weight: 700; color: var(--dark);
+      cursor: pointer; display: flex; align-items: center; justify-content: center;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .step-btn:active { background: var(--gray-2); }
+    .step-val {
+      min-width: 56px; text-align: center;
+      font: 800 22px 'Manrope', sans-serif; color: var(--dark);
+    }
+
+    /* ── Sheet SKU rows ────────────────────────── */
+    .log-sku-row {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 14px 0; border-bottom: 1px solid var(--gray-2); gap: 12px;
+    }
+    .log-sku-row:last-child { border-bottom: none; }
+    .log-sku-info { flex: 1; min-width: 0; }
+    .log-sku-name { font: 700 16px 'Manrope', sans-serif; color: var(--dark); }
+    .log-sku-demand { font: 400 13px 'Manrope', sans-serif; color: var(--gray-4); margin-top: 2px; }
+
+    /* ── Extra sheet select ────────────────────── */
+    .extra-sku-select {
+      width: 100%; padding: 14px; margin-bottom: 20px;
+      border: 1.5px solid var(--gray-2); border-radius: 10px;
+      font: 600 16px 'Manrope', sans-serif; color: var(--dark);
+      background: var(--white); appearance: none; -webkit-appearance: none;
+    }
+
+    /* ── Configure SKU type buttons ───────────── */
+    .cfg-type-btn {
+      width: 100%; padding: 14px; text-align: left;
+      border: 1.5px solid var(--gray-2); border-radius: 10px;
+      background: var(--white); color: var(--dark);
+      font: 600 15px 'Manrope', sans-serif; cursor: pointer;
+      -webkit-tap-highlight-color: transparent; margin-bottom: 8px;
+    }
+    .cfg-type-btn:last-child { margin-bottom: 0; }
+    .cfg-type-btn.selected { border-color: var(--red); background: #fff0f0; color: var(--red); }
+
+    /* ── Sheet inv input row ───────────────────── */
+    .inv-input-row {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 12px 0; border-bottom: 1px solid var(--gray-2); gap: 10px;
+    }
+    .inv-input-row:last-child { border-bottom: none; }
+    .inv-input-lbl { font: 700 15px 'Manrope', sans-serif; color: var(--dark); flex: 1; }
+    .inv-input {
+      width: 80px; padding: 10px; text-align: center;
+      font: 700 17px 'Manrope', sans-serif !important;
+      border: 1.5px solid var(--gray-2); border-radius: 8px;
+    }
+    .inv-input-unit { font: 400 12px 'Manrope', sans-serif; color: var(--gray-4); white-space: nowrap; }
+
+    /* ── Sheet buttons ─────────────────────────── */
+    .btn-primary {
+      display: block; width: 100%; min-height: 54px;
+      background: var(--red); color: var(--white); border: none;
+      border-radius: 10px; font: 700 16px 'Manrope', sans-serif; cursor: pointer;
+    }
+    .btn-primary:active { background: var(--red-dk); }
+    .btn-primary:disabled { opacity: 0.5; }
+    .btn-secondary {
+      display: block; width: 100%; min-height: 48px;
+      background: var(--gray-1); color: var(--dark); border: 1.5px solid var(--gray-2);
+      border-radius: 10px; font: 600 15px 'Manrope', sans-serif; cursor: pointer;
+      margin-top: 8px;
+    }
+
+    /* ── New SKU row + inline logger ───────────── */
+    .sku-block {
+      padding: 14px 0; border-bottom: 1px solid var(--gray-2);
+    }
+    .sku-block:last-of-type { border-bottom: none; }
+    .sku-block-head {
+      display: flex; align-items: flex-start; justify-content: space-between;
+      gap: 8px; margin-bottom: 4px;
+    }
+    .sku-block-name { font: 800 18px 'Manrope', sans-serif; color: var(--dark); flex: 1; }
+    .sku-block-need {
+      font: 700 15px 'Manrope', sans-serif; color: var(--dark); margin-bottom: 2px;
+    }
+    .sku-block-need strong { font-size: 18px; }
+    .sku-block-meta { font: 400 12px 'Manrope', sans-serif; color: var(--gray-3); margin-bottom: 6px; }
+    .sku-block-onhand {
+      font: 600 12px 'Manrope', sans-serif; color: var(--gray-4);
+      padding: 4px 0; margin-bottom: 8px;
+    }
+    .sku-block-onhand .ohi { display: inline-block; margin-right: 10px; }
+    .sku-block-onhand .ohi.zero { opacity: 0.35; }
+
+    /* Inline stepper logger */
+    .row-logger {
+      display: flex; align-items: center; gap: 8px;
+      background: var(--gray-1); border-radius: 12px;
+      padding: 10px 10px;
+    }
+    .row-logger.done { background: #e8f5e8; }
+    .row-logger.over { background: #fff0f0; }
+    .row-log-btn {
+      width: 44px; height: 48px; border: 1.5px solid var(--gray-2);
+      border-radius: 10px; background: var(--white);
+      font: 700 22px 'Manrope', sans-serif; color: var(--dark); cursor: pointer;
+      -webkit-tap-highlight-color: transparent; flex-shrink: 0;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .row-log-btn:active { background: var(--gray-2); }
+    .row-log-btn:disabled { opacity: 0.4; cursor: default; }
+    .row-log-display {
+      flex: 1; text-align: center; display: flex; flex-direction: column;
+      align-items: center; gap: 1px;
+    }
+    .row-log-numbers { display: flex; align-items: baseline; justify-content: center; gap: 4px; }
+    .row-log-input {
+      width: 64px; padding: 4px 6px; text-align: center;
+      font: 800 18px 'Manrope', sans-serif !important; color: var(--dark);
+      border: 1.5px solid transparent; border-radius: 6px;
+      background: rgba(255,255,255,0.6);
+      -moz-appearance: textfield;
+    }
+    .row-log-input::-webkit-outer-spin-button,
+    .row-log-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+    .row-log-input:focus { border-color: var(--red); outline: none; background: var(--white); }
+    .row-log-of {
+      font: 700 15px 'Manrope', sans-serif; color: var(--gray-3);
+    }
+    .row-log-label {
+      font: 600 10px 'Manrope', sans-serif; color: var(--gray-4);
+      text-transform: uppercase; letter-spacing: 0.5px;
+    }
+    .row-log-status {
+      font: 700 12px 'Manrope', sans-serif; flex-shrink: 0;
+      min-width: 32px; text-align: center;
+    }
+    .row-log-status.saving { color: var(--gray-3); font-weight: 600; }
+    .row-log-status.saved  { color: var(--green); }
+    .row-log-status.done   { color: var(--green); }
+    .row-log-status.over   { color: var(--red); }
+    .row-log-status.error  { color: var(--red); }
+
+    @media (min-width: 640px) {
+      .team-name { font-size: 21px; }
+      .sku-name  { font-size: 18px; }
+      .batch-total-num { font-size: 32px; }
+    }
+
+    /* ───────────────── Worker view (UIUX redesign) ───────────────── */
+    /* When body has role-shape or role-bfp, hide manager chrome */
+    body.role-worker .topnav { display: none; }
+    body.role-worker .tab-bar { display: none !important; }
+    /* FOH role gets a single combined "Today" screen — Dips + Dough on one
+       page. No tab navigation, by design (user explicitly asked for the
+       simplest possible UX). The tab strip stays hidden via .role-worker. */
+
+    /* Worker header — two rows: identity on top, date nav below */
+    .worker-header {
+      position: sticky; top: 0; z-index: 100;
+      background: var(--dark); color: var(--white);
+      display: none; flex-direction: column;
+      border-bottom: 2px solid var(--red);
+    }
+    body.role-worker .worker-header { display: flex !important; }
+    .worker-header-row1 {
+      display: flex; align-items: center; gap: 10px;
+      padding: 12px 14px 8px;
+    }
+    .worker-header-row2 {
+      display: flex; align-items: center; gap: 8px;
+      padding: 0 10px 10px;
+    }
+    .worker-header-name {
+      font-family: 'Paytone One', sans-serif; font-size: 17px;
+      color: var(--white); white-space: nowrap;
+    }
+    .worker-header-spacer { flex: 1; }
+    .worker-lang-pill {
+      background: rgba(255,255,255,0.08); border: none; color: #ccc;
+      font: 700 12px 'Manrope', sans-serif; letter-spacing: 0.5px;
+      padding: 6px 10px; border-radius: 16px; cursor: pointer;
+    }
+    .worker-lang-pill .active-lang { color: var(--white); font-weight: 800; }
+    .worker-refresh-btn {
+      width: 36px; height: 36px; padding: 0;
+      background: rgba(255,255,255,0.08); border: none;
+      color: var(--white); font-size: 16px; cursor: pointer;
+      border-radius: 18px;
+    }
+    .worker-refresh-btn:active { background: rgba(255,255,255,0.16); }
+
+    /* Date nav row */
+    .worker-nav-arrow {
+      width: 36px; height: 36px; padding: 0;
+      background: none; border: none; color: var(--white);
+      font-size: 24px; font-weight: 700; cursor: pointer;
+      border-radius: 18px; flex-shrink: 0;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .worker-nav-arrow:active { background: rgba(255,255,255,0.10); }
+    .worker-date-btn {
+      flex: 1; background: none; border: none; color: var(--white);
+      cursor: pointer; padding: 4px 8px; border-radius: 8px;
+      display: flex; flex-direction: column; align-items: center; gap: 1px;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .worker-date-btn:active { background: rgba(255,255,255,0.06); }
+    .worker-date-label { font: 700 14px 'Manrope', sans-serif; color: var(--white); }
+    .worker-date-label.is-today { color: var(--amber); }
+    .worker-date-sub   { font: 400 11px 'Manrope', sans-serif; color: #aaa; }
+    .worker-week-btn {
+      background: rgba(255,255,255,0.08); border: none; color: #ccc;
+      font: 700 12px 'Manrope', sans-serif; letter-spacing: 0.4px;
+      padding: 6px 12px; border-radius: 16px; cursor: pointer; flex-shrink: 0;
+      text-transform: uppercase;
+    }
+    .worker-week-btn.active { background: var(--amber); color: var(--dark); }
+
+    /* Walk-in extra-batch button on dark page bg */
+    body.role-worker .log-btn-extra {
+      background: rgba(255,255,255,0.06);
+      border: 1.5px solid rgba(255,255,255,0.15);
+      color: #ccc;
+    }
+    body.role-worker .log-btn-extra:active { background: rgba(255,255,255,0.12); }
+
+    /* Hide the floating role-corner pill — replaced by header text */
+    body.role-worker .role-corner-pill { display: none !important; }
+
+    /* Status section headers above grouped cards */
+    .status-section-label {
+      font: 700 11px 'Manrope', sans-serif; color: var(--gray-3);
+      text-transform: uppercase; letter-spacing: 0.7px;
+      padding: 16px 4px 8px;
+    }
+    .status-section-label.pending  { color: var(--red); }
+    .status-section-label.progress { color: #0C447C; }
+    .status-section-label.done     { color: var(--green); }
+
+    /* SKU card — worker view variant */
+    .wcard {
+      position: relative; background: var(--white); border-radius: 14px;
+      margin-bottom: 10px; overflow: hidden;
+      padding: 14px 14px 14px 19px;
+    }
+    .wcard::before {
+      content: ''; position: absolute; left: 0; top: 0; bottom: 0;
+      width: 5px; background: var(--wcard-stripe, var(--gray-3));
+    }
+    .wcard.status-overdue  { background: #FCEBEB; }
+    .wcard.status-pending  { background: var(--white); }
+    .wcard.status-progress { background: #E6F1FB; }
+    .wcard.status-done     { background: #EAF3DE; }
+
+    .wcard-head {
+      display: flex; align-items: center; justify-content: space-between;
+      gap: 8px; margin-bottom: 4px;
+    }
+    .wcard-name { font: 800 17px 'Manrope', sans-serif; color: var(--dark); }
+    .wcard-cheese {
+      display: inline-block; margin-top: 4px;
+      font: 600 11px 'Manrope', sans-serif; color: #6b3a06;
+      background: #fef3d6; padding: 2px 8px; border-radius: 10px;
+    }
+    .wcard-prior-note {
+      font: 600 12px 'Manrope', sans-serif;
+      color: #2a7a2a;
+      margin: -2px 0 6px;
+    }
+    .wcard-pill {
+      font: 700 11px 'Manrope', sans-serif;
+      padding: 3px 10px; border-radius: 12px;
+      white-space: nowrap;
+    }
+    .wcard-pill.overdue  { background: rgba(196,30,30,0.12); color: var(--red); }
+    .wcard-pill.pending  { background: rgba(0,0,0,0.06); color: var(--gray-4); }
+    .wcard-pill.progress { background: rgba(12,68,124,0.12); color: #0C447C; }
+    .wcard-pill.done     { background: rgba(42,122,42,0.18); color: var(--green); }
+
+    /* Twin metric boxes */
+    .wcard-metrics {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+      margin-top: 10px;
+    }
+    .wmetric {
+      background: rgba(255,255,255,0.6); border-radius: 10px;
+      padding: 10px 10px 8px; text-align: center;
+    }
+    .wcard.status-pending .wmetric { background: rgba(0,0,0,0.03); }
+    .wmetric-label {
+      font: 700 10px 'Manrope', sans-serif; color: var(--gray-4);
+      letter-spacing: 0.6px; margin-bottom: 4px;
+    }
+    .wmetric-value {
+      font: 700 22px 'Manrope', sans-serif; color: var(--dark);
+      line-height: 1.1;
+    }
+    .wmetric-value .of { color: var(--gray-3); font-weight: 600; }
+    .wmetric-input {
+      width: 70px; padding: 0 4px; text-align: center;
+      font: 800 22px 'Manrope', sans-serif !important;
+      color: var(--dark); border: 1.5px solid transparent;
+      border-radius: 6px; background: rgba(255,255,255,0.7);
+      -moz-appearance: textfield;
+    }
+    .wmetric-input::-webkit-outer-spin-button,
+    .wmetric-input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+    .wmetric-input:focus { border-color: var(--red); outline: none; background: var(--white); }
+
+    /* TANDAS pips */
+    .pip-row { display: flex; flex-wrap: wrap; gap: 4px; justify-content: center; margin-top: 6px; min-height: 12px; }
+    .pip {
+      width: 10px; height: 10px; border-radius: 50%;
+      background: rgba(0,0,0,0.12); flex-shrink: 0;
+    }
+    .pip.filled { background: var(--wcard-stripe, var(--gray-3)); }
+    .pip.partial {
+      background: linear-gradient(90deg, var(--wcard-stripe, var(--gray-3)) 50%, rgba(0,0,0,0.12) 50%);
+    }
+    .pip-overflow { font: 600 10px 'Manrope', sans-serif; color: var(--gray-4); margin-left: 4px; align-self: center; }
+
+    /* PRETZELS bar */
+    .pbar {
+      height: 6px; background: rgba(0,0,0,0.08); border-radius: 3px;
+      overflow: hidden; margin-top: 8px;
+    }
+    .pbar-fill { height: 100%; background: var(--wcard-stripe, var(--gray-3)); transition: width 0.3s ease; }
+
+    /* Stepper */
+    .wstepper {
+      display: flex; align-items: center; gap: 12px;
+      margin-top: 12px;
+    }
+    .wstep-btn {
+      width: 52px; height: 52px; flex-shrink: 0;
+      border: 1.5px solid var(--gray-2); border-radius: 12px;
+      background: var(--white); color: var(--dark);
+      font: 700 26px 'Manrope', sans-serif; cursor: pointer;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .wstep-btn:active { background: var(--gray-1); }
+    .wstep-btn:disabled { opacity: 0.35; cursor: default; }
+    .wstep-center {
+      flex: 1; text-align: center;
+      font: 800 17px 'Manrope', sans-serif; color: var(--dark);
+    }
+    .wstep-status {
+      font: 700 12px 'Manrope', sans-serif; flex-shrink: 0;
+      min-width: 32px; text-align: center;
+    }
+    .wstep-status.saving { color: var(--gray-3); font-weight: 600; }
+    .wstep-status.saved  { color: var(--green); }
+    .wstep-status.done   { color: var(--green); }
+    .wstep-status.over   { color: var(--red); }
+    .wstep-status.error  { color: var(--red); }
+
+    .whelper {
+      font: 400 11px 'Manrope', sans-serif; color: var(--gray-4);
+      text-align: center; margin-top: 8px;
+    }
+    .wdetails-toggle {
+      display: inline-block; font: 600 11px 'Manrope', sans-serif;
+      color: var(--gray-4); margin-top: 6px; cursor: pointer;
+      background: none; border: none; padding: 4px 0;
+    }
+    .wdetails-panel {
+      font: 400 11px 'Manrope', sans-serif; color: var(--gray-4);
+      margin-top: 4px; line-height: 1.5;
+      padding: 6px 8px; background: rgba(0,0,0,0.03); border-radius: 6px;
+    }
+
+    /* Compact "Listo" card variant */
+    .wcard-compact {
+      padding: 10px 14px 10px 19px;
+      display: flex; align-items: center; gap: 8px;
+    }
+    .wcard-compact .wcard-check { font-size: 18px; color: var(--green); flex-shrink: 0; }
+    .wcard-compact .wcard-compact-text {
+      flex: 1; font: 600 13px 'Manrope', sans-serif; color: var(--dark);
+    }
+    .wcard-compact .wcard-compact-text strong { font-weight: 800; }
+    .wcard-compact .wcard-expand-hint {
+      font: 400 10px 'Manrope', sans-serif; color: var(--gray-3);
+    }
+
+    /* Day progress meter (worker view top) */
+    .wmeter {
+      background: var(--white); border-radius: 12px; padding: 12px 14px;
+      margin: 12px 0;
+    }
+    .wmeter-row {
+      display: flex; justify-content: space-between; align-items: baseline;
+      font: 600 13px 'Manrope', sans-serif; color: var(--dark);
+      margin-bottom: 6px;
+    }
+    .wmeter-row .pretzels { color: var(--gray-4); font-weight: 500; }
+    .wmeter-bar {
+      height: 8px; background: rgba(0,0,0,0.07);
+      border-radius: 4px; overflow: hidden;
+    }
+    .wmeter-fill { height: 100%; background: #639922; transition: width 0.4s ease; }
+
+    /* Completion celebration banner */
+    .celebrate-banner {
+      background: #EAF3DE; border-radius: 12px; padding: 16px;
+      margin: 12px 0; text-align: center;
+      animation: fadeIn 0.5s ease;
+    }
+    .celebrate-banner-title {
+      font: 800 18px 'Manrope', sans-serif; color: #173404;
+      margin-bottom: 4px;
+    }
+    .celebrate-banner-sub {
+      font: 400 13px 'Manrope', sans-serif; color: #173404; opacity: 0.85;
+    }
+    @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+    /* BFP pack list — shows which deliveries this card's pretzels feed into,
+       broken down by customer + case size + count. Helps BFP team think
+       in cases as they pack. Display-only for now (no checkboxes yet). */
+    .wpack-list {
+      margin-top: 10px;
+      padding: 8px 10px;
+      background: rgba(255, 255, 255, 0.55);
+      border: 1px solid rgba(0, 0, 0, 0.08);
       border-radius: 6px;
-      background: #fff;
-      color: #1A1A1A;
-      outline: none;
-      transition: border-color 0.2s;
-      width: 100%;
+      font: 500 12px 'Manrope', sans-serif;
     }
-    .field-group input:focus,
-    .field-group select:focus { border-color: #C41E1E; }
-
-    /* ── Toast ── */
-    .toast { position: fixed; bottom: 24px; right: 24px; z-index: 9999; background: #1A1A1A; color: #fff; font: 600 14px 'Manrope', sans-serif; padding: 12px 20px; border-radius: 8px; box-shadow: 0 4px 16px rgba(0,0,0,.25); opacity: 1; transition: opacity .4s; pointer-events: none; }
-    .toast.success { background: #2a7a2a; }
-    .toast.error   { background: #C41E1E; }
-    .toast.fade    { opacity: 0; }
-
-    /* ── Buttons ── */
-    .btn-primary { display: block; width: 100%; padding: 12px 20px; font: 700 14px 'Manrope', sans-serif; background: #C41E1E; color: #fff; border: none; border-radius: 8px; cursor: pointer; transition: background .2s; text-align: center; }
-    .btn-primary:hover:not(:disabled) { background: #a01818; }
-    .btn-primary:disabled { background: #ccc; cursor: not-allowed; }
-
-    /* ── Language toggle ── */
-    .lang-toggle { position: absolute; top: 0; right: 0; display: flex; align-items: center; gap: 4px; }
-    .lang-btn { background: none; border: 2px solid rgba(255,255,255,0.3); color: rgba(255,255,255,0.5); font: 700 12px 'Manrope',sans-serif; padding: 4px 10px; border-radius: 4px; cursor: pointer; transition: all .15s; }
-    .lang-btn.active { border-color: #fff; color: #fff; background: rgba(255,255,255,0.1); }
-    .lang-sep { color: rgba(255,255,255,0.3); font-size: 14px; }
-
-    /* ── Batch code preview ── */
-    .code-preview { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; font: 600 13px 'Manrope',sans-serif; color: #555; }
-    .batch-code-display { font: 700 20px 'Courier New',monospace; color: #1A1A1A; letter-spacing: 2px; background: #F5F0E8; padding: 6px 14px; border-radius: 6px; }
-
-    /* ── Active batch card ── */
-    .active-batch-card { margin-bottom: 0; }
-    .active-batch-meta { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-    .active-batch-label { font: 700 10px 'Manrope',sans-serif; color: #999; letter-spacing: 1px; text-transform: uppercase; margin-bottom: 4px; }
-    .active-batch-code { font: 700 24px 'Courier New',monospace; color: #1A1A1A; letter-spacing: 2px; }
-    .active-batch-sub { font: 400 13px 'Manrope',sans-serif; color: #777; margin-top: 4px; }
-    .btn-done { background: #2a7a2a; color: #fff; font: 700 13px 'Manrope',sans-serif; border: none; border-radius: 8px; padding: 12px 22px; cursor: pointer; white-space: nowrap; flex-shrink: 0; }
-    .btn-done:hover { background: #1e5e1e; }
-
-    /* ── Scan input ── */
-    .scan-label { display: block; font: 700 11px 'Manrope',sans-serif; color: #999; letter-spacing: 0.8px; text-transform: uppercase; margin-bottom: 8px; }
-    .search-wrap { display: flex; gap: 8px; }
-    .search-wrap input { flex: 1; font: 400 16px 'Manrope',sans-serif; padding: 12px 16px; border: 2px solid #ddd; border-radius: 8px; outline: none; transition: border-color .2s; }
-    .search-wrap input:focus { border-color: #C41E1E; }
-    .search-wrap input:disabled { background: #f5f5f5; color: #aaa; }
-    .search-wrap button { background: #C41E1E; color: #fff; font: 700 14px 'Manrope',sans-serif; border: none; border-radius: 8px; padding: 12px 22px; cursor: pointer; white-space: nowrap; }
-    .search-wrap button:hover:not(:disabled) { background: #a01818; }
-    .search-wrap button:disabled { background: #ccc; cursor: not-allowed; }
-    .scan-hint { font: 400 12px 'Manrope',sans-serif; color: #aaa; margin-top: 8px; font-style: italic; }
-
-    /* ── Scanned list ── */
-    .scanned-list { margin-top: 16px; }
-    .scanned-item { display: flex; align-items: center; gap: 12px; background: #fff; border-radius: 8px; padding: 10px 16px; margin-bottom: 8px; border-left: 4px solid #ccc; box-shadow: 0 1px 3px rgba(0,0,0,.05); }
-    .scanned-item.resolved   { border-left-color: #2a7a2a; }
-    .scanned-item.unresolved { border-left-color: #ddd; }
-    .scanned-barcode { font: 600 13px 'Courier New',monospace; color: #1A1A1A; }
-    .scanned-name { flex: 1; font: 400 13px 'Manrope',sans-serif; color: #555; }
-    .scanned-name.unknown { color: #aaa; font-style: italic; }
-    .scanned-time { font: 400 11px 'Manrope',sans-serif; color: #bbb; white-space: nowrap; }
-
-    /* ── History filters ── */
-    .history-filters { margin-bottom: 20px; }
-    .filter-row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
-    .filter-row input, .filter-row select { font: 400 13px 'Manrope',sans-serif; padding: 8px 12px; border: 2px solid #444; border-radius: 6px; background: #3a3a3a; color: #fff; outline: none; transition: border-color .15s; }
-    .filter-row input:focus, .filter-row select:focus { border-color: #C41E1E; }
-    .filter-row input::placeholder { color: #666; }
-    .filter-row select option { background: #2e2e2e; }
-    .btn-filter-clear { background: none; border: 2px solid #555; color: #888; font: 700 12px 'Manrope',sans-serif; border-radius: 6px; padding: 8px 16px; cursor: pointer; white-space: nowrap; transition: all .15s; }
-    .btn-filter-clear:hover { border-color: #C41E1E; color: #C41E1E; }
-
-    /* ── History batch cards ── */
-    .history-status { color: #888; font: 400 14px 'Manrope',sans-serif; text-align: center; padding: 32px 0; }
-    .batch-card { background: #2e2e2e; border-radius: 10px; margin-bottom: 12px; overflow: hidden; }
-    .batch-card-header { display: flex; align-items: center; gap: 16px; padding: 14px 18px; cursor: pointer; user-select: none; }
-    .batch-card-header:hover { background: #333; }
-    .batch-card-code { font: 700 16px 'Courier New',monospace; color: #fff; letter-spacing: 1px; }
-    .batch-card-product { font: 600 13px 'Manrope',sans-serif; color: #aaa; flex: 1; }
-    .batch-card-date { font: 400 12px 'Manrope',sans-serif; color: #666; white-space: nowrap; }
-    .batch-card-count { font: 400 12px 'Manrope',sans-serif; color: #666; white-space: nowrap; }
-    .batch-card-chevron { color: #555; font-size: 18px; transition: transform .2s; }
-    .batch-card.open .batch-card-chevron { transform: rotate(180deg); }
-    .batch-card-body { display: none; border-top: 1px solid #3a3a3a; }
-    .batch-card.open .batch-card-body { display: block; }
-    .batch-ing-table { width: 100%; border-collapse: collapse; }
-    .batch-ing-table td { font: 400 13px 'Manrope',sans-serif; padding: 9px 18px; border-bottom: 1px solid #3a3a3a; color: #ccc; }
-    .batch-ing-table tr:last-child td { border-bottom: none; }
-    .batch-ing-table .ing-barcode { font-family: 'Courier New',monospace; color: #fff; }
-    .batch-ing-table .ing-name { color: #aaa; }
-    .batch-ing-table .ing-name.unknown { color: #555; font-style: italic; }
-    .batch-ing-table .ing-time { color: #555; white-space: nowrap; font-size: 11px; }
-    .no-results { color: #555; font: 400 14px 'Manrope',sans-serif; text-align: center; padding: 32px 0; }
-
-    /* ── Mobile ── */
-    @media (max-width: 640px) {
-      .active-batch-meta { flex-direction: column; align-items: flex-start; }
-      .filter-row input, .filter-row select { width: 100%; }
+    .wpack-label {
+      font: 700 10px 'Manrope', sans-serif;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: #888;
+      margin-bottom: 4px;
     }
+    .wpack-list ul { list-style: none; margin: 0; padding: 0; }
+    .wpack-list li {
+      display: flex; align-items: center; gap: 6px;
+      padding: 3px 0; line-height: 1.3;
+      border-top: 1px solid rgba(0, 0, 0, 0.06);
+    }
+    .wpack-list li:first-child { border-top: none; }
+    .wpack-list .pack-count { font: 700 13px 'Manrope', sans-serif; min-width: 56px; }
+    .wpack-list .pack-cust  { color: var(--dark); flex: 1; }
+    .wpack-list .pack-date  { font: 400 11px 'Manrope', sans-serif; color: #888; }
+    /* Per-case checkbox slots — tap to toggle pack state. */
+    .wpack-list .pack-slots {
+      display: flex; flex-wrap: wrap; gap: 4px; margin-left: 8px;
+    }
+    .wpack-list .pack-slot {
+      width: 22px; height: 22px;
+      display: inline-flex; align-items: center; justify-content: center;
+      border: 1.5px solid #ccc; border-radius: 4px;
+      font: 700 11px 'Manrope', sans-serif; color: transparent;
+      background: transparent; cursor: pointer;
+      transition: background 0.15s, color 0.15s, border-color 0.15s;
+      padding: 0;
+    }
+    .wpack-list .pack-slot:hover { border-color: #888; }
+    .wpack-list .pack-slot.packed {
+      background: #4a4; border-color: #4a4; color: #fff;
+    }
+    .wpack-list li.all-packed { opacity: 0.55; }
+    .wpack-list li.all-packed .pack-cust::before { content: '✓ '; color: #4a4; font-weight: 700; }
+
+    /* Schedule-diff toast — fired after a stock save to show the user how
+       the schedule responded across days. Pure observation; doesn't modify
+       any underlying state or other UI. */
+    .schedule-diff-toast {
+      position: fixed; left: 50%; top: 16px; transform: translateX(-50%);
+      max-width: min(520px, calc(100vw - 32px));
+      background: #1A1A1A; color: #fff;
+      border: 1px solid #2d5a3a; border-left: 4px solid #4a4;
+      border-radius: 8px; box-shadow: 0 4px 24px rgba(0,0,0,0.35);
+      padding: 12px 16px; z-index: 1000;
+      font: 500 13px 'Manrope', sans-serif;
+      animation: fadeIn 0.25s ease;
+      cursor: pointer;
+    }
+    .schedule-diff-toast.unchanged { border-left-color: #888; border-color: #444; }
+    .schedule-diff-toast.has-overdue { border-left-color: #c44; border-color: #6e1e1e; }
+    .schedule-diff-toast-title {
+      font: 800 14px 'Manrope', sans-serif; color: #fff;
+      margin-bottom: 6px;
+    }
+    .schedule-diff-toast-row {
+      display: grid; grid-template-columns: 110px 1fr;
+      gap: 10px; padding: 2px 0;
+      font: 500 12px 'Manrope', sans-serif; color: #ccc;
+    }
+    .schedule-diff-toast-row .day  { color: #aaa; }
+    .schedule-diff-toast-row .add  { color: #c8f0d4; }
+    .schedule-diff-toast-row .sub  { color: #f8d7da; }
+    .schedule-diff-toast-row .same { color: #888; }
+    .schedule-diff-toast-dismiss {
+      font: 600 11px 'Manrope', sans-serif; color: #888;
+      margin-top: 6px; text-align: right;
+    }
+
+    /* Stock audit modal — manager-only diagnostic for inventory drift.
+       Shows per-SKU walkthrough: snapshot baseline → flows → deductions.
+       Same dark-card visual language as the schedule-diff toast. */
+    .stock-audit-overlay {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.6);
+      z-index: 1100; display: flex; align-items: center; justify-content: center;
+      padding: 16px; animation: fadeIn 0.15s ease;
+    }
+    .stock-audit-modal {
+      background: #1A1A1A; color: #fff;
+      width: 100%; max-width: 640px;
+      max-height: calc(100vh - 32px);
+      border-radius: 10px; padding: 20px; overflow-y: auto;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+      font: 500 13px 'Manrope', sans-serif;
+    }
+    .stock-audit-modal h3 {
+      font: 800 18px 'Manrope', sans-serif; margin: 0 0 4px;
+    }
+    .stock-audit-meta { font-size: 12px; color: #888; margin-bottom: 14px; }
+    .stock-audit-sku {
+      margin-bottom: 12px; border: 1px solid #2a2a2a; border-radius: 6px;
+      padding: 10px 12px; background: #0f0f0f;
+    }
+    .stock-audit-sku-name {
+      font: 700 14px 'Manrope', sans-serif; color: #fff; margin-bottom: 6px;
+    }
+    .stock-audit-row {
+      display: grid; grid-template-columns: 1fr auto;
+      gap: 10px; padding: 2px 0;
+      font: 500 12px 'Manrope', sans-serif; color: #ccc;
+    }
+    .stock-audit-row .label { color: #aaa; }
+    .stock-audit-row .add  { color: #c8f0d4; }
+    .stock-audit-row .sub  { color: #f8d7da; }
+    .stock-audit-row.total {
+      border-top: 1px solid #444; padding-top: 4px; margin-top: 4px;
+      font-weight: 700; color: #fff;
+    }
+    .stock-audit-skipped {
+      margin-top: 8px; padding-top: 6px; border-top: 1px dashed #2a2a2a;
+      font-size: 11px; color: #888;
+    }
+    .stock-audit-skipped-title { font-weight: 700; margin-bottom: 2px; color: #aaa; }
+    .stock-audit-skipped-row { padding: 1px 0; }
+    .stock-audit-footer {
+      display: flex; justify-content: space-between; align-items: center;
+      margin-top: 16px;
+    }
+    .stock-audit-close {
+      background: var(--paper); color: #1A1A1A; border: none; border-radius: 5px;
+      padding: 8px 18px; font: 700 13px 'Manrope', sans-serif; cursor: pointer;
+    }
+    .stock-audit-close:hover { background: #fff; }
+    .stock-audit-empty { color: #888; font-style: italic; padding: 8px 0; }
+    /* Audit button next to Save Stock — manager-only, secondary style */
+    #stock-audit {
+      background: transparent; color: var(--paper); border: 1px solid var(--paper);
+      border-radius: 5px; padding: 8px 14px;
+      font: 600 13px 'Manrope', sans-serif; cursor: pointer;
+      margin-left: 8px;
+    }
+    #stock-audit:hover { background: var(--paper); color: #1A1A1A; }
   </style>
 </head>
 <body>
 
-<nav class="site-nav">
-  <div class="nav-wrap">
-    <a href="../v2/index.html"><img class="nav-logo" src="https://www.dangerouspretzel.com/images/logos/svg-logo.svg" alt="Dangerous Pretzel Co."></a>
-    <div class="nav-links">
-      <a href="../v2/menu.html">Menu</a>
-      <a href="../v2/catering.html">Catering</a>
-      <a href="../v2/index.html">Home</a>
-      <a href="../delivery-planner/index.html">Delivery Planner</a>
-      <a href="../barcode-lookup/index.html">Barcode Lookup</a>
-      <a href="../receiving-history/index.html">Receiving History</a>
-      <a href="../inventory/index.html">Inventory</a>
-      <a href="../inventory-forecast/index.html">Forecast</a>
-      <a href="../recipes/index.html">Recipes</a>
-      <a href="../production/index.html">Production</a>
-    </div>
+<nav class="topnav">
+  <button class="nav-arrow" id="nav-prev" aria-label="Previous day">‹</button>
+  <div class="date-display" id="date-display" role="button" tabindex="0" aria-label="Go to today">
+    <span class="date-label" id="date-label">Today</span>
+    <span class="date-sub" id="date-sub"></span>
   </div>
+  <button class="nav-arrow" id="nav-next" aria-label="Next day">›</button>
+  <button class="week-toggle" id="week-toggle">Week</button>
+  <button class="week-toggle" id="lang-btn" aria-label="Switch language">EN</button>
+  <button class="week-toggle" id="refresh-btn" aria-label="Refresh data" title="Reload deliveries + production data">↻</button>
 </nav>
 
-<section class="hero">
-  <div style="position:relative; max-width:1100px; margin:0 auto; padding:0 5%;">
-    <h1 data-i18n="hero">PRODUCTION.</h1>
-    <div class="lang-toggle">
-      <button id="lang-en" class="lang-btn active">EN</button>
-      <span class="lang-sep">|</span>
-      <button id="lang-es" class="lang-btn">ES</button>
+<!-- Worker header — calm two-row layout; only rendered for ?role=shape|bfp -->
+<div class="worker-header" id="worker-header" style="display:none">
+  <div class="worker-header-row1">
+    <span class="worker-header-name" id="worker-header-name"></span>
+    <span class="worker-header-spacer"></span>
+    <button class="worker-lang-pill" id="worker-lang-btn" aria-label="Switch language">
+      <span id="worker-lang-es">ES</span> · <span id="worker-lang-en">EN</span>
+    </button>
+    <button class="worker-refresh-btn" id="worker-refresh-btn" aria-label="Refresh data" title="↻">↻</button>
+  </div>
+  <div class="worker-header-row2">
+    <button class="worker-nav-arrow" id="worker-prev" aria-label="Previous day">‹</button>
+    <button class="worker-date-btn" id="worker-date-btn" aria-label="Go to today">
+      <span class="worker-date-label" id="worker-date-label"></span>
+      <span class="worker-date-sub"   id="worker-date-sub"></span>
+    </button>
+    <button class="worker-nav-arrow" id="worker-next" aria-label="Next day">›</button>
+    <button class="worker-week-btn"  id="worker-week-btn" aria-label="Week view">Sem</button>
+  </div>
+</div>
+
+<div class="content">
+  <div id="alert-area"></div>
+  <div class="tab-bar" id="tab-bar" style="display:none">
+    <button class="tab-btn active" data-tab="shape">🥨 Shape</button>
+    <button class="tab-btn" data-tab="bfp">🔥 BFP</button>
+    <button class="tab-btn" data-tab="cheese">🧀 Cheese</button>
+    <button class="tab-btn" data-tab="stock">📦 Stock</button>
+  </div>
+  <div id="main-view"><div class="no-prod">Loading…</div></div>
+</div>
+
+<!-- Extra / unscheduled batch sheet -->
+<div class="sheet-overlay" id="extra-overlay" role="dialog" aria-modal="true">
+  <div class="sheet">
+    <div class="sheet-handle"></div>
+    <div class="sheet-header">
+      <div class="sheet-title" id="extra-title">Add Unscheduled Batch</div>
+      <div class="sheet-sub" id="extra-sub">Last-minute order or walk-in</div>
+    </div>
+    <div class="sheet-body" style="padding:20px">
+      <select class="extra-sku-select" id="extra-sku-select"></select>
+      <div style="display:flex;align-items:flex-start;justify-content:space-between;padding:4px 0;gap:12px">
+        <div style="flex:1">
+          <span id="extra-batches-lbl" style="font:700 16px 'Manrope',sans-serif;color:var(--dark)">Pretzels</span>
+          <div id="extra-hint" style="font:400 12px 'Manrope',sans-serif;color:var(--gray-3);margin-top:3px"></div>
+        </div>
+        <div class="stepper-lg">
+          <button class="step-btn" id="extra-dec">−</button>
+          <input type="number" id="extra-val" min="0" inputmode="numeric" value="0"
+                 style="width:80px;text-align:center;border:1.5px solid var(--gray-2);border-radius:8px;padding:4px 6px;font:800 20px 'Manrope',sans-serif !important;background:var(--white);margin:0 6px">
+          <button class="step-btn" id="extra-inc">+</button>
+        </div>
+      </div>
+    </div>
+    <div class="sheet-footer">
+      <button class="btn-primary" id="extra-save">Save Batch</button>
+      <button class="btn-secondary" id="extra-cancel">Cancel</button>
     </div>
   </div>
-</section>
+</div>
 
-<section class="section-cream">
-  <div class="max-800">
 
-    <!-- START VIEW -->
-    <div id="start-view">
-      <div class="card">
-        <div class="field-group">
-          <label data-i18n="labelProduct">Product</label>
-          <select id="product-select">
-            <option value="" data-i18n-option="selectProduct">Select a product…</option>
-          </select>
-        </div>
-        <div class="field-group">
-          <label data-i18n="labelDate">Date</label>
-          <input type="date" id="batch-date">
-        </div>
-        <div class="code-preview" id="code-preview-wrap" hidden>
-          <span data-i18n="labelBatchCode">Batch Code</span>
-          <span class="batch-code-display" id="code-preview">—</span>
-        </div>
-        <button class="btn-primary" id="start-batch-btn" disabled data-i18n="startBatch">Start Batch</button>
+<!-- Configure SKU sheet -->
+<div class="sheet-overlay" id="cfg-overlay" role="dialog" aria-modal="true">
+  <div class="sheet">
+    <div class="sheet-handle"></div>
+    <div class="sheet-header">
+      <div class="sheet-title" id="cfg-title-text">Configure SKU</div>
+      <div class="sheet-sub" id="cfg-sku-display"></div>
+    </div>
+    <div class="sheet-body" style="padding:20px 20px 4px">
+      <div id="cfg-mode-bar" style="display:flex;background:var(--gray-1);border-radius:10px;padding:3px;gap:3px;margin-bottom:16px">
+        <button class="cfg-mode-btn active" data-cfg-mode="config" id="cfg-newtab" style="flex:1;padding:10px 6px;border:none;border-radius:8px;background:var(--white);font:700 13px 'Manrope',sans-serif;color:var(--dark);box-shadow:0 1px 4px rgba(0,0,0,0.10);cursor:pointer">New SKU</button>
+        <button class="cfg-mode-btn" data-cfg-mode="alias" id="cfg-aliastab" style="flex:1;padding:10px 6px;border:none;border-radius:8px;background:none;font:700 13px 'Manrope',sans-serif;color:var(--gray-4);cursor:pointer">Map to existing</button>
+        <button class="cfg-mode-btn" data-cfg-mode="box" id="cfg-boxtab" style="flex:1;padding:10px 6px;border:none;border-radius:8px;background:none;font:700 13px 'Manrope',sans-serif;color:var(--gray-4);cursor:pointer">Box mapping</button>
+      </div>
+
+      <div id="cfg-config-panel">
+        <label id="cfg-lbl-batch" style="font:700 14px 'Manrope',sans-serif;color:var(--dark);display:block;margin-bottom:8px">
+          Pretzels per batch
+        </label>
+        <input type="number" id="cfg-batch-size" min="1"
+          placeholder="e.g. 48"
+          style="width:100%;padding:14px;border:1.5px solid var(--gray-2);border-radius:10px;margin-bottom:14px">
+
+        <label id="cfg-lbl-tray" style="font:700 14px 'Manrope',sans-serif;color:var(--dark);display:block;margin-bottom:6px">
+          Pretzels per tray <span style="font-weight:400;color:var(--gray-3)">(BFP step size, optional)</span>
+        </label>
+        <input type="number" id="cfg-tray-size" min="0"
+          placeholder="e.g. 9"
+          style="width:100%;padding:14px;border:1.5px solid var(--gray-2);border-radius:10px;margin-bottom:14px">
+
+        <label id="cfg-lbl-case" style="font:700 14px 'Manrope',sans-serif;color:var(--dark);display:block;margin-bottom:6px">
+          Pretzels per case <span style="font-weight:400;color:var(--gray-3)">(BFP wholesale unit, optional)</span>
+        </label>
+        <input type="number" id="cfg-case-size" min="0"
+          placeholder="e.g. 52"
+          style="width:100%;padding:14px;border:1.5px solid var(--gray-2);border-radius:10px;margin-bottom:20px">
+
+        <div id="cfg-lbl-type" style="font:700 14px 'Manrope',sans-serif;color:var(--dark);margin-bottom:10px">Production type</div>
+        <button class="cfg-type-btn selected" data-cfg-type="standard" id="cfg-btn-std">Standard pretzel</button>
+        <button class="cfg-type-btn" data-cfg-type="coating" id="cfg-btn-coat">+ Coating step (BBK / Spicy Bee)</button>
+        <button class="cfg-type-btn" data-cfg-type="foh" id="cfg-btn-foh">Front of house only — don't schedule</button>
+      </div>
+
+      <div id="cfg-alias-panel" style="display:none">
+        <p id="cfg-alias-help" style="font:400 13px 'Manrope',sans-serif;color:var(--gray-4);margin-bottom:12px">
+          Map this SKU name to an existing canonical SKU. All deliveries using this name will be redirected.
+        </p>
+        <label id="cfg-alias-lbl" style="font:700 14px 'Manrope',sans-serif;color:var(--dark);display:block;margin-bottom:8px">
+          Map to canonical SKU
+        </label>
+        <select id="cfg-alias-target" class="extra-sku-select" style="margin-bottom:8px"></select>
+      </div>
+
+      <div id="cfg-box-panel" style="display:none">
+        <p id="cfg-box-help" style="font:400 13px 'Manrope',sans-serif;color:var(--gray-4);margin-bottom:12px">
+          A catering box that contains multiple of one or more pretzel/dip SKUs. Each line below adds units of a real SKU when an order includes 1× this box.
+        </p>
+        <div id="cfg-box-rows" style="display:flex;flex-direction:column;gap:8px;margin-bottom:8px"></div>
+        <button class="btn-secondary" id="cfg-box-add-row" type="button" style="width:100%;padding:10px;background:none;border:1.5px dashed var(--gray-2);border-radius:10px;color:var(--gray-4);font:700 13px 'Manrope',sans-serif;cursor:pointer;margin-bottom:12px">+ Add a SKU to this box</button>
+        <p style="font:400 12px 'Manrope',sans-serif;color:var(--gray-3);margin:0">
+          Example: <em>Catering: Honey Mustard Dip Box</em> → 12 × <em>honey mustard dip</em>.
+        </p>
       </div>
     </div>
-
-    <!-- SCAN VIEW -->
-    <div id="scan-view" hidden>
-      <div class="active-batch-card card">
-        <div class="active-batch-meta">
-          <div>
-            <div class="active-batch-label" data-i18n="labelBatchCode">Batch Code</div>
-            <div class="active-batch-code" id="active-code">—</div>
-            <div class="active-batch-sub" id="active-sub"></div>
-          </div>
-          <button class="btn-done" id="finish-batch-btn" data-i18n="done">✓ Done</button>
-        </div>
-      </div>
-
-      <div class="card" style="margin-top:16px;">
-        <label class="scan-label" data-i18n="labelScan">Scan Ingredient</label>
-        <div class="search-wrap">
-          <input id="barcode-input" type="text" autocomplete="off" spellcheck="false" disabled
-                 data-i18n-placeholder="scanPlaceholder">
-          <button id="scan-btn" disabled data-i18n="logBtn">Log</button>
-        </div>
-        <p class="scan-hint" data-i18n="scanHint">Press Enter to log ingredient</p>
-      </div>
-
-      <div id="scanned-list" class="scanned-list"></div>
+    <div class="sheet-footer">
+      <button class="btn-primary" id="cfg-save">Save</button>
+      <button class="btn-secondary" id="cfg-cancel">Cancel</button>
     </div>
-
   </div>
-</section>
-
-<section class="section-dark">
-  <div class="max-1100">
-    <h2 data-i18n="historyTitle">Batch History</h2>
-
-    <div class="history-filters card card-dark">
-      <div class="filter-row">
-        <input type="text" id="filter-batch" data-i18n-placeholder="filterBatch">
-        <input type="text" id="filter-barcode" data-i18n-placeholder="filterBarcode">
-        <input type="date" id="filter-date-from">
-        <input type="date" id="filter-date-to">
-        <select id="filter-product">
-          <option value="" data-i18n-option="filterProduct">All products</option>
-        </select>
-        <button class="btn-filter-clear" id="filter-clear" data-i18n="clearFilters">Clear</button>
-      </div>
-    </div>
-
-    <div id="history-status" class="history-status" data-i18n="loading">Loading…</div>
-    <div id="history-results" hidden></div>
-  </div>
-</section>
-
-<div id="toast" class="toast" hidden></div>
+</div>
 
 <script type="module">
   import { fetchLog, appendLog } from '../../scripts/sheet-logger.js';
+  import {
+    BATCH_SIZES, CASE_SIZES, TRAY_SIZES, FOH_SKUS, BAKE_GROUPS,
+    DOUGH_AGE_WARN_DAYS, DOUGH_AGE_FAIL_DAYS,
+    CHEESE_BATCH_SIZE, CHEESE_KEY, CHEESE_MAX_LEAD,
+    DIP_CONFIG, DEFAULT_BOX_EXPANSIONS,
+    makeSkuMeta,
+    resolveDeliveries, resolveProductionLogs,
+    getInventoryReport, attributeDeliveryCoverage,
+    scheduleCheese, scheduleDip,
+    isShapeOnlyDelivery,
+  } from '../../scripts/inventory.js?v=2026-05-12-drift-fixes-plus-audit';
 
-  const PRODUCTION_PATH = '/dangpretz/production';
-  const RECEIVING_PATH  = '/dangpretz/receiving';
+  // Shape-only catering + box expansion. ENABLED BY DEFAULT — catering
+  // boxes (Catering: ...) and FOH Placeholder deliveries skip BFP and
+  // count dough as ready (FOH bakes them fresh at fulfillment).
+  // Override per-device with ?shapeonly=0 (sticky via localStorage) if
+  // an issue surfaces. ?shapeonly=1 force-enables (clears any prior
+  // 'off' override).
+  const SHAPE_ONLY_ENABLED = (() => {
+    try {
+      const url = new URLSearchParams(window.location.search).get('shapeonly');
+      if (url === '1' || url === 'on') localStorage.removeItem('shapeOnly2026');
+      else if (url === '0' || url === 'off') localStorage.setItem('shapeOnly2026', 'off');
+      return localStorage.getItem('shapeOnly2026') !== 'off';
+    } catch (_) { return true; }
+  })();
 
-  const PRODUCTS = [
-    { code: 'PBB10', name: 'Baseball Bats',       nameEs: 'Bates de béisbol' },
-    { code: 'PVM10', name: 'Mustache',             nameEs: 'Bigote' },
-    { code: 'PPM20', name: 'Mammoth',              nameEs: 'Mamut' },
-    { code: 'PPL10', name: 'Plain 10oz',           nameEs: 'Plain 10oz' },
-    { code: 'PPL07', name: 'Plain 7oz',            nameEs: 'Plain 7oz' },
-    { code: 'TPL04', name: 'Plain Twist',          nameEs: 'Twist Plain' },
-    { code: 'PGP10', name: 'BBK 10oz',             nameEs: 'BBK 10oz' },
-    { code: 'PGP07', name: 'BBK 7oz',              nameEs: 'BBK 7oz' },
-    { code: 'TGP04', name: 'BBK Twist',            nameEs: 'BBK Twist' },
-    { code: 'PSB10', name: 'Spicy Bee 10oz',       nameEs: 'Abeja Picante 10oz' },
-    { code: 'PSB07', name: 'Spicy Bee 7oz',        nameEs: 'Abeja Picante 7oz' },
-    { code: 'TSB04', name: 'Spicy Bee Twist',      nameEs: 'Abeja Picante Twist' },
-    { code: 'PDD07', name: "Devil's Delight 7oz",  nameEs: 'Deleite del Diablo 7oz' },
-    { code: 'PBL07', name: 'Bootlegger 7oz',       nameEs: 'Bootlegger 7oz' },
-    { code: 'BPL01', name: 'Plain Bombs',          nameEs: 'Bombas Plain' },
-    { code: 'DDC03', name: 'Dangerous Dip',        nameEs: 'Dip Peligroso' },
+  // FOH dip consumption — single Square scan returns dailyAvg for cheese
+  // + 4 retail dips. Fetched on load; rate is stable across hours.
+  const DIP_CONSUMPTION_URL = 'https://dpc-catering-checkout.drew-f39.workers.dev/dip-consumption?days=28';
+  // Per-dip dailyAvg keyed by canonical SKU (DIP_CONFIG keys). Cheese kept
+  // as cheeseFohDailyAvg too for legacy callers; will be removed once all
+  // call sites migrate.
+  let dipDailyAvgs = {};
+  let cheeseFohDailyAvg = 0;
+
+  // ╔══════════════════════════════════════════════════════════════════════════╗
+  // ║ ARCHITECTURE                                                             ║
+  // ╠══════════════════════════════════════════════════════════════════════════╣
+  // ║                                                                          ║
+  // ║  RAW LOGS  (Google Sheets via sheet-logger)                              ║
+  // ║   ├── delivery-planner: create/update/confirm/status/delete/barcodes     ║
+  // ║   └── production:       inventory/shape_done/bfp_done/                   ║
+  // ║                         sku_config/sku_alias/workers_config              ║
+  // ║                                                                          ║
+  // ║  RESOLUTION  (one-time per page load)                                    ║
+  // ║   ├── resolveDeliveries     → allDeliveries[] (status, _confirmedAt)     ║
+  // ║   └── resolveProductionLogs → productionState (per-date) + skuConfig     ║
+  // ║                              + skuAliases + productionLogs (raw, kept    ║
+  // ║                              for timestamp-precise inventory math)       ║
+  // ║                                                                          ║
+  // ║  PURE DERIVATIONS  (run on every render)                                 ║
+  // ║   ├── getInventoryReport()  → SINGLE SOURCE OF TRUTH for inventory       ║
+  // ║   │   { effective, doughQueue, flowsSinceSnapshot, alerts, snapshot }    ║
+  // ║   ├── buildOptimalSchedule  → schedule.{shape, bfp, overdue, ...}        ║
+  // ║   └── buildWorkerItems      → per-day per-SKU display items              ║
+  // ║                                                                          ║
+  // ║  RENDER                                                                  ║
+  // ║   ├── renderTeamCard / renderWorkerDayView / renderWorkerCard            ║
+  // ║   ├── renderStockTab        (forecast, inputs, "delivered since" labels) ║
+  // ║   └── banners               (overdue, aging dough, unconfigured, etc.)   ║
+  // ║                                                                          ║
+  // ║ INVARIANTS                                                               ║
+  // ║                                                                          ║
+  // ║  1. ALL inventory questions go through getInventoryReport().             ║
+  // ║     If you find yourself reading getLatestInventory() or computing       ║
+  // ║     "raw frozen − delivered" anywhere outside that function, STOP —      ║
+  // ║     route through getInventoryReport() instead.                          ║
+  // ║                                                                          ║
+  // ║  2. Demand for a delivery = qty − inventory_attributed_FIFO. Computed    ║
+  // ║     once inside buildOptimalSchedule, using report.effective. Don't      ║
+  // ║     re-derive it elsewhere.                                              ║
+  // ║                                                                          ║
+  // ║  3. Daily capacity = workers × BATCHES_PER_WORKER − completions logged   ║
+  // ║     on that day. The −completions is what stops the scheduler from      ║
+  // ║     pulling more work onto today as the team finishes batches.           ║
+  // ║                                                                          ║
+  // ║  4. Display target = needBatches + madeBatches per card (workload).      ║
+  // ║     Sum across cards = team's day-total workload. Spare = cap − sum.     ║
+  // ║     Stable denominator: as work happens, need ↓ and made ↑, sum fixed.   ║
+  // ║                                                                          ║
+  // ║ INVENTORY LEDGER (events after snapshot timestamp)                       ║
+  // ║                                                                          ║
+  // ║   shape_done +N  → cf += N×bs (also appended to dough age queue)         ║
+  // ║   bfp_done   +N  → cf -= N×bs (cap 0, FIFO from oldest)                  ║
+  // ║                  → fr += N×bs                                            ║
+  // ║   delivery confirmed → fr -= delivery qty (cap 0)                        ║
+  // ║                                                                          ║
+  // ║ Snapshot establishes a checkpoint. All flows since are layered on top.   ║
+  // ║ Same-day events use timestamp comparison (not date), so a mid-day count  ║
+  // ║ correctly excludes pre-count events while crediting post-count ones.     ║
+  // ╚══════════════════════════════════════════════════════════════════════════╝
+
+  // ─── CONFIG ───────────────────────────────────────────────────────────────
+
+  const DELIVERY_LOG   = '/dangpretz/delivery-planner';
+  const PRODUCTION_LOG = '/dangpretz/production';
+
+  // BATCH_SIZES, CASE_SIZES, TRAY_SIZES, FOH_SKUS, BAKE_GROUPS imported from shared module.
+
+  // ─── RUNTIME SKU HELPERS ─────────────────────────────────────────────────
+  // skuConfig (loaded from log) overrides/extends hardcoded BATCH_SIZES.
+
+  const getBatchSize    = sku => (skuConfig[sku]?.batchSize > 0 ? skuConfig[sku].batchSize : 0) || BATCH_SIZES[sku] || 0;
+  const getTraySize     = sku => (skuConfig[sku]?.traySize > 0 ? skuConfig[sku].traySize : 0) || TRAY_SIZES[sku] || 0;
+  const getCaseSize     = sku => (skuConfig[sku]?.caseSize > 0 ? skuConfig[sku].caseSize : 0) || CASE_SIZES[sku] || 0;
+  const isFOH           = sku => skuConfig[sku] ? skuConfig[sku].type === 'foh' : FOH_SKUS.has(sku.toLowerCase()) || FOH_SKUS.has(sku);
+  const isCoating       = sku => skuConfig[sku] ? skuConfig[sku].type === 'coating' : BAKE_GROUPS.coating.includes(sku);
+  // Lifecycle-less SKUs: tracked production but no dough → bake → freeze
+  // pipeline. Snapshot stock counts go into a third `onHand` bucket instead
+  // of the `frozen` bucket. Phase 3a hardcodes; Phase 3b moves to DIP_CONFIG.
+  const LIFECYCLELESS_SKUS = new Set([
+    '3oz cheese dip',
+    'bulk dangerous dip (25 srv)',
+    // Retail + catering-portion dips (DIP_CONFIG entries) — produced in
+    // batches but no dough/bake lifecycle, so stock is a single on-hand
+    // count. Catering boxes (Dangerous Dip Box, Swell Cream Box) expand
+    // to these same SKUs so we don't need separate "portion" SKUs.
+    'hot ranch dip',
+    'sweet cream dip',
+    'house mustard dip',
+    'honey mustard dip',
+  ]);
+  // FOH bakes/sells these SKUs in-store. When FOH pulls trays from the
+  // wholesale walk-in to stock their speed rack, the Dough section logs a
+  // foh_transfer for each. Subset matches "all 6.5oz + bombs" — bats
+  // included because they're bomb-shape and likely pulled together. Tune
+  // here if FOH ever bakes a 10oz line in-store.
+  const FOH_DOUGH_SKUS = [
+    '6.5oz plain',
+    '6.5oz bbk',
+    '6.5oz spicy bee',
+    'plain bombs',
+    'bees bats',
   ];
+  // Per-SKU stripe color (worker view) — regex priority. Returns CSS color string.
+  const getStripeColor = (sku) => {
+    const s = (sku || '').toLowerCase();
+    if (/^catering:/i.test(sku) || /catering/i.test(s))  return '#5F5E5A';
+    if (/spicy/.test(s))                                  return '#A32D2D';
+    if (/bees|honey/.test(s))                             return '#EF9F27';
+    if (/bbk/.test(s))                                    return '#633806';
+    if (/mammoth/.test(s))                                return '#854F0B';
+    if (/mustache/.test(s))                               return '#D85A30';
+    if (/twist/.test(s))                                  return '#985E26';
+    if (/plain|bombs/.test(s))                            return '#BA7517';
+    return '#5F5E5A';
+  };
 
-  // ── i18n ──────────────────────────────────────────────────────────────────────
-  const STRINGS = {
+  // Step size for the inline +/- logger:
+  //   shape: full batch (workers shape whole batches)
+  //   bfp:   tray if configured, else falls back to batch
+  const getStepDelta = (type, sku) => {
+    if (type === 'bfp') {
+      const ts = getTraySize(sku);
+      if (ts > 0) return ts;
+    }
+    return getBatchSize(sku);
+  };
+  // All production SKUs (hardcoded + in-app configured, excluding FOH)
+  const allProductionSkus = () => [...new Set([
+    ...Object.keys(BATCH_SIZES),
+    ...Object.keys(skuConfig).filter(s => !isFOH(s) && getBatchSize(s) > 0),
+  ])];
+
+  // ─── BUSINESS RULES ───────────────────────────────────────────────────────
+  // Edit these to match operational reality. Each is a single source of truth
+  // for the rule it represents — no other place hardcodes these numbers.
+  const BATCHES_PER_WORKER  = 5;   // batches per worker per day (cap)
+  const SHAPE_MIN_LEAD      = 2;   // shape must happen at least N days before delivery
+  const SHAPE_MAX_LEAD      = 7;   // shape can happen up to N days before delivery
+  const BFP_MIN_LEAD        = 1;   // BFP must happen at least N days before delivery
+  const BFP_MAX_LEAD        = 3;   // BFP can happen up to N days before delivery
+  const SCHEDULE_LOOKAHEAD  = 14;  // days of deliveries the scheduler scans
+  const FORECAST_LOOKAHEAD  = 7;   // days the Stock-tab forecast looks ahead
+  // DOUGH_AGE_WARN_DAYS, DOUGH_AGE_FAIL_DAYS imported from shared module.
+
+  // ─── STATE ────────────────────────────────────────────────────────────────
+
+  let deliveryLogs    = []; // raw delivery log rows — resolved on demand so skuConfig (loaded in parallel) can drive box expansion
+  let allDeliveries   = [];
+  let allSkus         = []; // master list from delivery-planner/skus.json
+  let productionState = {};
+  let productionLogs  = []; // raw production log rows — kept for timestamp-precise effective inventory
+  let skuConfig       = {}; // { sku: { batchSize, type } } — from sku_config log entries
+  let skuAliases      = {}; // { oldSku: canonicalSku } — from sku_alias log entries
+  let packedCases     = {}; // {deliveryId: {sku: {caseIndex: {packed, ts}}}} — from case_packed log entries
+  let latestInventoryTs = null; // ISO timestamp of latest inventory snapshot
+  let schedule        = { shape: {}, bfp: {}, overdue: [], foh: [], unconfigured: [] };
+  let currentDate     = new Date();
+  let viewMode        = 'day';
+
+  let extraType = null, extraDate = null;
+  // extraValuePretzels = current pretzel count in the extra sheet's input (not batches)
+  let extraValuePretzels = 0;
+
+  // ─── i18n ─────────────────────────────────────────────────────────────────
+  // Language source of truth (priority): ?lang= URL param > localStorage >
+  // worker-role default (Spanish, since BOH workers are mostly Spanish-first) >
+  // browser locale > 'en'
+  const _urlSearch    = new URLSearchParams(window.location.search);
+  const _langParam    = _urlSearch.get('lang');
+  const _roleParamRaw = _urlSearch.get('role');
+  const _isWorkerView = _roleParamRaw === 'shape' || _roleParamRaw === 'bfp';
+  const _langStored   = (() => { try { return localStorage.getItem('prod-lang'); } catch { return null; } })();
+  const _langBrowser  = (navigator.language || '').toLowerCase().startsWith('es') ? 'es' : 'en';
+  let appLang = ['en','es'].includes(_langParam)  ? _langParam
+              : ['en','es'].includes(_langStored) ? _langStored
+              : _isWorkerView ? 'es'
+              : _langBrowser;
+
+  const I18N = {
     en: {
-      hero: 'PRODUCTION.',
-      labelProduct: 'Product',
-      selectProduct: 'Select a product…',
-      labelDate: 'Date',
-      labelBatchCode: 'Batch Code',
-      startBatch: 'Start Batch',
-      labelScan: 'Scan Ingredient',
-      scanPlaceholder: 'Scan or type a barcode…',
-      logBtn: 'Log',
-      scanHint: 'Press Enter to log ingredient',
-      done: '✓ Done',
-      historyTitle: 'Batch History',
-      filterBatch: 'Batch code…',
-      filterBarcode: 'Ingredient barcode…',
-      filterProduct: 'All products',
-      clearFilters: 'Clear',
-      loading: 'Loading…',
-      noResults: 'No batches found.',
-      unknown: 'Unknown barcode',
-      ingredients: 'ingredients',
+      // Tabs / titles
+      shape_card:     'Shape & Cold Ferment',
+      bfp_card:       'Bake · Freeze · Pack',
+      shape_tab:      'Shape',
+      bfp_tab:        'BFP',
+      stock_tab:      'Stock',
+      // Status
+      must_do_today:  '🔴 Must do today',
+      pulling_ahead:  '🟡 Pulling ahead',
+      overdue:        '🚨 Overdue',
+      overdue_today:  '🚨 Overdue — do today',
+      done:           '✅ Done',
+      not_started:    'Not started',
+      no_orders:      'No orders',
+      // Workers
+      workers:        'Workers',
+      batch_capacity: ({n}) => `${n} batch capacity`,
+      worker_cap:     ({w, c}) => `${w} worker${w !== 1 ? 's' : ''} · ${c} batch cap`,
+      // Production
+      pretzels_today: ({p, b, bs, hasCases, cases, cs}) =>
+        `<strong>${p}</strong> pretzels left today <span style="color:var(--gray-3);font-weight:600">(${b} ${b !== 1 ? 'batches' : 'batch'} of ${bs}${hasCases ? ` · ~${cases} ${cases !== 1 ? 'cases' : 'case'} of ${cs}` : ''})</span>`,
+      pretzels_today_trays: ({p, t, ts, hasCases, cases, cs}) =>
+        `<strong>${p}</strong> pretzels left today <span style="color:var(--gray-3);font-weight:600">(${t} ${t !== 1 ? 'trays' : 'tray'} of ${ts}${hasCases ? ` · ~${cases} ${cases !== 1 ? 'cases' : 'case'} of ${cs}` : ''})</span>`,
+      pretzels_today_only: ({p, hasCases, cases, cs}) =>
+        `<strong>${p}</strong> pretzels left today${hasCases ? ` <span style="color:var(--gray-3);font-weight:600">(~${cases} ${cases !== 1 ? 'cases' : 'case'} of ${cs})</span>` : ''}`,
+      batches_today_lead: ({b, p}) =>
+        `<strong>${b}</strong> ${b !== 1 ? 'batches' : 'batch'} left today <span style="color:var(--gray-3);font-weight:600">(${p} pretzels)</span>`,
+      prior_done: ({n, date}) => `↪ ${n} ${n !== 1 ? 'batches' : 'batch'} already done${date ? ' on ' + date : ''}`,
+      prior_done_trays: ({n, date}) => `↪ ${n} ${n !== 1 ? 'trays' : 'tray'} already done${date ? ' on ' + date : ''}`,
+      prior_done_pretzels: ({n, date}) => `↪ ${n} pretzels already done${date ? ' on ' + date : ''}`,
+      pretzels_made:  'pretzels made today',
+      total_today_pretzels: ({p, b}) => `${p} pretzels today (${b} batch${b !== 1 ? 'es' : ''})`,
+      total_today_batches:  ({b, p}) => `${b} batches today (${p} pretzels)`,
+      total_pretzels_label: ({b}) => `pretzels today (${b} batch${b !== 1 ? 'es' : ''})`,
+      total_batches_label:  ({p}) => `batches today (${p} pretzels)`,
+      spare:          ({n}) => `✅ ${n} spare`,
+      over:           ({n}) => `🔴 +${n} over`,
+      for_delivery:   ({date}) => `For ${date}`,
+      logged_today:   'Logged today',
+      // Inventory
+      dough_label:    'dough',
+      frozen_label:   'frozen',
+      tray_of:        ({n}) => `tray of ${n}`,
+      batch_of:       ({n}) => `batch of ${n}`,
+      made_sub_shape: ({made, total, b, unit}) => `${made} of ${total} ${total !== 1 ? 'batches' : 'batch'} · +/- = ${unit}`,
+      made_sub_bfp:   ({mc, tc, hasCases, unit}) => `${hasCases ? `~${mc} of ~${tc} ${tc !== 1 ? 'cases' : 'case'} · ` : ''}+/- = ${unit}`,
+      // Buttons
+      add_unsched:    '+ Add Unscheduled Batch',
+      save_stock:     'Save Stock Count',
+      save:           'Save',
+      cancel:         'Cancel',
+      // Empty states
+      nothing_today:  'Nothing scheduled today.',
+      all_clear:      'All clear — nothing assigned to you today.',
+      nothing_for:    ({team}) => `Nothing for ${team} today.`,
+      check_other:    ({team}) => `Check the ${team} tab.`,
+      no_prod_extra:  'All upcoming orders covered, or no deliveries within production windows.',
+      // Alerts
+      overdue_title:  ({n}) => `🚨 ${n} overdue — production window${n > 1 ? 's have' : ' has'} closed`,
+      shape_label:    'Shape',
+      bfp_label:      'BFP',
+      new_sku:        ({sku}) => `⚠️ New SKU in orders: <strong>${sku}</strong>`,
+      set_up:         'Set up →',
+      unconfirmed:    ({n}) => `📦 ${n} delivery${n !== 1 ? 'ies' : 'y'} today not yet confirmed — `,
+      go_to_planner:  'Go to planner →',
+      dup_alert:      ({n}) => `⚠️ ${n} possible duplicate delivery${n > 1 ? 's' : ''} — `,
+      review_planner: 'Review →',
+      // Stock tab
+      stock_title:    'Stock Count',
+      last_count:     ({d}) => `Last count: ${d}`,
+      no_count_yet:   'No count saved yet',
+      reduced_for:    ({n}) => ` · ${n} SKU${n > 1 ? 's' : ''} reduced for deliveries since count`,
+      sku_col:        'SKU',
+      dough_col:      '🧊 Dough',
+      frozen_col:     '❄️ Frozen / 📦 On hand',
+      since_today:    'today',
+      since_yest:     'since yesterday',
+      since_date:     ({d}) => `since ${d}`,
+      delivered:      ({n, w, when}) => `−${n} delivered ${when} (was ${w})`,
+      forecast_window:({n}) => `Next ${n} days`,
+      summary_short:  ({n, p}) => `🔴 ${n} SKU${n !== 1 ? 's' : ''} short — need ${p} more`,
+      summary_surplus:({n, p}) => `🟢 ${n} SKU${n !== 1 ? 's' : ''} covered with surplus (${p} extra)`,
+      summary_none:   ({n}) => `⚪ ${n} SKU${n !== 1 ? 's' : ''} with no upcoming orders`,
+      no_skus_cfg:    'No production SKUs configured.',
+      fc_short:       ({d, p, n, c}) => `🔴 ${d}d need ${p} · stock ${n} · short ${c.text}`,
+      fc_tight:       ({d, p, n, net}) => `🟡 ${d}d need ${p} · stock ${n} · just enough (+${net})`,
+      fc_surplus:     ({d, p, n, c}) => `🟢 ${d}d need ${p} · stock ${n} · surplus +${c.text}`,
+      fc_none:        ({n}) => `⚪ no upcoming orders · stock ${n}`,
+      cases_paren:    ({n, c}) => ` (~${n} ${n !== 1 ? 'cases' : 'case'})`,
+      // Configure SKU
+      cfg_title:      'Configure SKU',
+      cfg_per_batch:  'Pretzels per batch',
+      cfg_per_tray:   'Pretzels per tray',
+      cfg_per_tray_sub: '(BFP step size, optional)',
+      cfg_per_case:   'Pretzels per case',
+      cfg_per_case_sub: '(BFP wholesale unit, optional)',
+      cfg_type:       'Production type',
+      cfg_standard:   'Standard pretzel',
+      cfg_coating:    '+ Coating step (BBK / Spicy Bee)',
+      cfg_foh:        "Front of house only — don't schedule",
+      cfg_new_tab:    'New SKU',
+      cfg_alias_tab:  'Map to existing',
+      cfg_alias_help: 'Map this SKU name to an existing canonical SKU. All deliveries using this name will be redirected.',
+      cfg_alias_label:'Map to canonical SKU',
+      // Add unscheduled
+      extra_title:    'Add Unscheduled Batch',
+      extra_sub:      'Last-minute order or walk-in',
+      extra_batches:  'Pretzels',
+      extra_save:     'Save Batch',
+      // Week view
+      no_prod_lookahead: ({n}) => `No production scheduled in the next ${n} days.`,
+      this_week:      'This week',
+      next_week:      'Next week',
+      today_label:    'Today',
+      tomorrow_label: 'Tomorrow',
+      yesterday_label:'Yesterday',
+      week_view:      'Week View',
+      next_n_days:    ({n}) => `Next ${n} days`,
+      days_away:      ({n}) => `${n} days away`,
+      days_ago:       ({n}) => `${n} days ago`,
+      no_prod_day:    'no production',
+      // Misc
+      foh_only:       ({list}) => `FOH only (not scheduled): ${list}`,
+      tomorrow_pending:({n}) => `${n} batch${n !== 1 ? 'es' : ''} scheduled tomorrow — earliest item not yet in production window`,
+      // Phase A — UIUX redesign keys
+      header_shape_team: 'Shape Team',
+      header_bfp_team:   'BFP Team',
+      section_pending:   'PENDING TODAY',
+      section_progress:  'IN PROGRESS',
+      section_done:      'DONE',
+      pill_overdue:      'Overdue',
+      pill_pending:      'Pending',
+      pill_progress:     'In progress',
+      pill_done:         'Done',
+      metric_tandas:     'BATCHES',
+      metric_trays:      'TRAYS',
+      metric_pretzels:   'PRETZELS',
+      stepper_count:     ({n, total}) => `${n} / ${total} batches`,
+      stepper_count_trays: ({n, total}) => `${n} / ${total} trays`,
+      stepper_count_pretzels: ({n, total}) => `${n} / ${total} pretzels`,
+      helper_tap_batch:  ({n}) => `1 tap = 1 batch · ${n} pretzels`,
+      helper_tap_tray:   ({n}) => `1 tap = 1 tray · ${n} pretzels`,
+      done_summary:      ({n, total, p}) => `${n}/${total} batches · ${p} pretzels · completed`,
+      done_summary_trays: ({n, total, p}) => `${n}/${total} trays · ${p} pretzels · completed`,
+      done_summary_pretzels: ({p}) => `${p} pretzels · completed`,
+      details_link:      'Details',
+      details_raw:       'Raw materials',
+      details_for_delivery: 'For delivery',
+      walkin_unknown:    'Ask Drew to add this variety',
+      celebrate_title:   '🎉 Day complete!',
+      celebrate_sub:     'Good work. You can close the app.',
+      meter_summary:     ({m, total, p, ptotal}) => `${m} of ${total} batches done · ${p} / ${ptotal} pretzels`,
+      cheese_chip:       '🧀 cheese topping while baking',
+      ahead_note:        ({n}) => `Ahead of schedule · ${n} already frozen`,
+      capacity_extra:    ({n}) => `${n} extra batches scheduled`,
     },
     es: {
-      hero: 'PRODUCCIÓN.',
-      labelProduct: 'Producto',
-      selectProduct: 'Seleccionar producto…',
-      labelDate: 'Fecha',
-      labelBatchCode: 'Código de Lote',
-      startBatch: 'Iniciar Lote',
-      labelScan: 'Escanear Ingrediente',
-      scanPlaceholder: 'Escanear o escribir código de barras…',
-      logBtn: 'Registrar',
-      scanHint: 'Presiona Enter para registrar ingrediente',
-      done: '✓ Listo',
-      historyTitle: 'Historial de Lotes',
-      filterBatch: 'Código de lote…',
-      filterBarcode: 'Código de barras…',
-      filterProduct: 'Todos los productos',
-      clearFilters: 'Limpiar',
-      loading: 'Cargando…',
-      noResults: 'No se encontraron lotes.',
-      unknown: 'Código desconocido',
-      ingredients: 'ingredientes',
+      shape_card:     'Formar y fermentar',
+      bfp_card:       'Hornear · Congelar · Empacar',
+      shape_tab:      'Formar',
+      bfp_tab:        'HCE',
+      stock_tab:      'Inventario',
+      must_do_today:  '🔴 Hacer hoy',
+      pulling_ahead:  '🟡 Adelantado',
+      overdue:        '🚨 Atrasado',
+      overdue_today:  '🚨 Atrasado — hacer hoy',
+      done:           '✅ Listo',
+      not_started:    'Sin empezar',
+      no_orders:      'Sin pedidos',
+      workers:        'Trabajadores',
+      batch_capacity: ({n}) => `${n} tandas de capacidad`,
+      worker_cap:     ({w, c}) => `${w} trabajador${w !== 1 ? 'es' : ''} · ${c} tandas máx`,
+      pretzels_today: ({p, b, bs, hasCases, cases, cs}) =>
+        `<strong>${p}</strong> pretzels pendientes hoy <span style="color:var(--gray-3);font-weight:600">(${b} ${b !== 1 ? 'tandas' : 'tanda'} de ${bs}${hasCases ? ` · ~${cases} ${cases !== 1 ? 'cajas' : 'caja'} de ${cs}` : ''})</span>`,
+      pretzels_today_trays: ({p, t, ts, hasCases, cases, cs}) =>
+        `<strong>${p}</strong> pretzels pendientes hoy <span style="color:var(--gray-3);font-weight:600">(${t} ${t !== 1 ? 'bandejas' : 'bandeja'} de ${ts}${hasCases ? ` · ~${cases} ${cases !== 1 ? 'cajas' : 'caja'} de ${cs}` : ''})</span>`,
+      pretzels_today_only: ({p, hasCases, cases, cs}) =>
+        `<strong>${p}</strong> pretzels pendientes hoy${hasCases ? ` <span style="color:var(--gray-3);font-weight:600">(~${cases} ${cases !== 1 ? 'cajas' : 'caja'} de ${cs})</span>` : ''}`,
+      batches_today_lead: ({b, p}) =>
+        `<strong>${b}</strong> ${b !== 1 ? 'tandas' : 'tanda'} pendiente${b !== 1 ? 's' : ''} hoy <span style="color:var(--gray-3);font-weight:600">(${p} pretzels)</span>`,
+      prior_done: ({n, date}) => `↪ ${n} ${n !== 1 ? 'tandas' : 'tanda'} ya ${n !== 1 ? 'hechas' : 'hecha'}${date ? ' el ' + date : ''}`,
+      prior_done_trays: ({n, date}) => `↪ ${n} ${n !== 1 ? 'bandejas ya hechas' : 'bandeja ya hecha'}${date ? ' el ' + date : ''}`,
+      prior_done_pretzels: ({n, date}) => `↪ ${n} pretzels ya hechos${date ? ' el ' + date : ''}`,
+      pretzels_made:  'pretzels hechos hoy',
+      total_today_pretzels: ({p, b}) => `${p} pretzels hoy (${b} ${b !== 1 ? 'tandas' : 'tanda'})`,
+      total_today_batches:  ({b, p}) => `${b} ${b !== 1 ? 'tandas' : 'tanda'} hoy (${p} pretzels)`,
+      total_pretzels_label: ({b}) => `pretzels hoy (${b} ${b !== 1 ? 'tandas' : 'tanda'})`,
+      total_batches_label:  ({p}) => `${p > 1 ? 'tandas' : 'tanda'} hoy (${p} pretzels)`,
+      spare:          ({n}) => `✅ ${n} de sobra`,
+      over:           ({n}) => `🔴 +${n} de más`,
+      for_delivery:   ({date}) => `Para entrega del ${date}`,
+      logged_today:   'Registrado hoy',
+      dough_label:    'masa',
+      frozen_label:   'congelado',
+      tray_of:        ({n}) => `bandeja de ${n}`,
+      batch_of:       ({n}) => `tanda de ${n}`,
+      made_sub_shape: ({made, total, b, unit}) => `${made} de ${total} ${total !== 1 ? 'tandas' : 'tanda'} · +/- = ${unit}`,
+      made_sub_bfp:   ({mc, tc, hasCases, unit}) => `${hasCases ? `~${mc} de ~${tc} ${tc !== 1 ? 'cajas' : 'caja'} · ` : ''}+/- = ${unit}`,
+      add_unsched:    '+ Agregar tanda extra',
+      save_stock:     'Guardar inventario',
+      save:           'Guardar',
+      cancel:         'Cancelar',
+      nothing_today:  'Nada programado hoy.',
+      all_clear:      'Todo listo — nada asignado para hoy.',
+      nothing_for:    ({team}) => `Nada para ${team} hoy.`,
+      check_other:    ({team}) => `Revisa la pestaña de ${team}.`,
+      no_prod_extra:  'Todos los pedidos cubiertos o sin entregas en ventana de producción.',
+      overdue_title:  ({n}) => `🚨 ${n} atrasado${n > 1 ? 's' : ''} — ventana de producción cerrada`,
+      shape_label:    'Formar',
+      bfp_label:      'HCE',
+      new_sku:        ({sku}) => `⚠️ Producto nuevo en pedidos: <strong>${sku}</strong>`,
+      set_up:         'Configurar →',
+      unconfirmed:    ({n}) => `📦 ${n} entrega${n !== 1 ? 's' : ''} sin confirmar — `,
+      go_to_planner:  'Abrir planificador →',
+      dup_alert:      ({n}) => `⚠️ ${n} posible duplicado${n > 1 ? 's' : ''} — `,
+      review_planner: 'Revisar →',
+      stock_title:    'Conteo de inventario',
+      last_count:     ({d}) => `Último conteo: ${d}`,
+      no_count_yet:   'Sin conteo guardado',
+      reduced_for:    ({n}) => ` · ${n} producto${n > 1 ? 's' : ''} reducido${n > 1 ? 's' : ''} por entregas`,
+      sku_col:        'Producto',
+      dough_col:      '🧊 Masa',
+      frozen_col:     '❄️ Congelado / 📦 Inventario',
+      since_today:    'hoy',
+      since_yest:     'desde ayer',
+      since_date:     ({d}) => `desde ${d}`,
+      delivered:      ({n, w, when}) => `−${n} entregados ${when} (eran ${w})`,
+      forecast_window:({n}) => `Próximos ${n} días`,
+      summary_short:  ({n, p}) => `🔴 Faltan ${p} pretzels · ${n} producto${n !== 1 ? 's' : ''}`,
+      summary_surplus:({n, p}) => `🟢 ${n} producto${n !== 1 ? 's' : ''} con sobrante (+${p})`,
+      summary_none:   ({n}) => `⚪ ${n} producto${n !== 1 ? 's' : ''} sin pedidos próximos`,
+      no_skus_cfg:    'Sin productos de producción configurados.',
+      fc_short:       ({d, p, n, c}) => `🔴 ${d}d necesitas ${p} · inv ${n} · faltan ${c.text}`,
+      fc_tight:       ({d, p, n, net}) => `🟡 ${d}d necesitas ${p} · inv ${n} · justo (+${net})`,
+      fc_surplus:     ({d, p, n, c}) => `🟢 ${d}d necesitas ${p} · inv ${n} · sobran +${c.text}`,
+      fc_none:        ({n}) => `⚪ sin pedidos próximos · inv ${n}`,
+      cases_paren:    ({n, c}) => ` (~${n} ${n !== 1 ? 'cajas' : 'caja'})`,
+      cfg_title:      'Configurar producto',
+      cfg_per_batch:  'Pretzels por tanda',
+      cfg_per_tray:   'Pretzels por bandeja',
+      cfg_per_tray_sub: '(tamaño de paso HCE, opcional)',
+      cfg_per_case:   'Pretzels por caja',
+      cfg_per_case_sub: '(unidad mayorista HCE, opcional)',
+      cfg_type:       'Tipo de producción',
+      cfg_standard:   'Pretzel estándar',
+      cfg_coating:    '+ Con cobertura (BBK / Spicy Bee)',
+      cfg_foh:        'Solo mostrador — no programar',
+      cfg_new_tab:    'Producto nuevo',
+      cfg_alias_tab:  'Mapear a existente',
+      cfg_alias_help: 'Mapea este nombre a un producto existente. Las entregas con este nombre se redirigirán.',
+      cfg_alias_label:'Mapear al producto canónico',
+      extra_title:    'Agregar tanda extra',
+      extra_sub:      'Pedido de último momento',
+      extra_batches:  'Pretzels',
+      extra_save:     'Guardar tanda',
+      no_prod_lookahead: ({n}) => `Sin producción en los próximos ${n} días.`,
+      this_week:      'Esta semana',
+      next_week:      'Próxima semana',
+      today_label:    'Hoy',
+      tomorrow_label: 'Mañana',
+      yesterday_label:'Ayer',
+      week_view:      'Vista semanal',
+      next_n_days:    ({n}) => `Próximos ${n} días`,
+      days_away:      ({n}) => `en ${n} día${n !== 1 ? 's' : ''}`,
+      days_ago:       ({n}) => `hace ${n} día${n !== 1 ? 's' : ''}`,
+      no_prod_day:    'sin producción',
+      foh_only:       ({list}) => `Solo mostrador (no programado): ${list}`,
+      tomorrow_pending:({n}) => `${n} ${n !== 1 ? 'tandas' : 'tanda'} programada${n !== 1 ? 's' : ''} mañana — fuera de ventana hoy`,
+      // Phase A — UIUX redesign keys
+      header_shape_team: 'Equipo de Masa',
+      header_bfp_team:   'Equipo HCE',
+      section_pending:   'PENDIENTE HOY',
+      section_progress:  'EN PROGRESO',
+      section_done:      'LISTO',
+      pill_overdue:      'Atrasado',
+      pill_pending:      'Pendiente',
+      pill_progress:     'En progreso',
+      pill_done:         'Listo',
+      metric_tandas:     'TANDAS',
+      metric_trays:      'BANDEJAS',
+      metric_pretzels:   'PRETZELS',
+      stepper_count:     ({n, total}) => `${n} / ${total} tandas`,
+      stepper_count_trays: ({n, total}) => `${n} / ${total} bandejas`,
+      stepper_count_pretzels: ({n, total}) => `${n} / ${total} pretzels`,
+      helper_tap_batch:  ({n}) => `1 toque = 1 tanda · ${n} pretzels`,
+      helper_tap_tray:   ({n}) => `1 toque = 1 bandeja · ${n} pretzels`,
+      done_summary:      ({n, total, p}) => `${n}/${total} tandas · ${p} pretzels · completado`,
+      done_summary_trays: ({n, total, p}) => `${n}/${total} bandejas · ${p} pretzels · completado`,
+      done_summary_pretzels: ({p}) => `${p} pretzels · completado`,
+      details_link:      'Detalles',
+      details_raw:       'Materia prima',
+      details_for_delivery: 'Para entrega',
+      walkin_unknown:    'Pídele a Drew que añada esta variedad',
+      celebrate_title:   '🎉 ¡Día completado!',
+      celebrate_sub:     'Buen trabajo. Ya puedes cerrar la app.',
+      meter_summary:     ({m, total, p, ptotal}) => `${m} de ${total} tandas hechas · ${p} / ${ptotal} pretzels`,
+      cheese_chip:       '🧀 cubrir con queso al hornear',
+      ahead_note:        ({n}) => `Adelantado · ya hay ${n} congelados`,
+      capacity_extra:    ({n}) => `${n} ${n !== 1 ? 'tandas' : 'tanda'} extra programada${n !== 1 ? 's' : ''}`,
     },
   };
 
-  let lang = localStorage.getItem('prod-lang') || 'en';
-  let prodLogs = [];
-  let receivingLogs = [];
-  let batchMap = new Map(); // batchCode → { meta, ingredients: [] }
-  let activeBatch = null;   // { batchCode, productCode, productName, date }
-  let scanDebounceTimer = null;
+  const t = (key, params) => {
+    const entry = (I18N[appLang] && I18N[appLang][key]) ?? I18N.en[key] ?? key;
+    return typeof entry === 'function' ? entry(params || {}) : entry;
+  };
+  const _localeStr = () => appLang === 'es' ? 'es-MX' : 'en-US';
 
-  // ── Utilities ─────────────────────────────────────────────────────────────────
-  function escapeHtml(s) {
-    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  // Batch counts can be fractional from typed pretzel inputs (e.g., 47 pretzels
+  // in a batch of 72 = 0.65 batches). Round to whole when very close, else
+  // show 1 decimal — pretzels remain the precise truth in the display.
+  const fmtBatches = (n) => {
+    if (n == null || isNaN(n)) return '0';
+    const rounded = Math.round(n);
+    if (Math.abs(n - rounded) < 0.05) return String(rounded);
+    return (Math.round(n * 10) / 10).toFixed(1);
+  };
+
+  // Role from ?role=shape | ?role=bfp | ?role=foh | (default = manager).
+  // Used to scope the UI so each team only sees their own surface:
+  //   shape → only Shape tab
+  //   bfp   → only BFP tab
+  //   foh   → only Dips (Cheese tab) + Stock tabs — FOH manages dip
+  //           production and on-hand counts; doesn't touch shape/BFP.
+  // Normalize to lowercase so ?role=FOH / ?role=Shape / etc. all work the
+  // same. Unknown values fall through to 'manager'.
+  const _roleParam = (new URLSearchParams(window.location.search).get('role') || '').toLowerCase().trim();
+  const userRole   = _roleParam === 'shape' ? 'shape'
+                  : _roleParam === 'bfp'   ? 'bfp'
+                  : _roleParam === 'foh'   ? 'foh'
+                  : 'manager';
+  if (userRole === 'shape')      document.title = appLang === 'es' ? 'Formar · Producción' : 'Shape · Production';
+  else if (userRole === 'bfp')   document.title = appLang === 'es' ? 'HCE · Producción'    : 'BFP · Production';
+  else if (userRole === 'foh')   document.title = appLang === 'es' ? 'FOH · Salsas'        : 'FOH · Dips';
+  else                            document.title = appLang === 'es' ? 'Producción' : 'Production';
+
+  // Set body class for role-aware CSS hiding (handled in stylesheet).
+  // Worker views (shape/bfp) get their own simplified header — no floating
+  // corner pill anymore (replaced by the inline header text).
+  if (userRole !== 'manager') {
+    const setBody = () => {
+      document.body.classList.add('role-worker', `role-${userRole}`);
+      const wh = document.getElementById('worker-header');
+      if (wh) wh.style.display = 'flex';
+    };
+    if (document.body) setBody();
+    else document.addEventListener('DOMContentLoaded', setBody);
   }
 
-  function showToast(msg, type = '') {
-    const el = document.getElementById('toast');
-    el.textContent = msg;
-    el.className = 'toast' + (type ? ' ' + type : '');
-    el.hidden = false;
-    clearTimeout(el._timer);
-    el._timer = setTimeout(() => { el.classList.add('fade'); setTimeout(() => { el.hidden = true; el.classList.remove('fade'); }, 400); }, 2500);
-  }
+  let dayTab = userRole === 'bfp' ? 'bfp'
+             : userRole === 'foh' ? 'foh-home' // single-screen view: Dips + Dough on one page
+             : 'shape'; // 'shape' | 'bfp' | 'stock' | 'cheese' | 'foh-home' (visibility per role rules)
 
-  function todayStr() {
-    return new Date().toISOString().slice(0, 10);
-  }
+  // Inline logging state
+  // loggedPretzels[type][dateStr][sku] = current pretzel count (local, mid-edit)
+  // lastSavedPretzels = same shape, snapshot of what's been persisted
+  // saveTimers[key] = pending debounce timeout id
+  let loggedPretzels    = {};
+  let lastSavedPretzels = {};
+  const saveTimers      = {};
+  const SAVE_DEBOUNCE_MS = 1000;
 
-  function fmtDate(dateStr) {
-    if (!dateStr) return '—';
-    const [y, m, d] = dateStr.split('-');
-    return `${m}/${d}/${y}`;
-  }
+  // ─── DATE HELPERS ─────────────────────────────────────────────────────────
 
-  function fmtTime(iso) {
-    if (!iso) return '';
-    const d = new Date(iso);
-    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  }
+  const DAYS   = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+  const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 
-  // ── i18n ──────────────────────────────────────────────────────────────────────
-  function applyStrings() {
-    const S = STRINGS[lang];
-    document.querySelectorAll('[data-i18n]').forEach((el) => {
-      const key = el.dataset.i18n;
-      if (S[key] !== undefined) el.textContent = S[key];
+  // Date string in production's local time (America/Denver), not UTC. Workers
+  // shaping at 9pm Mountain (= 3am UTC) should still get the LOCAL day, not
+  // tomorrow's UTC day. en-CA locale gives ISO-style YYYY-MM-DD output.
+  const toDateStr   = d => d.toLocaleDateString('en-CA', { timeZone: 'America/Denver' });
+  const parseDate   = s => { const [y,m,d] = s.split('-').map(Number); return new Date(y, m-1, d); };
+  const addDays     = (d, n) => { const r = new Date(d); r.setDate(r.getDate() + n); return r; };
+  const daysBetween = (a, b) => Math.round((parseDate(b) - parseDate(a)) / 86400000);
+  const fmtShort    = d => d.toLocaleDateString(_localeStr(), { month: 'short', day: 'numeric' });
+  const fmtFull     = d => d.toLocaleDateString(_localeStr(), { weekday: 'short', month: 'short', day: 'numeric' });
+  const fmtDay      = d => d.toLocaleDateString(_localeStr(), { weekday: 'short' });
+  const esc         = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+
+  // ─── RESOLVE DELIVERIES ───────────────────────────────────────────────────
+
+  // resolveDeliveries and resolveProductionLogs imported from shared module
+  // (../../scripts/inventory.js). The shared resolveProductionLogs returns
+  // an object — this module unpacks it in loadProduction().
+
+  // ─── WORKER PERSISTENCE ───────────────────────────────────────────────────
+
+  // Worker count: prefer the synced value from the production log so all
+  // devices (manager + Shape tablet + BFP tablet) see the same daily capacity.
+  // Falls back to per-device localStorage (legacy + offline edits).
+  const getWorkers = (type, date) => {
+    const fromLog = (productionState[date] || {})[type === 'shape' ? 'shapeWorkers' : 'bfpWorkers'];
+    if (fromLog && fromLog > 0) return Math.max(1, fromLog);
+    return Math.max(1, parseInt(localStorage.getItem(`prod-${type}-workers-${date}`), 10) || 1);
+  };
+  // saveWorkers updates THREE things:
+  //   1. productionState in-memory  (so the next getWorkers/render() call sees
+  //      the new value immediately — getWorkers prefers log-derived state over
+  //      localStorage, so without this the UI shows the stale value until the
+  //      next loadProduction)
+  //   2. localStorage              (per-device fallback + offline)
+  //   3. production log            (synced across devices, fire-and-forget)
+  const saveWorkers = (type, date, n) => {
+    const v = Math.max(1, n);
+    if (!productionState[date]) productionState[date] = {};
+    productionState[date][type === 'shape' ? 'shapeWorkers' : 'bfpWorkers'] = v;
+    localStorage.setItem(`prod-${type}-workers-${date}`, String(v));
+    appendLog(PRODUCTION_LOG, {
+      action:    'workers_config',
+      type,
+      date,
+      workers:   String(v),
+      timeStamp: new Date().toISOString(),
+    }).catch((e) => console.error('workers_config save failed:', e));
+  };
+
+  // ─── INVENTORY REPORT ─────────────────────────────────────────────────────
+  // The heavy lifting now lives in /scripts/inventory.js so the planner can
+  // share it. These thin wrappers feed module-scope state into the pure
+  // helpers exported there.
+
+  /**
+   * SINGLE SOURCE OF TRUTH for all inventory state. Calls the shared
+   * implementation with this module's loaded state.
+   *
+   * @returns full inventory report (see /scripts/inventory.js for the shape).
+   */
+  function getInventoryReportLocal() {
+    return getInventoryReport({
+      productionLogs,
+      productionState,
+      allDeliveries,
+      skuAliases,
+      latestInventoryTs,
+      getBatchSize,
+      getTraySize,
     });
-    document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
-      const key = el.dataset.i18nPlaceholder;
-      if (S[key] !== undefined) el.placeholder = S[key];
+  }
+
+  function getEffectiveInventory() {
+    return getInventoryReportLocal().effective;
+  }
+
+  // ─── BUILD OPTIMAL SCHEDULE ───────────────────────────────────────────────
+
+  /**
+   * Greedy rolling-window scheduler. Runs on every data load.
+   *
+   * **Pipeline**
+   * 1. Collect demand per SKU per delivery date from active deliveries.
+   * 2. Subtract `getInventoryReport().effective` FIFO — frozen reduces both
+   *    shape and bfp demand (already shaped + baked); cold-ferment reduces
+   *    only shape demand.
+   * 3. Pool consolidation: ceil per SKU once (avoids per-delivery rounding
+   *    inflation), then distribute back to deliveries FIFO.
+   * 4. Force overdue items (window already closed) to today's slot, daysLeft=0.
+   * 5. `schedulePool` walks day-by-day, placing must-do items first then
+   *    backfilling capacity with earlier-window items if room remains.
+   *
+   * **Priority** (within a day)
+   * 1. `daysLeft === 0` — must-do today (window closes today or already closed)
+   * 2. `daysLeft ASC` — most urgent next
+   * 3. `runSize DESC` — consolidate large runs into earlier days
+   * 4. `deliveryDate ASC` — break ties FIFO
+   *
+   * **Capacity policy**
+   * - `effectiveCap = max(remainingCap, mustDoTotal)` where
+   *   `remainingCap = max(0, workers × BATCHES_PER_WORKER − completionsToday)`.
+   * - Must-do always fits (over-cap warning fires for legitimate deadline clusters).
+   * - Backfill respects the day's actual remaining hours.
+   *
+   * **BFP-only constraints**
+   * - Same-day shape→BFP: per business decision, NO hard guard. Manager
+   *   manages timing physically (4–6h gap). Today's effective cf is treated
+   *   as available for today's BFP.
+   * - Cross-day: `ctx.shapeSchedule[yesterday]` adds yesterday's planned shape
+   *   output to today's dough balance (1-day cold-ferment minimum).
+   *
+   * @returns {{
+   *   shape: Object<string, Array<Object>>,
+   *   bfp: Object<string, Array<Object>>,
+   *   overdue: Array<{team: string, sku: string, batches: number, windowEnd: string, deliveryDate: string}>,
+   *   foh: Array<string>,
+   *   unconfigured: Array<string>
+   * }}
+   */
+  function buildOptimalSchedule() {
+    const today    = new Date();
+    const todayStr = toDateStr(today);
+
+    // Step 1: Collect all pending demand across the lookahead window
+    // bySkuItems: sku -> [{deliveryDate, batches, pretzels, shapeWindow, bfpWindow, orders, shapeLeft, bfpLeft}]
+    const bySkuItems    = {};
+    const fohSeen       = new Set();
+    const unconfigured  = new Set();
+
+    for (let i = 0; i <= SCHEDULE_LOOKAHEAD; i++) {
+      const delivDate = toDateStr(addDays(today, i));
+      const dd        = parseDate(delivDate);
+      const skuMap    = {};
+
+      allDeliveries
+        .filter(d => d.date === delivDate && !['delivered','picked_up','cancelled'].includes(d.status))
+        .forEach(delivery => {
+          let items = [];
+          try { items = JSON.parse(delivery.lineItems || '[]'); } catch {}
+          // Shape-only deliveries (catering boxes, FOH Placeholder) don't go
+          // through BFP — FOH bakes them fresh from dough at fulfillment.
+          const isShapeOnly = !!delivery._shapeOnly;
+          items.forEach(({ sku, quantity }) => {
+            if (!sku) return;
+            let key = sku.trim();
+            if (skuAliases[key]) key = skuAliases[key]; // resolve old → canonical name
+            if (isFOH(key)) { fohSeen.add(key); return; }
+            if (key === CHEESE_KEY) return; // cheese has its own pipeline (Cheese tab); shape/BFP teams don't make it
+            if (!skuMap[key]) skuMap[key] = { shapePretzels: 0, bfpPretzels: 0, orders: [] };
+            const q = Number(quantity) || 0;
+            skuMap[key].shapePretzels += q;
+            if (!isShapeOnly) skuMap[key].bfpPretzels += q;
+            const cust = delivery.customer || delivery.location || '?';
+            if (!skuMap[key].orders.includes(cust)) skuMap[key].orders.push(cust);
+          });
+        });
+
+      Object.entries(skuMap).forEach(([sku, data]) => {
+        const batchSize = getBatchSize(sku);
+        if (!batchSize) { unconfigured.add(sku); return; } // flag for warning UI
+        if (!bySkuItems[sku]) bySkuItems[sku] = [];
+        // Track demand in PRETZELS (shapeLeftP, bfpLeftP) so we can pool by SKU
+        // before ceiling — prevents per-delivery rounding from inflating batches.
+        // For shape-only deliveries (catering, FOH Placeholder), bfpLeftP < shapeLeftP
+        // — we shape the dough but skip BFP since FOH bakes fresh.
+        bySkuItems[sku].push({
+          sku, pretzels: data.shapePretzels, deliveryDate: delivDate,
+          orders: data.orders,
+          shapeWindow: { start: toDateStr(addDays(dd, -SHAPE_MAX_LEAD)), end: toDateStr(addDays(dd, -SHAPE_MIN_LEAD)) },
+          bfpWindow:   { start: toDateStr(addDays(dd, -BFP_MAX_LEAD)),   end: toDateStr(addDays(dd, -BFP_MIN_LEAD))   },
+          shapeLeftP: data.shapePretzels, // remaining pretzel demand for shape
+          bfpLeftP:   data.bfpPretzels,   // remaining pretzel demand for BFP (zero for shape-only deliveries)
+          shapeLeft:  0,             // batches (filled in after pooling)
+          bfpLeft:    0,
+          batches:    0,             // display batch count (filled in after pooling)
+        });
+      });
+    }
+
+    // Sort each SKU's items by delivery date (FIFO for inventory + completion attribution)
+    Object.values(bySkuItems).forEach(arr => arr.sort((a,b) => a.deliveryDate.localeCompare(b.deliveryDate)));
+
+    // Step 2: Subtract effective inventory from per-delivery demand.
+    //
+    // Effective inventory = snapshot + flows since snapshot:
+    //   coldFerment_now = snapshot.cf + shape_done - bfp_done
+    //   frozen_now      = snapshot.frozen + bfp_done - delivered
+    //
+    // This is the SAME state the user sees in "Raw materials" (getEffectiveInventory).
+    // Using it here means a single source of truth: scheduler demand and displayed
+    // inventory always agree. It also fixes the bees-bats class of bug — bfp_done
+    // produces frozen pretzels that cover BOTH shape and bfp demand for future
+    // deliveries, not just today's BFP work. The previous "subtract shape_done from
+    // shape demand, subtract bfp_done from bfp demand" treated the two flows as
+    // parallel when they're actually sequential (shape→bfp→frozen→delivered).
+    const latestInv = getEffectiveInventory();
+
+    // Frozen runs first: finished pretzels in freezer satisfy BOTH shape and BFP
+    // demand (they're already shaped AND baked).
+    Object.entries(latestInv.frozen).forEach(([sku, pretzels]) => {
+      if (!bySkuItems[sku] || !getBatchSize(sku)) return;
+      let leftP = pretzels;
+      for (const item of bySkuItems[sku]) {
+        const take = Math.min(item.bfpLeftP, leftP);
+        item.bfpLeftP   -= take;
+        item.shapeLeftP  = Math.max(0, item.shapeLeftP - take); // frozen also covers shape
+        leftP           -= take;
+        if (leftP <= 0) break;
+      }
     });
-    // Update product select options with translated names
-    const sel = document.getElementById('product-select');
-    if (sel) {
-      const current = sel.value;
-      sel.innerHTML = `<option value="">${S.selectProduct}</option>` +
-        PRODUCTS.map((p) => `<option value="${p.code}">${lang === 'es' ? p.nameEs : p.name}</option>`).join('');
-      sel.value = current;
-    }
-    // Update filter product options
-    const fsel = document.getElementById('filter-product');
-    if (fsel) {
-      const cur = fsel.value;
-      fsel.innerHTML = `<option value="">${S.filterProduct}</option>` +
-        PRODUCTS.map((p) => `<option value="${p.code}">${lang === 'es' ? p.nameEs : p.name}</option>`).join('');
-      fsel.value = cur;
-    }
-    // Active/inactive toggle buttons
-    document.getElementById('lang-en').classList.toggle('active', lang === 'en');
-    document.getElementById('lang-es').classList.toggle('active', lang === 'es');
-  }
 
-  // ── Batch code helpers ────────────────────────────────────────────────────────
-  function dateToParts(dateStr) {
-    return dateStr.replace(/-/g, ''); // '2026-05-19' → '20260519'
-  }
+    // Cold-ferment runs second: shaped dough only satisfies shape demand.
+    Object.entries(latestInv.coldFerment).forEach(([sku, pretzels]) => {
+      if (!bySkuItems[sku] || !getBatchSize(sku)) return;
+      let leftP = pretzels;
+      for (const item of bySkuItems[sku]) {
+        const take = Math.min(item.shapeLeftP, leftP);
+        item.shapeLeftP -= take; leftP -= take;
+        if (leftP <= 0) break;
+      }
+    });
 
-  function computeNextCounter(productCode, date) {
-    const count = prodLogs.filter(
-      (r) => r.action === 'create_batch' && r.productCode === productCode && r.date === date,
-    ).length;
-    return String(count + 1).padStart(2, '0');
-  }
+    // Pool remaining pretzel demand per SKU, ceil ONCE to get total batches needed,
+    // then distribute back to deliveries FIFO. This prevents the per-delivery ceiling
+    // from inflating batch counts when one batch could cover multiple deliveries.
+    Object.entries(bySkuItems).forEach(([sku, arr]) => {
+      const bs = getBatchSize(sku);
+      if (!bs) return;
 
-  function buildCode(productCode, date) {
-    const counter = computeNextCounter(productCode, date);
-    return productCode + dateToParts(date) + counter;
-  }
-
-  // ── Code preview (live update) ─────────────────────────────────────────────
-  function updateCodePreview() {
-    const code = document.getElementById('product-select').value;
-    const date = document.getElementById('batch-date').value;
-    const wrap = document.getElementById('code-preview-wrap');
-    const preview = document.getElementById('code-preview');
-    const btn = document.getElementById('start-batch-btn');
-    if (code && date) {
-      preview.textContent = buildCode(code, date);
-      wrap.hidden = false;
-      btn.disabled = false;
-    } else {
-      wrap.hidden = true;
-      btn.disabled = true;
-    }
-  }
-
-  // ── Barcode resolution ────────────────────────────────────────────────────────
-  function resolveBarcode(barcode) {
-    // Search receiving logs most-recent-first for matching barcode
-    for (let i = receivingLogs.length - 1; i >= 0; i--) {
-      const r = receivingLogs[i];
-      if (r.barcode === barcode && r.productName) return r.productName;
-    }
-    return '';
-  }
-
-  // ── Build batch map from logs ─────────────────────────────────────────────────
-  function buildBatchMap(logs) {
-    const map = new Map();
-    for (const r of logs) {
-      if (r.action === 'create_batch') {
-        map.set(r.batchCode, { meta: r, ingredients: [] });
-      } else if (r.action === 'batch_ingredient') {
-        if (map.has(r.batchCode)) {
-          map.get(r.batchCode).ingredients.push(r);
-        } else {
-          // orphaned ingredient (batch created in earlier session) — create stub
-          map.set(r.batchCode, { meta: { batchCode: r.batchCode, productName: '—', date: '' }, ingredients: [r] });
+      const distribute = (leftField, batchField) => {
+        const totalP = arr.reduce((s, i) => s + Math.max(0, i[leftField]), 0);
+        let remaining = Math.ceil(totalP / bs); // single ceil for the entire SKU
+        // Allocate FIFO by delivery date (arr already sorted ascending)
+        arr.forEach(item => {
+          if (item[leftField] <= 0 || remaining <= 0) { item[batchField] = 0; return; }
+          const need = Math.ceil(item[leftField] / bs);
+          item[batchField] = Math.min(need, remaining);
+          remaining -= item[batchField];
+        });
+        // Any leftover (rounding slack) goes to the last delivery with positive demand
+        if (remaining > 0) {
+          for (let i = arr.length - 1; i >= 0; i--) {
+            if (arr[i][leftField] > 0) { arr[i][batchField] += remaining; break; }
+          }
         }
+      };
+
+      distribute('shapeLeftP', 'shapeLeft');
+      distribute('bfpLeftP',   'bfpLeft');
+
+      // Set display batches as max(shape, bfp) per delivery so the card shows the
+      // right batch count regardless of which team is viewing
+      arr.forEach(item => { item.batches = Math.max(item.shapeLeft, item.bfpLeft); });
+    });
+
+    // Build pools — overdue items are forced into today's window so they
+    // appear on today's schedule (with isOverdue flag) AND in the alert banner
+    const overdue = [];
+    const shapePool = [], bfpPool = [];
+    Object.values(bySkuItems).flat().forEach(item => {
+      if (item.shapeLeft > 0) {
+        const closed = item.shapeWindow.end < todayStr;
+        if (closed) overdue.push({ team: 'shape', sku: item.sku, batches: item.shapeLeft, windowEnd: item.shapeWindow.end, deliveryDate: item.deliveryDate });
+        shapePool.push({
+          sku: item.sku, left: item.shapeLeft, deliveryDate: item.deliveryDate,
+          window: closed ? { start: todayStr, end: todayStr } : item.shapeWindow,
+          orders: item.orders, pretzels: item.pretzels,
+          isOverdue: closed,
+        });
+      }
+      if (item.bfpLeft > 0) {
+        const closed = item.bfpWindow.end < todayStr;
+        if (closed) overdue.push({ team: 'bfp', sku: item.sku, batches: item.bfpLeft, windowEnd: item.bfpWindow.end, deliveryDate: item.deliveryDate });
+        bfpPool.push({
+          sku: item.sku, left: item.bfpLeft, deliveryDate: item.deliveryDate,
+          window: closed ? { start: todayStr, end: todayStr } : item.bfpWindow,
+          orders: item.orders, pretzels: item.pretzels,
+          isOverdue: closed,
+        });
+      }
+    });
+
+    /**
+     * Greedy day-by-day allocator. Walks the pool of un-scheduled
+     * shape-or-BFP items and places each one on its earliest fit-day,
+     * subject to capacity and (for BFP) the rolling dough balance.
+     *
+     * **Capacity policy** (per day)
+     * - `remainingCap = max(0, workers × BATCHES_PER_WORKER − completionsToday)`
+     * - `effectiveCap = max(remainingCap, mustDoTotal)`
+     * - Must-do (window closes today) always fits — over-cap warning fires
+     *   for the legitimate "deadline cluster" case.
+     * - Non-must-do backfills only into actual remaining hours.
+     *
+     * **BFP-only constraints**
+     * - Same-day shape→BFP is allowed (manager manages timing physically).
+     * - `ctx.shapeSchedule[yesterday]` adds yesterday's planned shape output
+     *   to today's dough balance.
+     * - Items defer to a later day if there's no dough (overdue items
+     *   bypass — visibility takes priority over dough constraint).
+     *
+     * @param {Array<Object>} pool   per-delivery items with `left` pretzels
+     * @param {'shape'|'bfp'} type
+     * @param {{shapeSchedule: Object, initialDough: Object<string,number>}|null} ctx
+     * @returns {Object<string, Array<Object>>}  date → dayItems[]
+     */
+    function schedulePool(pool, type, ctx = null) {
+      const sched   = {};
+      const lookahead = type === 'shape'
+        ? SCHEDULE_LOOKAHEAD + SHAPE_MAX_LEAD
+        : SCHEDULE_LOOKAHEAD + BFP_MAX_LEAD;
+
+      // Per-SKU dough balance, tracked across days for BFP scheduling
+      const doughBalance = {};
+      if (type === 'bfp' && ctx) {
+        Object.entries(ctx.initialDough || {}).forEach(([sku, n]) => {
+          doughBalance[sku] = Number(n) || 0;
+        });
+      }
+
+      for (let i = 0; i < lookahead; i++) {
+        const dayStr  = toDateStr(addDays(today, i));
+        const workers  = getWorkers(type, dayStr);
+        const capacity = workers * BATCHES_PER_WORKER;
+
+        // Capacity accounts for work already completed on this day & team —
+        // those batches occupied worker time and shouldn't be backfilled
+        // again. Without this, completing a batch would just cause the
+        // scheduler to pull another non-must-do batch onto today, growing
+        // the day's total past capacity instead of leaving the worker idle
+        // (or letting the work fall to a future day).
+        const doneKey = type === 'shape' ? 'shapeDone' : 'bfpDone';
+        const madeOnDay = ((productionState[dayStr] || {})[doneKey] || [])
+          .reduce((s, c) => s + (Number(c.batches) || 0), 0);
+        const remainingCap = Math.max(0, capacity - madeOnDay);
+
+        // For BFP: at the start of each day, add yesterday's scheduled shape
+        // output to the dough balance (1-day cold-ferment minimum)
+        if (type === 'bfp' && ctx && i > 0) {
+          const yestStr = toDateStr(addDays(today, i - 1));
+          (ctx.shapeSchedule[yestStr] || []).forEach(item => {
+            const bs = getBatchSize(item.sku);
+            if (!bs) return;
+            doughBalance[item.sku] = (doughBalance[item.sku] || 0) + (item.batches * bs);
+          });
+        }
+
+        // Eligible items: window includes today and still have work left
+        const eligible = pool.filter(p =>
+          p.left > 0 && dayStr >= p.window.start && dayStr <= p.window.end
+        );
+        if (eligible.length === 0) continue;
+
+        // Compute current run sizes per SKU across remaining pool
+        const runSizes = {};
+        pool.forEach(p => { if (p.left > 0) runSizes[p.sku] = (runSizes[p.sku] || 0) + p.left; });
+
+        // Annotate and sort
+        const annotated = eligible
+          .map(p => ({ ...p, daysLeft: daysBetween(dayStr, p.window.end), runSize: runSizes[p.sku] || 0 }))
+          .sort((a, b) => {
+            if (a.daysLeft !== b.daysLeft) return a.daysLeft - b.daysLeft;  // urgent first
+            if (b.runSize  !== a.runSize)  return b.runSize  - a.runSize;   // large run first (consolidate)
+            return a.deliveryDate.localeCompare(b.deliveryDate);             // earliest delivery tiebreak
+          });
+
+        // Always fit must-do items even if over capacity. Cap is the day's
+        // REMAINING capacity (after subtracting work already done today) so
+        // backfill doesn't overload the day past its budget.
+        const mustDoTotal = annotated.filter(a => a.daysLeft === 0).reduce((s, a) => s + a.left, 0);
+        const effectiveCap = Math.max(remainingCap, mustDoTotal);
+        const isOverloaded = mustDoTotal > capacity;
+
+        let cap = effectiveCap;
+        const dayItems = [];
+
+        for (const a of annotated) {
+          if (cap <= 0) break;
+          let take = Math.min(a.left, cap);
+
+          // BFP dough constraint: cap take by available dough for this SKU
+          // (overdue items bypass — they're already a problem and need visibility)
+          if (type === 'bfp' && ctx && !a.isOverdue) {
+            const bs = getBatchSize(a.sku);
+            const doughBatches = bs > 0 ? Math.floor((doughBalance[a.sku] || 0) / bs) : 0;
+            take = Math.min(take, doughBatches);
+            if (take <= 0) continue; // no dough — defer this item to a later day
+          }
+
+          // Mutate pool item
+          const poolItem = pool.find(p => p.sku === a.sku && p.deliveryDate === a.deliveryDate);
+          if (poolItem) poolItem.left -= take;
+
+          // Decrement dough balance for BFP (capped so it never goes negative
+          // even if an overdue item bypassed the constraint)
+          if (type === 'bfp' && ctx) {
+            const bs = getBatchSize(a.sku);
+            const consumed = Math.min(take * bs, doughBalance[a.sku] || 0);
+            doughBalance[a.sku] = Math.max(0, (doughBalance[a.sku] || 0) - consumed);
+          }
+
+          // Merge same-SKU into day's item list
+          const existing = dayItems.find(d => d.sku === a.sku);
+          if (existing) {
+            existing.batches += take;
+            if (!existing.deliveryDates.includes(a.deliveryDate)) existing.deliveryDates.push(a.deliveryDate);
+            existing.urgent    = existing.urgent || a.daysLeft === 0;
+            existing.isOverdue = existing.isOverdue || !!a.isOverdue;
+            a.orders.forEach(o => { if (!existing.orders.includes(o)) existing.orders.push(o); });
+          } else {
+            dayItems.push({
+              sku: a.sku, batches: take,
+              deliveryDates: [a.deliveryDate],
+              urgent: a.daysLeft === 0,
+              overloaded: isOverloaded,
+              isOverdue: !!a.isOverdue,
+              orders: [...a.orders],
+            });
+          }
+          cap -= take;
+        }
+
+        // Sort each item's deliveryDates so the most urgent (overdue/earliest)
+        // shows first in the card label "For delivery: X + Y + Z".
+        dayItems.forEach(it => {
+          it.deliveryDates.sort((a, b) => a.localeCompare(b));
+        });
+        if (dayItems.length > 0) sched[dayStr] = dayItems;
+      }
+      return sched;
+    }
+
+    // Schedule shape FIRST so BFP can use the resulting dough timeline as a
+    // constraint on what can actually be baked each day.
+    const shapeSchedule = schedulePool(shapePool, 'shape');
+    const bfpSchedule   = schedulePool(bfpPool,   'bfp', {
+      shapeSchedule,
+      initialDough: { ...latestInv.coldFerment },
+    });
+
+    return {
+      shape:        shapeSchedule,
+      bfp:          bfpSchedule,
+      overdue,
+      foh:          [...fohSeen],
+      unconfigured: [...unconfigured],
+    };
+  }
+
+  // ─── TEAM STATUS ──────────────────────────────────────────────────────────
+
+  function getTeamStatus(type, dateStr) {
+    const items  = schedule[type][dateStr] || [];
+    const needed = items.reduce((s, d) => s + d.batches, 0);
+    if (needed === 0) return 'none';
+    const doneKey = type === 'shape' ? 'shapeDone' : 'bfpDone';
+    const done    = ((productionState[dateStr] || {})[doneKey] || [])
+      .reduce((s, c) => s + (Number(c.batches) || 0), 0);
+    if (done === 0) return 'todo';
+    if (done >= needed) return 'done';
+    return 'partial';
+  }
+
+  // ─── RENDER TEAM CARD ─────────────────────────────────────────────────────
+
+  function renderTeamCard(type, dateStr) {
+    const isBFP    = type === 'bfp';
+    const title    = isBFP ? t('bfp_card') : t('shape_card');
+    const workers  = getWorkers(type, dateStr);
+    const capacity = workers * BATCHES_PER_WORKER;
+
+    // Reuse the worker-view item builder — filters zero-net and adds bucket+priorMade
+    const items = buildWorkerItems(type, dateStr);
+
+    const totalOrig   = items.reduce((s, d) => s + d.totalBatches, 0);
+    const totalMade   = items.reduce((s, d) => s + d.madeBatches, 0);
+    const totalOrigP  = items.reduce((s, d) => s + d.origP, 0);
+    const totalMadeP  = items.reduce((s, d) => s + d.madeP, 0);
+    const isOver      = totalOrig > capacity + 0.5;
+    const spare       = Math.max(0, capacity - Math.ceil(totalOrig));
+
+    // Status badge — pretzel-based
+    let badgeClass, badgeText;
+    if (totalOrig === 0) {
+      badgeClass = 'badge-none'; badgeText = t('no_orders');
+    } else if (totalMade === 0) {
+      badgeClass = 'badge-none'; badgeText = t('not_started');
+    } else if (totalMade > totalOrig) {
+      badgeClass = 'badge-over'; badgeText = `${t('done')} +${totalMadeP - totalOrigP}`;
+    } else if (totalMade >= totalOrig) {
+      badgeClass = 'badge-done'; badgeText = t('done');
+    } else {
+      badgeClass = 'badge-partial'; badgeText = `⏳ ${totalMadeP}/${totalOrigP}`;
+    }
+
+    // Delivery dates context for header
+    const allDelivDates = [...new Set(items.flatMap(d => d.deliveryDates))].sort();
+    const delivContext = allDelivDates.length === 0 ? ''
+      : t('for_delivery', { date: allDelivDates.map(ds => fmtShort(parseDate(ds))).join(' + ') });
+
+    // Workers stepper
+    const workersHtml = `
+      <div class="workers-row">
+        <div>
+          <span class="workers-label">${t('workers')}</span>
+          <span class="workers-sub">${t('batch_capacity', { n: capacity })}</span>
+        </div>
+        <div class="stepper-inline">
+          <button class="stepper-btn" data-worker-dec data-type="${esc(type)}" data-date="${esc(dateStr)}">−</button>
+          <span class="stepper-val" id="wv-${esc(type)}-${esc(dateStr)}">${workers}</span>
+          <button class="stepper-btn" data-worker-inc data-type="${esc(type)}" data-date="${esc(dateStr)}">+</button>
+        </div>
+      </div>`;
+
+    // Group items by bucket and render each via the unified worker-card component.
+    // Status grouping replaces the old BFP "Standard / + Coating step" split — the
+    // cheese chip on each coating card already conveys the same info.
+    const groups = {
+      pending:  items.filter(d => d.bucket === 'overdue' || d.bucket === 'pending'),
+      progress: items.filter(d => d.bucket === 'progress'),
+      done:     items.filter(d => d.bucket === 'done'),
+    };
+    let skuHtml = '';
+    if (items.length === 0) {
+      skuHtml = `<div style="font:400 14px 'Manrope',sans-serif;color:var(--gray-3);padding:6px 0 12px">${t('no_prod_extra')}</div>`;
+    } else {
+      // In-progress at the top so the worker's active focus stays visible
+      // (avoids the card sliding to the bottom of a long pending list).
+      if (groups.progress.length > 0) {
+        skuHtml += `<div class="status-section-label progress">${t('section_progress')}</div>`;
+        skuHtml += groups.progress.map(d => renderWorkerCard(type, dateStr, d)).join('');
+      }
+      if (groups.pending.length > 0) {
+        skuHtml += `<div class="status-section-label pending">${t('section_pending')}</div>`;
+        skuHtml += groups.pending.map(d => renderWorkerCard(type, dateStr, d)).join('');
+      }
+      if (groups.done.length > 0) {
+        skuHtml += `<div class="status-section-label done">${t('section_done')}</div>`;
+        skuHtml += groups.done.map(d => renderWorkerCard(type, dateStr, d)).join('');
       }
     }
-    return map;
-  }
 
-  // ── Start batch ───────────────────────────────────────────────────────────────
-  async function startBatch() {
-    const productCode = document.getElementById('product-select').value;
-    const date = document.getElementById('batch-date').value;
-    if (!productCode || !date) return;
+    // Total panel — pretzel-based
+    const totalHtml = totalOrig > 0 ? `
+      <div class="batch-total ${isOver ? 'over' : 'ok'}">
+        <div class="batch-total-left">
+          <span class="batch-total-num">${totalOrigP}</span>
+          <span class="batch-total-lbl">${t('total_pretzels_label', { b: fmtBatches(totalOrig) })}</span>
+        </div>
+        <div style="text-align:right">
+          <span class="batch-status ${isOver ? 'status-over' : 'status-ok'}">
+            ${isOver ? t('over', { n: totalOrig - capacity }) : t('spare', { n: spare })}
+          </span>
+          <div class="workers-cap">${t('worker_cap', { w: workers, c: capacity })}</div>
+        </div>
+      </div>` : '';
 
-    const product = PRODUCTS.find((p) => p.code === productCode);
-    const productName = product ? product.name : productCode;
-    const counter = computeNextCounter(productCode, date);
-    const batchCode = productCode + dateToParts(date) + counter;
-
-    const btn = document.getElementById('start-batch-btn');
-    btn.disabled = true;
-    btn.textContent = '…';
-
-    try {
-      const entry = { action: 'create_batch', batchCode, productCode, productName, date, counter, timeStamp: new Date().toISOString() };
-      await appendLog(PRODUCTION_PATH, entry);
-      prodLogs.push(entry);
-      batchMap = buildBatchMap(prodLogs);
-
-      activeBatch = { batchCode, productCode, productName, date };
-      showScanView();
-      showToast(batchCode, 'success');
-    } catch (err) {
-      showToast('Failed to start batch: ' + (err.message || 'error'), 'error');
-      btn.disabled = false;
-      applyStrings();
+    // Spare-capacity hint
+    let spareHint = '';
+    if (totalOrig > 0 && !isOver && spare >= 4) {
+      const tomorrowStr = toDateStr(addDays(parseDate(dateStr), 1));
+      const tomorrowItems = schedule[type][tomorrowStr] || [];
+      const tomorrowTotal = tomorrowItems.reduce((s, d) => s + d.batches, 0);
+      if (tomorrowTotal > 0) {
+        spareHint = `<div class="foh-note" style="border-top:none;padding-top:6px;margin-top:0">
+          ${t('tomorrow_pending', { n: tomorrowTotal })}
+        </div>`;
+      }
     }
+
+    // FOH note (shape card only, once)
+    const fohHtml = (!isBFP && schedule.foh.length > 0)
+      ? `<div class="foh-note">${t('foh_only', { list: schedule.foh.map(esc).join(', ') })}</div>` : '';
+
+    // Only the "+ Add Unscheduled Batch" button remains — log completions are inline now
+    const extraBtnHtml = `<button class="log-btn-extra" data-extra-btn data-type="${esc(type)}" data-date="${esc(dateStr)}" style="margin-top:14px">${t('add_unsched')}</button>`;
+
+    return `<div class="team-card">
+      <div class="team-header">
+        <div>
+          <div class="team-name">${esc(title)}</div>
+          ${delivContext ? `<div class="team-date">${esc(delivContext)}</div>` : ''}
+        </div>
+        <span class="status-badge ${badgeClass}">${badgeText}</span>
+      </div>
+      <div class="team-body">
+        ${workersHtml}
+        ${skuHtml}
+        ${totalHtml}
+        ${spareHint}
+        ${fohHtml}
+        ${extraBtnHtml}
+      </div>
+    </div>`;
   }
 
-  // ── Show scan view ────────────────────────────────────────────────────────────
-  function showScanView() {
-    document.getElementById('start-view').hidden = true;
-    document.getElementById('scan-view').hidden = false;
-    document.getElementById('active-code').textContent = activeBatch.batchCode;
-    const product = PRODUCTS.find((p) => p.code === activeBatch.productCode);
-    const pName = product ? (lang === 'es' ? product.nameEs : product.name) : activeBatch.productName;
-    document.getElementById('active-sub').textContent = pName + ' · ' + fmtDate(activeBatch.date);
-    document.getElementById('scanned-list').innerHTML = '';
-    document.getElementById('barcode-input').disabled = false;
-    document.getElementById('scan-btn').disabled = false;
-    document.getElementById('barcode-input').focus();
+  // ─── WORKER DAY VIEW (UIUX redesign) ─────────────────────────────────────
+  // Calm, Spanish-first, status-grouped layout. See plan file for design intent.
+
+  /**
+   * Build the per-SKU item list that drives both worker and manager day views.
+   * Merges:
+   *   - what the scheduler placed for `dateStr` (`needBatches`),
+   *   - what the team has logged completed on `dateStr` (`madeBatches`),
+   *   - what's been done on prior days (priorBySku, for the "↪ already done" cue).
+   *
+   * **Display invariant**: `totalBatches = needBatches + madeBatches`.
+   * Today's target = remaining-to-do + already-done = team's workload for the
+   * day. Stable across the day (as need decreases, made grows, sum is fixed).
+   * Used as the "/N" denominator on cards AND as the basis for the team-total
+   * spare/over math, so done work correctly counts toward capacity used.
+   *
+   * @param {'shape'|'bfp'} type
+   * @param {string} dateStr  YYYY-MM-DD in Mountain TZ
+   * @returns {Array<{
+   *   sku: string, bucket: 'overdue'|'pending'|'progress'|'done',
+   *   needBatches: number, madeBatches: number, totalBatches: number,
+   *   origP: number, madeP: number,
+   *   priorMade: number, priorDate: string|null,
+   *   deliveryDates: string[], orders: string[],
+   *   urgent: boolean, isOverdue: boolean, overloaded: boolean
+   * }>}
+   */
+  function buildWorkerItems(type, dateStr) {
+    const dayState       = productionState[dateStr] || {};
+    const scheduledItems = schedule[type][dateStr] || [];
+    const doneKey        = type === 'shape' ? 'shapeDone' : 'bfpDone';
+    const completedRows  = dayState[doneKey] || [];
+
+    // Sum prior-day completions per SKU so we can show "↪ N batches already done"
+    // when work was carried over from yesterday/earlier. Per type only — Shape
+    // worker only sees Shape's prior work, BFP only BFP's.
+    const priorBySku = {};
+    const priorLatestDate = {};
+    Object.entries(productionState).forEach(([d, st]) => {
+      if (d >= dateStr) return; // past dates only
+      (st[doneKey] || []).forEach(c => {
+        const n = Number(c.batches) || 0;
+        if (!n) return;
+        priorBySku[c.sku] = (priorBySku[c.sku] || 0) + n;
+        if (!priorLatestDate[c.sku] || d > priorLatestDate[c.sku]) {
+          priorLatestDate[c.sku] = d;
+        }
+      });
+    });
+
+    const itemMap = {};
+    scheduledItems.forEach(item => {
+      itemMap[item.sku] = { ...item, needBatches: item.batches, madeBatches: 0 };
+    });
+    completedRows.forEach(c => {
+      const made = Number(c.batches) || 0;
+      // Skip net-zero entries (e.g., a +1 followed by a -1 leaves the sku
+      // in the merged log but with zero work — not actionable for today)
+      if (Math.abs(made) < 0.01 && !itemMap[c.sku]) return;
+      if (itemMap[c.sku]) {
+        itemMap[c.sku].madeBatches = made;
+      } else {
+        itemMap[c.sku] = {
+          sku: c.sku,
+          batches: 0, needBatches: 0, madeBatches: made,
+          deliveryDates: [], orders: [],
+          urgent: false, isOverdue: false, overloaded: false,
+        };
+      }
+    });
+
+    const items = Object.values(itemMap)
+      .filter(d => {
+        // Hide cards with no actionable work today AND no progress today.
+        // Prior-day work alone (e.g., yesterday finished it) doesn't justify
+        // a card on today's view — there's nothing to act on.
+        return d.needBatches > 0.01 || d.madeBatches > 0.01;
+      })
+      .map(d => {
+        const bs    = getBatchSize(d.sku);
+        // Today's TARGET (denominator on "X / Y batches" display) = the
+        // team's actual workload today = remaining work to do (needBatches,
+        // post-credit) + work already done today (madeBatches).
+        //
+        // Why workload, not max(need, made):
+        //   - max under-counts: a card with need=3 and made=2 has max=3, hiding
+        //     the 2 done batches that genuinely consumed worker time. The
+        //     team-total spare badge then claims spare capacity that doesn't
+        //     exist (the spent time is invisible to the math).
+        //   - workload = need + made stays stable across the day. As work is
+        //     logged, need decreases, made increases, the sum is fixed. This
+        //     gives the user a steady "2/5 → 3/5 → 4/5 → 5/5" progression
+        //     instead of the prior "2/3 → 3/3" denominator drop.
+        //   - Bucket detection: "done" still fires correctly. need=0 + made=N
+        //     → workload=N, made=N → done. Mid-progress (need>0) means real
+        //     work remains, so bucket stays "progress" until need actually
+        //     hits 0 (after credits absorb everything).
+        const totalBatches = d.needBatches + d.madeBatches;
+        // Round to whole pretzels — totalBatches can be FP-ish (4.6666...006)
+        // from chained reversal operations. Workers see integer counts.
+        const origP = Math.round(totalBatches * bs);
+        const madeP = Math.round(d.madeBatches * bs);
+        const priorMade = priorBySku[d.sku] || 0;
+        const priorDate = priorLatestDate[d.sku] || null;
+        let bucket;
+        if (madeP >= origP - 0.5 && origP > 0)  bucket = 'done';
+        else if (d.madeBatches > 0)              bucket = 'progress';
+        else if (d.isOverdue)                    bucket = 'overdue';
+        else                                      bucket = 'pending';
+        return { ...d, bucket, totalBatches, origP, madeP, priorMade, priorDate };
+      });
+
+    // Sort within each bucket by earliest delivery date
+    return items.sort((a, b) => {
+      const order = { overdue: 0, pending: 1, progress: 2, done: 3 };
+      if (order[a.bucket] !== order[b.bucket]) return order[a.bucket] - order[b.bucket];
+      const ad = a.deliveryDates[0] || '9999';
+      const bd = b.deliveryDates[0] || '9999';
+      return ad.localeCompare(bd);
+    });
   }
 
-  // ── Finish batch ──────────────────────────────────────────────────────────────
-  function finishBatch() {
-    activeBatch = null;
-    document.getElementById('scan-view').hidden = true;
-    document.getElementById('start-view').hidden = false;
-    document.getElementById('product-select').value = '';
-    document.getElementById('code-preview-wrap').hidden = true;
-    document.getElementById('start-batch-btn').disabled = true;
-    document.getElementById('barcode-input').disabled = true;
-    document.getElementById('scan-btn').disabled = true;
-    renderHistory();
+  // SKU card — compact "Listo" variant when complete (collapsed if not expanded).
+  // Expanded by tapping. Same DOM hooks as the full card so the stepper still wires.
+  const expandedDoneCards = new Set(); // SKU keys that are expanded despite being done
+
+  function renderWorkerCard(type, dateStr, d) {
+    const bs        = getBatchSize(d.sku);
+    const ts        = getTraySize(d.sku);
+    const stepDelta = getStepDelta(type, d.sku);
+    const stripe    = getStripeColor(d.sku);
+    const stepperKey = `${type}|${dateStr}|${d.sku}`;
+    const totalBatches = d.totalBatches;
+    const origP     = d.origP;
+    const madeP     = d.madeP;
+    const madeBatches = d.madeBatches;
+
+    // BFP team thinks in TRAYS (baking sheets). Shape thinks in BATCHES.
+    // For BFP: derive tray counts from pretzel totals (more reliable than
+    // batch math, since batch sizes can be FP-drifted from chained ops).
+    // If a BFP SKU has no traySize, fall back to pretzel-only display.
+    const isBFP    = type === 'bfp';
+    const useTrays = isBFP && ts > 0;
+    const totalUnits = useTrays
+      ? Math.ceil(origP / ts)
+      : Math.ceil(totalBatches);
+    const madeUnits = useTrays
+      ? Math.floor(madeP / ts)
+      : Math.floor(madeBatches);
+    const partialUnit = useTrays
+      ? ((madeP % ts) > 0.5 * ts && madeUnits < totalUnits)
+      : ((madeBatches % 1) > 0.1);
+    const dispMade  = useTrays ? madeUnits : fmtBatches(madeBatches);
+    const dispTotal = useTrays ? totalUnits : fmtBatches(totalBatches);
+    const metricKey = useTrays ? 'metric_trays' : 'metric_tandas';
+    const stepperKey_  = useTrays ? 'stepper_count_trays' : 'stepper_count';
+    const helperKey    = useTrays ? 'helper_tap_tray' : 'helper_tap_batch';
+
+    // Compact done card (unless user has expanded it for editing)
+    if (d.bucket === 'done' && !expandedDoneCards.has(d.sku)) {
+      const stripeStyle = `--wcard-stripe:${stripe}`;
+      const summaryKey = useTrays ? 'done_summary_trays' : 'done_summary';
+      return `<div class="wcard wcard-compact status-done" style="${stripeStyle}" data-expand-sku="${esc(d.sku)}">
+        <span class="wcard-check">✅</span>
+        <span class="wcard-compact-text"><strong>${esc(d.sku)}</strong> · ${t(summaryKey, { n: dispMade, total: dispTotal, p: madeP })}</span>
+        <span class="wcard-expand-hint">↓</span>
+      </div>`;
+    }
+
+    // Status pill
+    const pillKey = d.bucket === 'overdue' ? 'pill_overdue'
+                  : d.bucket === 'progress' ? 'pill_progress'
+                  : d.bucket === 'done'     ? 'pill_done'
+                                             : 'pill_pending';
+    const pillIcon = d.bucket === 'overdue' ? '🚨 '
+                   : d.bucket === 'progress' ? '⏳ '
+                   : d.bucket === 'done'     ? '✅ '
+                                              : '';
+
+    // Pips: one per unit (tray for BFP, batch for Shape)
+    const MAX_PIPS = 12;
+    let pipsHtml = '';
+    const pipCount = Math.max(1, Math.min(totalUnits, MAX_PIPS));
+    for (let i = 0; i < pipCount; i++) {
+      let cls = 'pip';
+      if (i < madeUnits)                                  cls += ' filled';
+      else if (i === madeUnits && partialUnit)            cls += ' partial';
+      pipsHtml += `<span class="${cls}"></span>`;
+    }
+    if (totalUnits > MAX_PIPS) {
+      pipsHtml += `<span class="pip-overflow">+${totalUnits - MAX_PIPS}</span>`;
+    }
+
+    // PRETZELS bar fill
+    const barPct = origP > 0 ? Math.min(100, Math.round((madeP / origP) * 100)) : 0;
+
+    // Helper line: ts for trays, bs for batches
+    const helper = t(helperKey, { n: useTrays ? ts : bs });
+
+    // Cheese chip for BBK SKUs
+    const cheeseChip = isCoating(d.sku) ? `<div class="wcard-cheese">${t('cheese_chip')}</div>` : '';
+
+    // Detail panel content — use effective inventory so the displayed dough/frozen
+    // reflects today's shape & BFP work and any confirmed deliveries since the
+    // last stock count, not just the raw snapshot.
+    const fullInv  = getEffectiveInventory();
+    const dough    = fullInv.coldFerment[d.sku] || 0;
+    const frozen   = fullInv.frozen[d.sku]      || 0;
+    const delivStr = d.deliveryDates.length > 0
+      ? d.deliveryDates.map(ds => `${fmtDay(parseDate(ds))} ${fmtShort(parseDate(ds))}`).join(' + ')
+      : t('logged_today');
+    const custStr  = (d.orders || []).map(esc).join(' · ');
+
+    // Status indicator (re-used for save state). Epsilon tolerance: anything
+    // within half a pretzel of the target is FP noise from chained operations.
+    const overBy = Math.round(madeP - origP);
+    const isDone    = madeP >= origP - 0.5 && origP > 0;
+    const isOverLog = overBy > 0;
+    const stepStatus = isOverLog
+      ? `<span class="wstep-status over" id="rls-${esc(type)}-${esc(d.sku)}">+${overBy}</span>`
+      : isDone
+      ? `<span class="wstep-status done" id="rls-${esc(type)}-${esc(d.sku)}">✅</span>`
+      : `<span class="wstep-status" id="rls-${esc(type)}-${esc(d.sku)}"></span>`;
+
+    // Prior-day rollover cue: only show when previous-date completions exist.
+    // For BFP, convert priorMade (in batches) to trays (priorMade*bs/ts).
+    const priorMadeUnits = useTrays
+      ? ((d.priorMade || 0) * bs) / Math.max(1, ts)
+      : (d.priorMade || 0);
+    const priorKey = useTrays ? 'prior_done_trays' : 'prior_done';
+    const priorChip = (d.priorMade || 0) > 0.01
+      ? `<div class="wcard-prior-note">${t(priorKey, {
+            n: useTrays ? Math.round(priorMadeUnits) : fmtBatches(d.priorMade),
+            date: d.priorDate ? `${fmtDay(parseDate(d.priorDate))} ${fmtShort(parseDate(d.priorDate))}` : '',
+          })}</div>`
+      : '';
+
+    // Pack list (BFP only): cases to pack for the deliveries this card
+    // contributes to. Reads case info from each line item's optional
+    // caseSize/caseCount; falls back to ceil(quantity / defaultCaseSize)
+    // for legacy line items.
+    //
+    // Pack window = bake-allocation dates ∪ TODAY. Today's deliveries
+    // always belong on the pack list — even if BFP isn't baking for them
+    // (e.g. today's order is fully covered by frozen stock). Otherwise the
+    // BFP team can't see "what's shipping right now" without flipping
+    // views.
+    let packListHtml = '';
+    const todayShipStr = (function () {
+      try {
+        return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Denver' });
+      } catch (_) {
+        return new Date().toISOString().slice(0, 10);
+      }
+    })();
+    const hasBakeDates = Array.isArray(d.deliveryDates) && d.deliveryDates.length > 0;
+    if (isBFP && hasBakeDates) {
+      const dateSet = new Set(d.deliveryDates);
+      dateSet.add(todayShipStr);
+      const packs = [];
+      allDeliveries.forEach((deliv) => {
+        if (!dateSet.has(deliv.date)) return;
+        if (['delivered','picked_up','cancelled'].includes(deliv.status)) return;
+        // Shape-only deliveries (catering boxes, FOH Placeholder) leave the
+        // pipeline at the dough stage — FOH bakes + boxes them fresh at
+        // fulfillment. BFP doesn't pack these, so they don't belong on
+        // the BFP pack list.
+        if (deliv._shapeOnly) return;
+        let items = [];
+        try { items = JSON.parse(deliv.lineItems || '[]'); } catch (_) {}
+        items.forEach((it) => {
+          let key = (it.sku || '').trim();
+          if (skuAliases[key]) key = skuAliases[key];
+          if (key !== d.sku) return;
+          const qty = Number(it.quantity) || 0;
+          if (qty <= 0) return;
+          // Use the line item's explicit case info ONLY. Falling back to
+          // ceil(qty / defaultCaseSize) produces misleading slots like
+          // "1×72" for a 15-pretzel order — reads as "one case of 72" when
+          // really it's 15 in a 72-capacity case. Without explicit case
+          // data, drop to "{qty}p" display (no slots, just the pretzel
+          // count). Manager can edit the delivery in the planner to attach
+          // case info if BFP needs to pack against it.
+          const explicitCs = Number(it.caseSize)  || 0;
+          const explicitCc = Number(it.caseCount) || 0;
+          const hasExplicitCases = explicitCs > 0 && explicitCc > 0;
+          packs.push({
+            deliveryId: deliv.deliveryId || '',
+            customer: deliv.customer || deliv.location || '?',
+            date:     deliv.date,
+            caseSize: hasExplicitCases ? explicitCs : 0,
+            caseCount: hasExplicitCases ? explicitCc : 0,
+            qty,
+          });
+        });
+      });
+      // Sort by date then customer for predictable ordering
+      packs.sort((a, b) => (a.date || '').localeCompare(b.date || '') || a.customer.localeCompare(b.customer));
+      if (packs.length > 0) {
+        const items = packs.map((p) => {
+          const dateLbl = p.date ? `${fmtDay(parseDate(p.date))} ${fmtShort(parseDate(p.date))}` : '';
+          // SKUs without standard cases (bees bats, plain bombs, cheese dip) display pretzel count instead.
+          const hasSlots = (p.caseSize > 0 && p.caseCount > 0 && p.deliveryId);
+          const countLbl = hasSlots
+            ? `${p.caseCount}×${p.caseSize}`
+            : `${p.qty}p`;
+
+          // Per-case slot buttons (checkboxes). Tap toggles the case_packed
+          // state for (deliveryId, sku, caseIndex). Only rendered when we
+          // have a discrete case structure to track.
+          let slotsHtml = '';
+          let allPacked = false;
+          if (hasSlots) {
+            const skuPacks = (packedCases[p.deliveryId] || {})[d.sku] || {};
+            let packedCount = 0;
+            const slots = [];
+            for (let i = 1; i <= p.caseCount; i++) {
+              const isPacked = !!skuPacks[i]?.packed;
+              if (isPacked) packedCount++;
+              slots.push(`<button type="button" class="pack-slot${isPacked ? ' packed' : ''}"
+                data-pack-toggle
+                data-delivery-id="${esc(p.deliveryId)}"
+                data-sku="${esc(d.sku)}"
+                data-case-size="${p.caseSize}"
+                data-case-index="${i}"
+                data-currently-packed="${isPacked ? '1' : '0'}"
+                aria-label="Case ${i} of ${p.caseCount}"
+                title="Case ${i} of ${p.caseCount}">${isPacked ? '✓' : ''}</button>`);
+            }
+            slotsHtml = `<span class="pack-slots">${slots.join('')}</span>`;
+            allPacked = packedCount >= p.caseCount;
+          }
+          const liCls = allPacked ? 'all-packed' : '';
+          return `<li class="${liCls}">
+            <span class="pack-count">${esc(countLbl)}</span>
+            <span class="pack-cust">${esc(p.customer)}</span>
+            <span class="pack-date">${esc(dateLbl)}</span>
+            ${slotsHtml}
+          </li>`;
+        }).join('');
+        const totalCases = packs.reduce((s, p) => s + (p.caseCount || 0), 0);
+        const labelTxt = appLang === 'es' ? 'Cajas a empacar' : 'Cases to pack';
+        const totalLine = totalCases > 0
+          ? ` · <strong>${totalCases}</strong>`
+          : '';
+        packListHtml = `<div class="wpack-list">
+          <div class="wpack-label">${labelTxt}${totalLine}</div>
+          <ul>${items}</ul>
+        </div>`;
+      }
+    }
+
+    return `<div class="wcard status-${d.bucket}" style="--wcard-stripe:${stripe}">
+      <div class="wcard-head">
+        <div>
+          <div class="wcard-name">${esc(d.sku)}</div>
+          ${cheeseChip}
+        </div>
+        <span class="wcard-pill ${d.bucket}">${pillIcon}${t(pillKey)}</span>
+      </div>
+      ${priorChip}
+
+      <div class="wcard-metrics">
+        <div class="wmetric">
+          <div class="wmetric-label">${t(metricKey)}</div>
+          <div class="wmetric-value"><strong>${dispMade}</strong><span class="of"> / ${dispTotal}</span></div>
+          <div class="pip-row">${pipsHtml}</div>
+        </div>
+        <div class="wmetric">
+          <div class="wmetric-label">${t('metric_pretzels')}</div>
+          <div class="wmetric-value">
+            <input type="number" class="wmetric-input" min="0" inputmode="numeric"
+                   value="${madeP}"
+                   data-log-input data-key="${esc(stepperKey)}"
+                   id="rli-${esc(type)}-${esc(d.sku)}">
+            <span class="of"> / ${origP}</span>
+          </div>
+          <div class="pbar"><div class="pbar-fill" style="width:${barPct}%"></div></div>
+        </div>
+      </div>
+
+      ${packListHtml}
+
+      <div class="wstepper">
+        <button class="wstep-btn" data-log-step data-key="${esc(stepperKey)}" data-delta="-1" ${madeP <= 0 ? 'disabled' : ''}>−</button>
+        <div class="wstep-center">${t(stepperKey_, { n: dispMade, total: dispTotal })}</div>
+        <button class="wstep-btn" data-log-step data-key="${esc(stepperKey)}" data-delta="1">+</button>
+        ${stepStatus}
+      </div>
+
+      <div class="whelper">${esc(helper)}</div>
+      <button class="wdetails-toggle" data-details-toggle data-sku="${esc(d.sku)}">ⓘ ${t('details_link')}</button>
+      <div class="wdetails-panel" id="wdp-${esc(type)}-${esc(d.sku)}" style="display:none">
+        <div>${t('details_raw')}: 🧊 ${dough} ${t('dough_label')} · ❄️ ${frozen} ${t('frozen_label')}</div>
+        <div>${t('details_for_delivery')}: ${esc(delivStr)}${custStr ? ' · ' + custStr : ''}</div>
+      </div>
+    </div>`;
   }
 
-  // ── Scan ingredient ──────────────────────────────────────────────────────────
-  async function scanIngredient() {
-    const input = document.getElementById('barcode-input');
-    const barcode = input.value.trim();
-    if (!barcode || !activeBatch) return;
+  function renderWorkerDayView(type, dateStr) {
+    const items = buildWorkerItems(type, dateStr);
 
-    const ingredientName = resolveBarcode(barcode);
-    const entry = {
-      action: 'batch_ingredient',
-      batchCode: activeBatch.batchCode,
-      barcode,
-      ingredientName,
-      timeStamp: new Date().toISOString(),
+    // Day meter: this team's totals
+    const totalBatches = items.reduce((s, d) => s + d.totalBatches, 0);
+    const madeBatches  = items.reduce((s, d) => s + d.madeBatches, 0);
+    const totalP       = items.reduce((s, d) => s + d.origP, 0);
+    const madeP        = items.reduce((s, d) => s + d.madeP, 0);
+    const meterPct     = totalP > 0 ? Math.min(100, Math.round((madeP / totalP) * 100)) : 0;
+    const meterHtml    = totalP > 0 ? `
+      <div class="wmeter">
+        <div class="wmeter-row">
+          <span><strong>${fmtBatches(madeBatches)}</strong> / ${fmtBatches(totalBatches)} ${appLang === 'es' ? 'tandas hechas' : 'batches done'}</span>
+          <span class="pretzels">${madeP} / ${totalP} pretzels</span>
+        </div>
+        <div class="wmeter-bar"><div class="wmeter-fill" style="width:${meterPct}%"></div></div>
+      </div>` : '';
+
+    // Group items by bucket
+    const groups = {
+      pending:  items.filter(d => d.bucket === 'overdue' || d.bucket === 'pending'),
+      progress: items.filter(d => d.bucket === 'progress'),
+      done:     items.filter(d => d.bucket === 'done'),
     };
 
-    // Disable during save
-    input.disabled = true;
-    document.getElementById('scan-btn').disabled = true;
+    const allDone = items.length > 0 && groups.done.length === items.length;
+    const celebrate = allDone ? `
+      <div class="celebrate-banner">
+        <div class="celebrate-banner-title">${t('celebrate_title')}</div>
+        <div class="celebrate-banner-sub">${t('celebrate_sub')}</div>
+      </div>` : '';
 
-    try {
-      await appendLog(PRODUCTION_PATH, entry);
-      prodLogs.push(entry);
-      if (batchMap.has(activeBatch.batchCode)) {
-        batchMap.get(activeBatch.batchCode).ingredients.push(entry);
+    let sectionsHtml = '';
+    // In-progress at the top (worker's active focus); pending after; done last.
+    if (groups.progress.length > 0) {
+      sectionsHtml += `<div class="status-section-label progress">${t('section_progress')}</div>`;
+      sectionsHtml += groups.progress.map(d => renderWorkerCard(type, dateStr, d)).join('');
+    }
+    if (groups.pending.length > 0) {
+      sectionsHtml += `<div class="status-section-label pending">${t('section_pending')}</div>`;
+      sectionsHtml += groups.pending.map(d => renderWorkerCard(type, dateStr, d)).join('');
+    }
+    if (groups.done.length > 0) {
+      sectionsHtml += `<div class="status-section-label done">${t('section_done')}</div>`;
+      sectionsHtml += groups.done.map(d => renderWorkerCard(type, dateStr, d)).join('');
+    }
+
+    // Walk-in button at the bottom
+    const extraBtn = `<button class="log-btn-extra" data-extra-btn data-type="${esc(type)}" data-date="${esc(dateStr)}" style="margin-top:14px">${t('add_unsched')}</button>`;
+
+    return meterHtml + celebrate + sectionsHtml + extraBtn;
+  }
+
+  // ─── RENDER DAY VIEW ──────────────────────────────────────────────────────
+
+  function renderDayView() {
+    const dateStr    = toDateStr(currentDate);
+    // FOH role has its own single-page surface (Dips + Dough on one screen)
+    // — pin it regardless of which tab the dayTab string says.
+    if (userRole === 'foh') return renderFohHome(dateStr);
+    // Stock + Cheese (Dips) tabs are visible to manager + FOH; shape/BFP get
+    // forced back to their team's home tab if they somehow land there.
+    const isAllowedStockCheese = userRole === 'manager' || userRole === 'foh';
+    if ((dayTab === 'stock' || dayTab === 'cheese') && !isAllowedStockCheese) {
+      dayTab = userRole === 'bfp' ? 'bfp' : 'shape';
+    }
+    if (dayTab === 'stock')  return renderStockTab();
+    if (dayTab === 'cheese') return renderCheeseTab(dateStr);
+
+    const type       = dayTab; // 'shape' or 'bfp'
+    const dayState   = productionState[dateStr] || {};
+    const hasShape = (schedule.shape[dateStr] || []).length > 0
+                  || (dayState.shapeDone || []).length > 0;
+    const hasBfp   = (schedule.bfp[dateStr]   || []).length > 0
+                  || (dayState.bfpDone   || []).length > 0;
+
+    if (!hasShape && !hasBfp) {
+      return `<div class="no-prod">${t('nothing_today')}<br>
+        <span style="font-size:13px;color:var(--gray-3)">${t('no_prod_extra')}</span>
+      </div>`;
+    }
+    const teamHas = type === 'shape' ? hasShape : hasBfp;
+    if (!teamHas) {
+      const teamLabel  = type === 'shape' ? t('shape_label') : t('bfp_label');
+      const otherLabel = type === 'shape' ? t('bfp_label')   : t('shape_label');
+      const hint = userRole === 'manager'
+        ? `<span style="font-size:13px;color:var(--gray-3)">${t('check_other', { team: otherLabel })}</span>`
+        : `<span style="font-size:13px;color:var(--gray-3)">${t('all_clear')}</span>`;
+      return `<div class="no-prod" style="padding:32px 20px">${t('nothing_for', { team: teamLabel })}<br>${hint}</div>`;
+    }
+    // Worker view: status-grouped sections + day meter; manager view: existing card
+    if (userRole !== 'manager') return renderWorkerDayView(type, dateStr);
+    return renderTeamCard(type, dateStr);
+  }
+
+  // ─── RENDER STOCK TAB ─────────────────────────────────────────────────────
+
+  function renderStockTab() {
+    // Single source of truth — every number on this tab routes through here.
+    const report          = getInventoryReportLocal();
+    const inv             = report.snapshot.raw;            // raw snapshot for "was X" labels only
+    const latestInvDate   = report.snapshot.date;
+    const flowDelivered   = report.flowsSinceSnapshot.delivered;
+
+    // Per-delivery coverage: which orders are already covered by current stock,
+    // which need production. Same FIFO logic as the planner's badges.
+    // Window: today through FORECAST_LOOKAHEAD days out — matches the forecast
+    // line above so the coverage list and the "7d need / stock / short" line
+    // describe the same set of deliveries. Past unconfirmed ghost orders
+    // (someone forgot to mark delivered) don't eat current inventory FIFO.
+    const todayDateStr = toDateStr(new Date());
+    const horizonStr   = toDateStr(addDays(new Date(), FORECAST_LOOKAHEAD));
+    const activeDeliveries = allDeliveries.filter(d =>
+      !['delivered','picked_up','cancelled'].includes(d.status) &&
+      (d.date || '') >= todayDateStr &&
+      (d.date || '') <= horizonStr);
+    const deliveryCoverage = attributeDeliveryCoverage({
+      activeDeliveries, inventoryReport: report, skuAliases, getBatchSize,
+    });
+    // Group coverage entries per SKU for the per-row expandable list.
+    const coverageBySku = {};
+    deliveryCoverage.forEach((cov, deliveryId) => {
+      Object.values(cov.lines).forEach(line => {
+        if (!coverageBySku[line.sku]) coverageBySku[line.sku] = [];
+        coverageBySku[line.sku].push({
+          deliveryId,
+          date: cov.date,
+          customer: cov.customer,
+          ...line,
+        });
+      });
+    });
+    Object.values(coverageBySku).forEach(arr => arr.sort((a, b) =>
+      (a.date || '').localeCompare(b.date || '')));
+
+    // Per-SKU "delivered since" totals derived from the report (no parallel calc).
+    const deducted      = {};
+    const deductDetails = {};
+    Object.entries(flowDelivered).forEach(([sku, list]) => {
+      list.forEach(({ customer, qty }) => {
+        deducted[sku] = (deducted[sku] || 0) + qty;
+        if (!deductDetails[sku]) deductDetails[sku] = [];
+        deductDetails[sku].push({ customer, qty });
+      });
+    });
+
+    // Display label for the snapshot date in human terms
+    const todayStr = toDateStr(new Date());
+    const yestStr  = toDateStr(addDays(new Date(), -1));
+    const sinceLabel = !latestInvDate ? ''
+      : latestInvDate === todayStr ? t('since_today')
+      : latestInvDate === yestStr  ? t('since_yest')
+      : t('since_date', { d: fmtShort(parseDate(latestInvDate)) });
+
+    const lastSavedStr = latestInvDate ? t('last_count', { d: fmtShort(parseDate(latestInvDate)) }) : t('no_count_yet');
+    const deductCount  = Object.values(deducted).filter(n => n > 0).length;
+    const deductNote   = deductCount > 0 ? t('reduced_for', { n: deductCount }) : '';
+
+    // Strip "Twisted Sugar - " prefix to keep customer lists readable
+    const compressCust = name => (name || '').replace(/^Twisted Sugar\s*-\s*/i, '');
+
+    // Build forecast-window demand per canonical SKU from active deliveries
+    const demandBySku = {};
+    for (let i = 0; i <= FORECAST_LOOKAHEAD; i++) {
+      const ds = toDateStr(addDays(new Date(), i));
+      allDeliveries
+        .filter(d => d.date === ds && !['delivered','picked_up','cancelled'].includes(d.status))
+        .forEach(delivery => {
+          let items = [];
+          try { items = JSON.parse(delivery.lineItems || '[]'); } catch {}
+          items.forEach(({ sku: lineSku, quantity }) => {
+            let key = lineSku?.trim();
+            if (!key) return;
+            if (skuAliases[key]) key = skuAliases[key];
+            demandBySku[key] = (demandBySku[key] || 0) + (Number(quantity) || 0);
+          });
+        });
+    }
+
+    // Compute per-SKU forecast bucket and summary tallies
+    const forecasts = {}; // sku -> { bucket, net, demand, stock, casesOff }
+    let summaryShortCount   = 0, summaryShortPretzels   = 0;
+    let summarySurplusCount = 0, summarySurplusPretzels = 0;
+    let summaryNoneCount    = 0;
+
+    allSkus.forEach(sku => {
+      if (isFOH(sku)) return; // FOH SKUs aren't part of production forecast
+      // Use effective inventory — same numbers as worker card and scheduler.
+      // Sum all three buckets: cf (dough), fr (frozen), oh (on-hand for
+      // lifecycle-less SKUs). For pretzels only cf+fr have values; for
+      // cheese / bulk dip / future retail dips, oh holds the count.
+      const doughEff  = report.effective.coldFerment[sku] || 0;
+      const frozenEff = report.effective.frozen[sku] || 0;
+      const onHandEff = report.effective.onHand?.[sku] || 0;
+      const stock     = doughEff + frozenEff + onHandEff;
+      const demand    = demandBySku[sku] || 0;
+      const net       = stock - demand;
+      const cs        = getCaseSize(sku);
+      const tightThreshold = cs > 0 ? cs : (getBatchSize(sku) || 0);
+      let bucket;
+      if (demand === 0)             bucket = 'none';
+      else if (net < 0)             bucket = 'short';
+      else if (net < tightThreshold) bucket = 'tight';
+      else                           bucket = 'surplus';
+      forecasts[sku] = { bucket, net, demand, stock, caseSize: cs };
+      if (bucket === 'short')   { summaryShortCount++;   summaryShortPretzels   += -net; }
+      if (bucket === 'surplus') { summarySurplusCount++; summarySurplusPretzels += net;  }
+      if (bucket === 'none')    summaryNoneCount++;
+    });
+
+    // Top summary card
+    const summaryHtml = `
+      <div class="stock-summary">
+        <span class="stock-summary-title">${t('forecast_window', { n: FORECAST_LOOKAHEAD })}</span>
+        ${summaryShortCount > 0
+          ? `<span class="stock-summary-line short">${t('summary_short', { n: summaryShortCount, p: summaryShortPretzels })}</span>`
+          : ''}
+        ${summarySurplusCount > 0
+          ? `<span class="stock-summary-line surplus">${t('summary_surplus', { n: summarySurplusCount, p: summarySurplusPretzels })}</span>`
+          : ''}
+        ${summaryNoneCount > 0
+          ? `<span class="stock-summary-line none">${t('summary_none', { n: summaryNoneCount })}</span>`
+          : ''}
+        ${summaryShortCount === 0 && summarySurplusCount === 0 && summaryNoneCount === 0
+          ? `<span class="stock-summary-line">${t('no_skus_cfg')}</span>`
+          : ''}
+      </div>`;
+
+    // Aging-dough indicator per SKU (oldest entry's age, if past warn threshold).
+    const oldestDoughAge = {};
+    Object.entries(report.doughQueue).forEach(([sku, queue]) => {
+      const oldest = queue.find(e => e.pretzels > 0);
+      if (!oldest) return;
+      const ageDays = Math.floor((Date.now() - new Date(oldest.ts).getTime()) / 86400000);
+      if (ageDays >= DOUGH_AGE_WARN_DAYS) oldestDoughAge[sku] = ageDays;
+    });
+
+    // FOH role: Stock tab is filtered to dip rows only. They manage dip
+    // on-hand counts, not pretzel inventory. Manager sees everything.
+    const stockSkus = userRole === 'foh'
+      ? allSkus.filter(sku => LIFECYCLELESS_SKUS.has(sku) || isFOH(sku))
+      : allSkus;
+    const rows = stockSkus.map(sku => {
+      const isFohSku   = isFOH(sku);
+      // Lifecycle-less SKUs: cheese, bulk dip, and the 4 retail dips coming
+      // in Phase 3b. They have no dough → bake → freeze pipeline; manager
+      // just enters an "on hand" count. Stock tab renders a single onHand
+      // input instead of dough + frozen. (Hardcoded for Phase 3a; Phase 3b
+      // moves this to DIP_CONFIG in inventory.js.)
+      const isLifecycleless = LIFECYCLELESS_SKUS.has(sku);
+      const frozenRaw  = inv.frozen[sku] || 0; // raw snapshot value, used only in "(was N)" label
+      const onHandRaw  = inv.onHand?.[sku] || 0;
+      const dedAmt     = deducted[sku] || 0;
+      const dedDetails = deductDetails[sku] || [];
+      // Pre-fill inputs with effective values — same source of truth as worker
+      // card, scheduler, and forecast above. Manager confirms or adjusts based
+      // on physical count rather than retyping from scratch.
+      const doughDisplay  = report.effective.coldFerment[sku] || 0;
+      const frozenDisplay = report.effective.frozen[sku] || 0;
+      // For lifecycle-less SKUs the input pre-fills with the FULL effective
+      // sum (cf + fr + oh) so that:
+      //  - Batches logged via the Dips-tab stepper (which credit cf) are
+      //    reflected in the Stock-tab number. If we only showed oh here,
+      //    the manager would see "0" right after making a batch, save 0,
+      //    and the cf credit would be filtered out by the snapshot
+      //    timestamp — losing the batch.
+      //  - Legacy pre-Phase-3a snapshots that stored cheese in fr are
+      //    absorbed into oh on next save.
+      // The Dips-tab ON HAND metric uses the same sum, so the two views
+      // never disagree.
+      const onHandDisplay = isLifecycleless
+        ? (report.effective.onHand?.[sku] || 0) + frozenDisplay + doughDisplay
+        : (report.effective.onHand?.[sku] || 0);
+      const fc         = forecasts[sku];
+      const ageDays    = oldestDoughAge[sku];
+
+      let dedStr = '';
+      if (dedAmt > 0) {
+        const MAX_SHOWN = 4;
+        const moreLabel = appLang === 'es' ? 'más' : 'more';
+        const parts = dedDetails.slice(0, MAX_SHOWN)
+          .map(x => `${esc(compressCust(x.customer))} ${x.qty}`);
+        if (dedDetails.length > MAX_SHOWN) parts.push(`+${dedDetails.length - MAX_SHOWN} ${moreLabel}`);
+        dedStr = `<div class="stock-deduct">${t('delivered', { n: dedAmt, w: frozenRaw, when: sinceLabel })}</div>
+                  <div class="stock-deduct-list">${parts.join(', ')}</div>`;
       }
-      // Prepend to scanned list
-      prependScannedItem(entry);
-      input.value = '';
-      input.disabled = false;
-      document.getElementById('scan-btn').disabled = false;
-      input.focus();
-    } catch (err) {
-      showToast('Failed to log: ' + (err.message || 'error'), 'error');
-      input.disabled = false;
-      document.getElementById('scan-btn').disabled = false;
-      input.focus();
-    }
-  }
 
-  function prependScannedItem(entry) {
-    const S = STRINGS[lang];
-    const resolved = entry.ingredientName && entry.ingredientName.trim();
-    const list = document.getElementById('scanned-list');
-    const div = document.createElement('div');
-    div.className = 'scanned-item ' + (resolved ? 'resolved' : 'unresolved');
-    div.innerHTML = `
-      <span class="scanned-barcode">${escapeHtml(entry.barcode)}</span>
-      <span class="scanned-name${resolved ? '' : ' unknown'}">${resolved ? escapeHtml(entry.ingredientName) : S.unknown}</span>
-      <span class="scanned-time">${fmtTime(entry.timeStamp)}</span>`;
-    list.insertBefore(div, list.firstChild);
-  }
+      // Inline aging indicator next to SKU name if oldest dough is past warn threshold.
+      const ageBadge = ageDays != null
+        ? `<span class="stock-aging${ageDays >= DOUGH_AGE_FAIL_DAYS ? ' critical' : ''}" title="Oldest dough ${ageDays} days old">⏳ ${ageDays}d</span>`
+        : '';
 
-  // ── Render history ─────────────────────────────────────────────────────────────
-  function renderHistory() {
-    const S = STRINGS[lang];
-    const results = document.getElementById('history-results');
-    const status = document.getElementById('history-status');
+      // Per-delivery coverage list — expandable so the row stays compact by default.
+      // Each entry tells the manager whether that delivery is covered by stock,
+      // covered by dough (just needs BFP), partial, or not started yet.
+      const skuCoverage = coverageBySku[sku] || [];
+      let coverageHtml = '';
+      if (skuCoverage.length > 0) {
+        const STATUS_LABEL = appLang === 'es'
+          ? { ready: '✅ listo', baking: '🍞 hornear', partial: '🔧 parcial', unstarted: '🔴 producir' }
+          : { ready: '✅ ready', baking: '🍞 baking',  partial: '🔧 partial', unstarted: '🔴 to make' };
+        const summaryLabel = appLang === 'es'
+          ? `Cobertura (${skuCoverage.length} entregas)`
+          : `Coverage (${skuCoverage.length} deliveries)`;
+        const items = skuCoverage.map(c => {
+          const dateLabel = c.date ? fmtShort(parseDate(c.date)) : '—';
+          const cust = compressCust(c.customer || '—');
+          const detail = c.status === 'ready'   ? `${c.qty}p ${appLang === 'es' ? 'congelado' : 'frozen'}`
+                       : c.status === 'baking'  ? `${c.qty}p ${appLang === 'es' ? 'en masa' : 'in dough'}`
+                       : c.status === 'partial' ? `${c.frozenP + c.doughP}p ${appLang === 'es' ? 'cubierto' : 'covered'}, ${c.needShapeP}p ${appLang === 'es' ? 'por hacer' : 'to shape'}`
+                       :                          `${c.qty}p ${appLang === 'es' ? 'sin empezar' : 'not started'}`;
+          return `<li class="coverage-row cov-${c.status}">
+            <span class="cov-date">${esc(dateLabel)}</span>
+            <span class="cov-cust" title="${esc(c.customer)}">${esc(cust)} · ${esc(detail)}</span>
+            <span class="cov-state">${STATUS_LABEL[c.status]}</span>
+          </li>`;
+        }).join('');
+        coverageHtml = `<details class="coverage-details">
+          <summary>${esc(summaryLabel)}</summary>
+          <ul class="coverage-list">${items}</ul>
+        </details>`;
+      }
 
-    const batchFilter   = document.getElementById('filter-batch').value.trim().toLowerCase();
-    const barcodeFilter = document.getElementById('filter-barcode').value.trim();
-    const dateFrom      = document.getElementById('filter-date-from').value;
-    const dateTo        = document.getElementById('filter-date-to').value;
-    const productFilter = document.getElementById('filter-product').value;
+      // Forecast indicator
+      let fcStr = '';
+      if (fc) {
+        const casesText = (n) => {
+          if (fc.caseSize <= 0) return '';
+          const cn = Math.ceil(n / fc.caseSize);
+          return t('cases_paren', { n: cn });
+        };
+        if (fc.bucket === 'short') {
+          fcStr = `<span class="stock-forecast short">${t('fc_short', { d: FORECAST_LOOKAHEAD, p: fc.demand, n: fc.stock, c: { text: -fc.net + casesText(-fc.net) } })}</span>`;
+        } else if (fc.bucket === 'tight') {
+          fcStr = `<span class="stock-forecast tight">${t('fc_tight', { d: FORECAST_LOOKAHEAD, p: fc.demand, n: fc.stock, net: fc.net })}</span>`;
+        } else if (fc.bucket === 'surplus') {
+          fcStr = `<span class="stock-forecast surplus">${t('fc_surplus', { d: FORECAST_LOOKAHEAD, p: fc.demand, n: fc.stock, c: { text: fc.net + casesText(fc.net) } })}</span>`;
+        } else if (fc.bucket === 'none' && fc.stock > 0) {
+          fcStr = `<span class="stock-forecast none">${t('fc_none', { n: fc.stock })}</span>`;
+        }
+      }
 
-    let batches = Array.from(batchMap.values());
-
-    // Apply filters
-    if (batchFilter)   batches = batches.filter((b) => b.meta.batchCode.toLowerCase().includes(batchFilter));
-    if (barcodeFilter) batches = batches.filter((b) => b.ingredients.some((i) => i.barcode === barcodeFilter));
-    if (dateFrom)      batches = batches.filter((b) => b.meta.date >= dateFrom);
-    if (dateTo)        batches = batches.filter((b) => b.meta.date <= dateTo);
-    if (productFilter) batches = batches.filter((b) => b.meta.productCode === productFilter);
-
-    // Sort newest first
-    batches.sort((a, b) => (b.meta.date || '').localeCompare(a.meta.date || '') || b.meta.batchCode.localeCompare(a.meta.batchCode));
-
-    status.hidden = true;
-    results.hidden = false;
-
-    if (!batches.length) {
-      results.innerHTML = `<div class="no-results">${escapeHtml(S.noResults)}</div>`;
-      return;
-    }
-
-    results.innerHTML = batches.map((b) => {
-      const { batchCode, productName, date } = b.meta;
-      const count = b.ingredients.length;
-      const ingRows = b.ingredients.map((ing) => {
-        const resolved = ing.ingredientName && ing.ingredientName.trim();
-        return `<tr>
-          <td class="ing-barcode">${escapeHtml(ing.barcode)}</td>
-          <td class="ing-name${resolved ? '' : ' unknown'}">${resolved ? escapeHtml(ing.ingredientName) : S.unknown}</td>
-          <td class="ing-time">${fmtTime(ing.timeStamp)}</td>
-        </tr>`;
-      }).join('');
-      return `<div class="batch-card" data-code="${escapeHtml(batchCode)}">
-        <div class="batch-card-header">
-          <span class="batch-card-code">${escapeHtml(batchCode)}</span>
-          <span class="batch-card-product">${escapeHtml(productName)}</span>
-          <span class="batch-card-date">${fmtDate(date)}</span>
-          <span class="batch-card-count">${count} ${S.ingredients}</span>
-          <span class="batch-card-chevron">⌄</span>
-        </div>
-        <div class="batch-card-body">
-          ${count ? `<table class="batch-ing-table">${ingRows}</table>` : `<p style="padding:14px 18px;color:#555;font-style:italic;">${S.noResults}</p>`}
-        </div>
+      // Right-side input is either the frozen count (pretzels) or the
+      // on-hand count (cheese / bulk dip / future retail dips). Both render
+      // in the same column slot — saveStock() reads data-stock-section to
+      // route the value to the correct snapshot field.
+      //
+      // Lifecycle-less SKUs also get a small ↺ button below the input that
+      // pre-fills 0 without saving — handy when FOH does a physical count
+      // and finds an SKU empty. They still click the main Save Stock Count
+      // to commit, so misclicks are easy to recover from.
+      const rightInput = isLifecycleless
+        ? `<div style="display:flex;flex-direction:column;gap:2px;align-items:stretch">
+             <input class="stock-input" type="number" min="0" data-stock-section="onhand" data-sku="${esc(sku)}" value="${onHandDisplay}" placeholder="0" title="On hand">
+             <button type="button" data-stock-zero data-zero-sku="${esc(sku)}" style="background:none;border:none;font:500 10px 'Manrope',sans-serif;color:var(--gray-3);cursor:pointer;padding:0;line-height:1.2" title="${appLang === 'es' ? 'Poner en cero (no guarda)' : 'Set to zero (does not save)'}">↺ ${appLang === 'es' ? 'cero' : 'zero'}</button>
+           </div>`
+        : `<input class="stock-input" type="number" min="0" data-stock-section="frozen" data-sku="${esc(sku)}" value="${frozenDisplay}" placeholder="0">`;
+      return `<div class="stock-row">
+        <div><span class="stock-sku">${esc(sku)}</span>${ageBadge}${dedStr}${fcStr}${coverageHtml}</div>
+        ${(isFohSku || isLifecycleless)
+          ? `<span class="stock-na">—</span>`
+          : `<input class="stock-input" type="number" min="0" data-stock-section="shape" data-sku="${esc(sku)}" value="${doughDisplay}" placeholder="0">`}
+        ${rightInput}
       </div>`;
     }).join('');
 
-    // Wire expand/collapse
-    results.querySelectorAll('.batch-card-header').forEach((hdr) => {
-      hdr.addEventListener('click', () => hdr.closest('.batch-card').classList.toggle('open'));
-    });
+    // Box mappings list — surfaces all catering box → SKU expansions so
+    // the manager can see what's wired up at a glance and jump back into
+    // edit mode for any of them. Includes both manager-saved configs
+    // (skuConfig.type === 'box') and the hardcoded fallbacks
+    // (DEFAULT_BOX_EXPANSIONS, marked "default" since no override exists).
+    const customBoxes = Object.entries(skuConfig)
+      .filter(([, cfg]) => cfg.type === 'box' && Array.isArray(cfg.expandsTo) && cfg.expandsTo.length > 0)
+      .map(([box, cfg]) => ({ box, expansions: cfg.expandsTo, isDefault: false }));
+    const customBoxNames = new Set(customBoxes.map((b) => b.box));
+    const defaultBoxes = Object.entries(DEFAULT_BOX_EXPANSIONS || {})
+      .filter(([box]) => !customBoxNames.has(box))
+      .map(([box, expansions]) => ({ box, expansions, isDefault: true }));
+    const boxEntries = [...customBoxes, ...defaultBoxes].sort((a, b) => a.box.localeCompare(b.box));
+    const boxMappingsHtml = boxEntries.length === 0 ? '' : `
+      <div style="margin-top:24px;padding-top:16px;border-top:1px solid #eee">
+        <div style="font:700 13px 'Manrope',sans-serif;color:var(--gray-3);margin-bottom:8px;text-transform:uppercase;letter-spacing:0.5px">
+          ${appLang === 'es' ? '📦 Cajas configuradas' : '📦 Box mappings'} (${boxEntries.length})
+        </div>
+        ${boxEntries.map(({ box, expansions, isDefault }) => {
+          const expansionsStr = expansions
+            .map(e => `${e.multiplier} × ${esc(e.sku)}`)
+            .join(', ');
+          const defaultTag = isDefault
+            ? `<span style="font-size:10px;background:#eee;color:var(--gray-3);padding:2px 6px;border-radius:8px;margin-left:6px">default</span>`
+            : '';
+          return `<div class="box-mapping-row" data-box-edit="${esc(box)}" style="display:flex;justify-content:space-between;padding:8px 12px;border-bottom:1px solid #f3f3f3;font:500 13px 'Manrope',sans-serif;cursor:pointer;align-items:center" title="Click to edit">
+            <span style="flex:1;min-width:0">
+              <strong style="color:var(--dark)">${esc(box)}</strong>${defaultTag}
+              <div style="color:var(--gray-3);font-size:12px;margin-top:2px">→ ${expansionsStr}</div>
+            </span>
+            <span style="color:var(--gray-3);font-size:12px;margin-left:8px">${appLang === 'es' ? 'Editar' : 'Edit'} →</span>
+          </div>`;
+        }).join('')}
+      </div>`;
+
+    // FOH role: simpler chrome. No forecast summary (pretzel-focused), no
+    // dough-aging banners. Stock-tab title swapped to dip-specific label.
+    const isFohRole = userRole === 'foh';
+    const tabTitle = isFohRole
+      ? (appLang === 'es' ? 'Salsas en inventario' : 'Dips on hand')
+      : t('stock_title');
+    // Heads-up bar for FOH: saving here overwrites any cheese_done batches
+    // logged today. Phrased so they don't accidentally zero out the count.
+    const fohHeadsUp = isFohRole ? `
+      <div style="margin:0 0 12px;padding:10px 12px;background:#FFF7E6;border-left:3px solid #E5C16A;border-radius:4px;font:500 12px 'Manrope',sans-serif;color:#5a4a1a">
+        💡 ${appLang === 'es'
+          ? '<strong>Importante:</strong> Guardar aquí reemplaza cualquier tanda que hayas registrado hoy. Confirma que coincida con la cuenta física en el refrigerador.'
+          : '<strong>Heads up:</strong> Save here overwrites any batches you have logged today. Match the physical count in the fridge.'}
+      </div>` : '';
+    return `<div class="team-card"><div class="team-body">
+      <div class="stock-tab-header">
+        <div>
+          <div class="stock-tab-title">${esc(tabTitle)}</div>
+          <div class="stock-tab-note">${esc(lastSavedStr)}${esc(deductNote)}</div>
+        </div>
+      </div>
+      ${fohHeadsUp}
+      ${isFohRole ? '' : summaryHtml}
+      <div class="stock-col-head">
+        <span>${t('sku_col')}</span>
+        <span style="text-align:center">${t('dough_col')}</span>
+        <span style="text-align:center">${t('frozen_col')}</span>
+      </div>
+      ${rows}
+      <div style="display:flex; align-items:center; margin-top:20px">
+        <button class="btn-primary" id="stock-save">${t('save_stock')}</button>
+        ${isFohRole ? '' : `<button type="button" id="stock-audit" title="${appLang === 'es' ? 'Por qué los números son los que son' : 'Why the numbers are what they are'}">🔍 ${appLang === 'es' ? 'Auditoría' : 'Audit'}</button>`}
+      </div>
+      ${isFohRole ? '' : boxMappingsHtml}
+    </div></div>`;
   }
 
-  // ── Load all data ─────────────────────────────────────────────────────────────
-  async function loadAll() {
+  // ─── DIPS TAB ─────────────────────────────────────────────────────────────
+  // Manager-facing view of the FOH dip schedule (cheese + retail dips).
+  // Mirrors the iCalendar feed (same scheduleDip() output per dip), so the
+  // tablet calendar and this view never disagree.
+  //
+  // Per-dip card: today's recommended batch (if any) + stepper + upcoming list.
+  // Stepper logs `cheese_done` rows with {sku, batches, size}; size determines
+  // single vs double crediting in getInventoryReport.
+  function renderDipCard(dipSku, dateStr, report) {
+    const cfg = DIP_CONFIG[dipSku];
+    if (!cfg) return '';
+    const dailyAvg = dipDailyAvgs[dipSku] || (dipSku === CHEESE_KEY ? cheeseFohDailyAvg : 0);
+    const sched = scheduleDip({
+      dipSku,
+      deliveries: allDeliveries,
+      inventoryReport: report,
+      fohDailyAvg: dailyAvg,
+      today: dateStr,
+      skuAliases,
+      lookaheadDays: 14,
+    });
+
+    const todayBatch = sched.batches.find(b => b.date === dateStr);
+    const dayState = productionState[dateStr] || {};
+    const doneList = dayState.cheeseDone || []; // log key stays cheese_done across all dips
+    // todayMadeUnits tallies dips produced today for this SKU (each log entry
+    // contributes batches × singleBatchSize OR doubleBatchSize per its size).
+    const todayMadeUnits = doneList
+      .filter(c => c.sku === dipSku)
+      .reduce((s, c) => {
+        const sz = c.size === 'double' ? cfg.doubleBatchSize : cfg.singleBatchSize;
+        return s + (Number(c.batches) || 0) * sz;
+      }, 0);
+
+    const onHand = (report.effective.coldFerment[dipSku] || 0)
+      + (report.effective.frozen[dipSku] || 0)
+      + (report.effective.onHand?.[dipSku] || 0);
+
+    let todayHtml = '';
+    if (todayBatch) {
+      const targetUnits = todayBatch.units;
+      const isDone = todayMadeUnits >= targetUnits - 0.01;
+      const coversList = todayBatch.covers.length > 0
+        ? todayBatch.covers.map(c => `${esc(c.customer)} (${c.qty}p ${appLang === 'es' ? 'para' : 'for'} ${esc(c.deliveryDate)})`).join(', ')
+        : (appLang === 'es' ? 'sólo FOH (mostrador)' : 'FOH walk-in only');
+      const overdueTag = todayBatch.overdue
+        ? `<span class="wcard-pill overdue">🚨 ${appLang === 'es' ? 'Atrasado' : 'Overdue'}</span>`
+        : '';
+      const statusPill = isDone
+        ? `<span class="wcard-pill done">✅ ${appLang === 'es' ? 'Hecho' : 'Done'}</span>`
+        : (todayBatch.overdue ? overdueTag : `<span class="wcard-pill pending">⏳ ${appLang === 'es' ? 'Pendiente' : 'Pending'}</span>`);
+      const sizeLabel = todayBatch.size === 'double' ? 'double' : 'single';
+      const sizeChip = (cfg.singleBatchSize !== cfg.doubleBatchSize)
+        ? `<span class="wcard-pill" style="background:#f0e8d0;color:#5a4a1a">${sizeLabel} (${todayBatch.units})</span>` : '';
+      // Stepper buttons: cheese has a single +1/-1; retail dips offer single
+      // and double buttons since they're distinct batch sizes.
+      const showDouble = cfg.singleBatchSize !== cfg.doubleBatchSize;
+      todayHtml = `
+        <div class="wcard ${isDone ? 'status-done' : (todayBatch.overdue ? 'status-overdue' : 'status-pending')}" style="--wcard-stripe:#E5C16A">
+          <div class="wcard-head">
+            <div>
+              <div class="wcard-name">${cfg.emoji} ${appLang === 'es' ? 'Hacer 1 tanda de' : 'Make 1 batch'} ${esc(cfg.label)}</div>
+              <div style="font:500 12px 'Manrope',sans-serif;color:var(--gray-3);margin-top:2px">
+                ${esc(coversList)}
+              </div>
+            </div>
+            <div style="display:flex;gap:6px;align-items:center">${sizeChip}${statusPill}</div>
+          </div>
+          <div class="wcard-metrics" style="margin-top:8px">
+            <div class="wmetric">
+              <div class="wmetric-label">${appLang === 'es' ? 'DIPS HECHOS' : 'DIPS MADE'}</div>
+              <div class="wmetric-value"><strong>${Math.round(todayMadeUnits)}</strong><span class="of"> / ${targetUnits}</span></div>
+            </div>
+            <div class="wmetric">
+              <div class="wmetric-label">${appLang === 'es' ? 'INVENTARIO' : 'ON HAND'}</div>
+              <div class="wmetric-value" data-onhand-edit="${esc(dipSku)}" title="${appLang === 'es' ? 'Toca para corregir' : 'Tap to fix'}" style="cursor:pointer"><strong>${Math.round(onHand)}</strong> <span style="font-size:10px;color:var(--gray-3);font-weight:normal">✎</span></div>
+            </div>
+          </div>
+          <div class="wstepper" style="display:flex;gap:6px;flex-wrap:nowrap;overflow-x:auto">
+            <button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="single" data-delta="-1" ${todayMadeUnits <= 0 ? 'disabled' : ''} style="min-width:44px;white-space:nowrap;font-size:14px">−</button>
+            <button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="single" data-delta="1" style="flex:1;white-space:nowrap;font-size:13px;padding:8px 10px">+ ${appLang === 'es' ? 'sencilla' : 'single'} (${cfg.singleBatchSize})</button>
+            ${showDouble ? `<button class="wstep-btn" data-dip-step data-sku="${esc(dipSku)}" data-size="double" data-delta="1" style="flex:1;white-space:nowrap;font-size:13px;padding:8px 10px">+ ${appLang === 'es' ? 'doble' : 'double'} (${cfg.doubleBatchSize})</button>` : ''}
+          </div>
+        </div>`;
+    } else {
+      // No-batch-needed card uses the same wcard chrome as the batch-needed
+      // case so all 5 dip cards align visually. Green stripe + "✅ Stocked"
+      // pill make it obvious at a glance which dips are good to go.
+      const runwayDays = dailyAvg > 0 ? Math.round(onHand / dailyAvg) : null;
+      const runwayLabel = runwayDays != null
+        ? `${runwayDays} ${appLang === 'es' ? 'días' : 'days'}`
+        : '—';
+      todayHtml = `
+        <div class="wcard status-done" style="--wcard-stripe:#b9d4a8">
+          <div class="wcard-head">
+            <div>
+              <div class="wcard-name">${cfg.emoji} ${esc(cfg.label.charAt(0).toUpperCase() + cfg.label.slice(1))}</div>
+              <div style="font:500 12px 'Manrope',sans-serif;color:var(--gray-3);margin-top:2px">
+                ${appLang === 'es' ? 'Sin tanda hoy — bien abastecido' : 'No batch needed today — well stocked'}
+              </div>
+            </div>
+            <span class="wcard-pill done">✅ ${appLang === 'es' ? 'Abastecido' : 'Stocked'}</span>
+          </div>
+          <div class="wcard-metrics" style="margin-top:8px">
+            <div class="wmetric">
+              <div class="wmetric-label">${appLang === 'es' ? 'INVENTARIO' : 'ON HAND'}</div>
+              <div class="wmetric-value" data-onhand-edit="${esc(dipSku)}" title="${appLang === 'es' ? 'Toca para corregir' : 'Tap to fix'}" style="cursor:pointer"><strong>${Math.round(onHand)}</strong> <span style="font-size:10px;color:var(--gray-3);font-weight:normal">✎</span></div>
+            </div>
+            <div class="wmetric">
+              <div class="wmetric-label">${appLang === 'es' ? 'FOH / DÍA' : 'FOH / DAY'}</div>
+              <div class="wmetric-value"><strong>${dailyAvg}</strong></div>
+            </div>
+            <div class="wmetric">
+              <div class="wmetric-label">${appLang === 'es' ? 'ALCANZA' : 'RUNWAY'}</div>
+              <div class="wmetric-value"><strong>${runwayLabel}</strong></div>
+            </div>
+          </div>
+        </div>`;
+    }
+
+    const upcoming = sched.batches.filter(b => b.date > dateStr).slice(0, 8);
+    const upcomingHtml = upcoming.length === 0 ? '' : `
+      <div style="margin-top:12px">
+        <div class="status-section-label" style="color:var(--gray-3);font-size:11px">
+          ${appLang === 'es' ? 'PRÓXIMAS' : 'UPCOMING'}
+        </div>
+        ${upcoming.map(b => {
+          const dateLabel = `${fmtDay(parseDate(b.date))} ${fmtShort(parseDate(b.date))}`;
+          const overdue = b.overdue ? ' 🚨' : '';
+          const sizeStr = b.size === 'double' ? ` · double (${b.units})` : ` · ${b.units}`;
+          return `<div style="display:flex;justify-content:space-between;padding:6px 12px;border-bottom:1px solid #eee;font:500 12px 'Manrope',sans-serif">
+            <span><strong>${esc(dateLabel)}</strong>${overdue}${sizeStr}</span>
+          </div>`;
+        }).join('')}
+      </div>`;
+
+    // Recent batches disclosure — lets manager undo a previously-logged
+    // batch from any of the last 7 days. Each entry shows date, size,
+    // dips, and an ↩ undo link that writes a negative cheese_done row.
+    // Hidden by default (the <details> element); collapsed state preferred
+    // because most days the manager doesn't need to dig in.
+    const todayISO = dateStr;
+    const sevenDaysAgo = (() => {
+      const d = parseDate(todayISO);
+      d.setDate(d.getDate() - 7);
+      return toDateStr(d);
+    })();
+    const recentBatchRows = [];
+    Object.keys(productionState)
+      .filter(ds => ds >= sevenDaysAgo && ds <= todayISO)
+      .sort()
+      .reverse()
+      .forEach((ds) => {
+        const list = (productionState[ds].cheeseDone || []).filter(c => c.sku === dipSku && (Number(c.batches) || 0) > 0);
+        list.forEach((c) => {
+          const sz = c.size === 'double' ? cfg.doubleBatchSize : cfg.singleBatchSize;
+          const units = (Number(c.batches) || 0) * sz;
+          const sizeLabel = c.size === 'double' ? (appLang === 'es' ? 'doble' : 'double') : (appLang === 'es' ? 'sencilla' : 'single');
+          recentBatchRows.push({
+            date: ds,
+            dateLabel: `${fmtDay(parseDate(ds))} ${fmtShort(parseDate(ds))}`,
+            batches: c.batches,
+            size: c.size || 'single',
+            sizeLabel,
+            units,
+          });
+        });
+      });
+    const recentHtml = recentBatchRows.length === 0 ? '' : `
+      <details style="margin-top:8px">
+        <summary style="font:500 11px 'Manrope',sans-serif;color:var(--gray-3);cursor:pointer;padding:6px 12px;text-transform:uppercase;letter-spacing:0.5px">
+          ${appLang === 'es' ? `Tandas recientes (${recentBatchRows.length})` : `Recent batches (${recentBatchRows.length})`}
+        </summary>
+        ${recentBatchRows.map(r => `
+          <div style="display:flex;justify-content:space-between;align-items:center;padding:6px 12px;border-bottom:1px solid #f3f3f3;font:500 12px 'Manrope',sans-serif">
+            <span><strong>${esc(r.dateLabel)}</strong> · ${r.batches} × ${esc(r.sizeLabel)} (${r.units})</span>
+            <button type="button" data-dip-undo data-sku="${esc(dipSku)}" data-date="${esc(r.date)}" data-size="${esc(r.size)}" data-batches="${r.batches}" style="background:none;border:none;color:var(--red);font:600 11px 'Manrope',sans-serif;cursor:pointer;padding:4px 8px" title="${appLang === 'es' ? 'Deshacer esta tanda' : 'Undo this batch'}">↩ ${appLang === 'es' ? 'deshacer' : 'undo'}</button>
+          </div>`).join('')}
+      </details>`;
+
+    // No per-dip section heading above the card — the card itself shows
+    // the dip name + emoji + status pill + on-hand metric. Adding a
+    // duplicate heading line outside the card was redundant noise.
+    return `<div style="margin-bottom:18px">
+      ${todayHtml}
+      ${upcomingHtml}
+      ${recentHtml}
+    </div>`;
+  }
+
+  function renderCheeseTab(dateStr) {
+    // Tab key is still 'cheese' (legacy) but rendered content is now all dips.
+    const report = getInventoryReportLocal();
+    const dipsHtml = Object.keys(DIP_CONFIG).map(sku => renderDipCard(sku, dateStr, report)).join('');
+
+    const calUrl = 'https://dpc-catering-checkout.drew-f39.workers.dev/foh-cal.ics';
+    const calHint = `
+      <div style="margin-top:24px;padding:12px;background:#f8f8f8;border-radius:8px;font:400 11px 'Manrope',sans-serif;color:var(--gray-3)">
+        📅 ${appLang === 'es' ? 'Calendario FOH' : 'FOH calendar'}: <code style="font-size:11px;background:#fff;padding:2px 4px;border-radius:3px">${calUrl}</code>
+        <br>${appLang === 'es' ? 'Suscríbete en myecalendar — actualiza cada hora.' : 'Subscribe in myecalendar — refreshes hourly.'}
+      </div>`;
+
+    return `<div class="team-card"><div class="team-body">
+      <div style="margin-bottom:16px">
+        <div style="font:800 18px 'Paytone One',sans-serif;color:var(--dark)">${appLang === 'es' ? '🧀 Salsas' : '🧀 Dips'}</div>
+        <div style="font:400 12px 'Manrope',sans-serif;color:var(--gray-3)">
+          ${appLang === 'es' ? 'Programación FOH para queso y salsas de menudeo' : 'FOH schedule for cheese + retail dips'}
+        </div>
+      </div>
+      ${dipsHtml}
+      ${calHint}
+    </div></div>`;
+  }
+
+  // ─── RENDER FOH HOME (single combined screen: Dips + Dough) ──────────────
+  //
+  // FOH's only screen. Two stacked sections inside one team-card:
+  //   1. Dips      — existing renderDipCard steppers (cheese + retail dips)
+  //   2. Dough     — pretzel-sheet pulls to the in-store speed rack
+  //                  (writes foh_transfer log rows; FIFO-consumes wholesale
+  //                  coldFerment, no frozen credit)
+  // The aim is a zero-cognitive-load view: open the app, see today's tasks,
+  // tap. No tab navigation. Manager view still has full Stock/Shape/BFP tabs.
+
+  function renderFohHome(dateStr) {
+    const report  = getInventoryReportLocal();
+    const dipsHtml = Object.keys(DIP_CONFIG)
+      .map((sku) => renderDipCard(sku, dateStr, report)).join('');
+    const doughHtml = renderFohDoughSection(report);
+
+    const calUrl = 'https://dpc-catering-checkout.drew-f39.workers.dev/foh-cal.ics';
+    const calHint = `
+      <div style="margin-top:24px;padding:12px;background:#f8f8f8;border-radius:8px;font:400 11px 'Manrope',sans-serif;color:var(--gray-3)">
+        📅 ${appLang === 'es' ? 'Calendario FOH' : 'FOH calendar'}: <code style="font-size:11px;background:#fff;padding:2px 4px;border-radius:3px">${calUrl}</code>
+        <br>${appLang === 'es' ? 'Suscríbete en myecalendar — actualiza cada hora.' : 'Subscribe in myecalendar — refreshes hourly.'}
+      </div>`;
+
+    return `<div class="team-card"><div class="team-body">
+      <div style="margin-bottom:16px">
+        <div style="font:800 18px 'Paytone One',sans-serif;color:var(--dark)">${appLang === 'es' ? '🧀 Salsas' : '🧀 Dips'}</div>
+        <div style="font:400 12px 'Manrope',sans-serif;color:var(--gray-3)">
+          ${appLang === 'es' ? 'Programación FOH para queso y salsas de menudeo' : 'FOH schedule for cheese + retail dips'}
+        </div>
+      </div>
+      ${dipsHtml}
+      <div style="margin:28px 0 14px 0;padding-top:18px;border-top:2px solid var(--gray-1)">
+        <div style="font:800 18px 'Paytone One',sans-serif;color:var(--dark)">${appLang === 'es' ? '🥨 Masa → estante rápido' : '🥨 Dough → speed rack'}</div>
+        <div style="font:400 12px 'Manrope',sans-serif;color:var(--gray-3)">
+          ${appLang === 'es' ? 'Registra las hojas que sacaste del refrigerador para hornear en tienda.' : 'Log the sheets you pulled from the walk-in to bake in-store.'}
+        </div>
+      </div>
+      ${doughHtml}
+      ${calHint}
+    </div></div>`;
+  }
+
+  // Dough section — per-SKU row showing "N sheets ready" + an input for
+  // sheets pulled. Bottom Save button writes one foh_transfer log row that
+  // bundles every non-zero input. Inputs reset on successful save.
+  function renderFohDoughSection(report) {
+    const cf = report?.effective?.coldFerment || {};
+    const fr = report?.effective?.frozen || {};
+    const rows = FOH_DOUGH_SKUS.map((sku) => {
+      const ts = getTraySize(sku) || 0;
+      // "Sheets ready" aggregates cf + fr — FOH pulls from whichever the
+      // walk-in has. Cf-only would understate available stock once cf
+      // drains below an order's needs but fr still has trays.
+      const pretzels = Math.max(0, cf[sku] || 0) + Math.max(0, fr[sku] || 0);
+      const sheetsReady = ts > 0 ? Math.floor(pretzels / ts) : 0;
+      const label = sku; // intentionally raw — FOH knows their SKU names
+      const readyTxt = ts > 0
+        ? `${sheetsReady} ${appLang === 'es' ? (sheetsReady === 1 ? 'hoja lista' : 'hojas listas') : (sheetsReady === 1 ? 'sheet ready' : 'sheets ready')}`
+        : (appLang === 'es' ? '⚠️ sin tamaño de bandeja — avisa al gerente' : '⚠️ tray size unset — tell manager');
+      // Defense-in-depth: if a new SKU lands in FOH_DOUGH_SKUS without a
+      // TRAY_SIZES entry, disable its input rather than silently swallowing
+      // FOH's pull (foh_transfer handler bails on `if (!ts2) return;`).
+      const disabled = ts > 0 ? '' : 'disabled';
+      const inputStyle = ts > 0
+        ? 'width:64px;padding:8px;border:2px solid var(--gray-1);border-radius:8px;font:700 16px \'Manrope\',sans-serif;text-align:center;color:var(--dark)'
+        : 'width:64px;padding:8px;border:2px dashed var(--gray-2);border-radius:8px;font:700 16px \'Manrope\',sans-serif;text-align:center;color:var(--gray-3);background:var(--gray-1);cursor:not-allowed';
+      return `
+        <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 12px;border-bottom:1px solid var(--gray-1)">
+          <div style="flex:1;min-width:0">
+            <div style="font:700 15px 'Manrope',sans-serif;color:var(--dark);text-transform:capitalize">${label}</div>
+            <div style="font:400 12px 'Manrope',sans-serif;color:${ts > 0 ? 'var(--gray-3)' : '#A32D2D'}">${readyTxt}</div>
+          </div>
+          <label style="display:flex;align-items:center;gap:8px;font:600 12px 'Manrope',sans-serif;color:var(--gray-3)">
+            <span>${appLang === 'es' ? 'Sacadas' : 'Pulled'}</span>
+            <input type="number" inputmode="numeric" min="0" step="1" value="0"
+                   data-foh-transfer-sheets data-sku="${sku}" ${disabled}
+                   style="${inputStyle}">
+          </label>
+        </div>`;
+    }).join('');
+
+    return `
+      <div style="background:#fff;border-radius:12px;border:1px solid var(--gray-1);overflow:hidden">
+        ${rows}
+        <div style="padding:14px 12px;display:flex;flex-direction:column;align-items:stretch;gap:8px">
+          <button id="foh-transfer-save"
+                  style="background:var(--dark);color:#fff;border:none;border-radius:10px;padding:14px;font:800 14px 'Manrope',sans-serif;cursor:pointer">
+            ${appLang === 'es' ? 'Guardar transferencia' : 'Save transfer'}
+          </button>
+          <div style="font:400 11px 'Manrope',sans-serif;color:var(--gray-3);text-align:center">
+            ${appLang === 'es' ? 'Toca guardar una o dos veces al día después de surtir el estante.' : 'Tap save once or twice a day after you stock the rack.'}
+          </div>
+        </div>
+      </div>`;
+  }
+
+  // Collects every non-zero data-foh-transfer-sheets input on the page,
+  // writes one bundled foh_transfer log row, then reloads. Empty saves are
+  // a no-op (button stays available but nothing fires). Negatives blocked
+  // client-side via min="0"; getInventoryReport also clamps cf at 0.
+  async function saveFohTransfer() {
+    const btn = document.getElementById('foh-transfer-save');
+    if (btn) btn.disabled = true;
+    const transfers = [];
+    document.querySelectorAll('[data-foh-transfer-sheets]').forEach((inp) => {
+      const sku = (inp.dataset.sku || '').trim();
+      const sheets = parseInt(inp.value, 10) || 0;
+      if (sku && sheets > 0) transfers.push({ sku, sheets });
+    });
+    if (!transfers.length) {
+      if (btn) btn.disabled = false;
+      return;
+    }
     try {
-      const [pRaw, rRaw] = await Promise.all([
-        fetchLog(PRODUCTION_PATH),
-        fetchLog(RECEIVING_PATH),
-      ]);
-      prodLogs      = Array.isArray(pRaw) ? pRaw : [];
-      receivingLogs = Array.isArray(rRaw) ? rRaw : [];
-      batchMap = buildBatchMap(prodLogs);
-
-      // Enable scan input if an active batch is open
-      document.getElementById('barcode-input').disabled = !activeBatch;
-      document.getElementById('scan-btn').disabled = !activeBatch;
-
-      renderHistory();
+      await appendLog(PRODUCTION_LOG, {
+        action: 'foh_transfer',
+        date: toDateStr(new Date()),
+        transfers: JSON.stringify(transfers),
+        timeStamp: new Date().toISOString(),
+      });
+      await loadProduction();
+      schedule = buildOptimalSchedule();
+      render();
+      // Success feedback — inputs reset on render(), so without this toast
+      // FOH has no signal that the save actually went through (was: only
+      // an alert() on failure, silence on success).
+      try {
+        const totalSheets = transfers.reduce((acc, t) => acc + (Number(t.sheets) || 0), 0);
+        showFohTransferToast(totalSheets);
+      } catch (toastErr) { console.warn('foh toast skipped:', toastErr); }
     } catch (err) {
-      document.getElementById('history-status').textContent = 'Error loading data.';
-      document.getElementById('history-status').hidden = false;
-      console.error(err);
+      // appendLog now throws on non-2xx — surface to the user instead of
+      // silently failing (the whole point of the recent sheet-logger
+      // hardening). Re-enable the button so they can retry.
+      // eslint-disable-next-line no-alert, no-console
+      console.error('foh_transfer save failed', err);
+      alert((appLang === 'es' ? 'No se pudo guardar' : 'Save failed') + `: ${err.message || err}`);
+      if (btn) btn.disabled = false;
     }
   }
 
-  // ── Wire everything ────────────────────────────────────────────────────────────
-  document.getElementById('batch-date').value = todayStr();
-  document.getElementById('product-select').addEventListener('change', updateCodePreview);
-  document.getElementById('batch-date').addEventListener('change', updateCodePreview);
-  document.getElementById('start-batch-btn').addEventListener('click', startBatch);
-  document.getElementById('finish-batch-btn').addEventListener('click', finishBatch);
-  document.getElementById('scan-btn').addEventListener('click', scanIngredient);
+  // Dip stepper — generic across cheese + retail dips. Logs cheese_done
+  // (action name kept for backward-compat) with {sku, batches, size}.
+  // size === 'double' credits doubleBatchSize via getInventoryReport's
+  // updated cheese_done handler.
+  async function logDipDelta(sku, size, delta) {
+    const dateStr = toDateStr(currentDate);
+    const completions = JSON.stringify([{ sku, batches: delta, size: size || 'single' }]);
+    await appendLog(PRODUCTION_LOG, {
+      action: 'cheese_done',
+      date: dateStr,
+      completions,
+      timeStamp: new Date().toISOString(),
+    });
+    await loadProduction();
+    schedule = buildOptimalSchedule();
+    render();
+  }
+  // Backward-compat for any remaining cheese-only call sites.
+  async function logCheeseDelta(delta) {
+    return logDipDelta(CHEESE_KEY, 'single', delta);
+  }
 
-  document.getElementById('barcode-input').addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') { e.preventDefault(); scanIngredient(); }
+  // Inline ON HAND editor: writes a single-SKU inventory snapshot. Same
+  // shape as Stock-tab save but scoped to just this dip. The snapshot
+  // timestamp is "now" so prior cf credits from cheese_done get filtered
+  // and the typed value becomes the authoritative on-hand count.
+  async function saveDipOnHand(sku, value) {
+    const n = parseInt(value, 10);
+    if (Number.isNaN(n) || n < 0) return;
+    const snap = { sku, coldFerment: 0, frozen: 0, onHand: n };
+    await appendLog(PRODUCTION_LOG, {
+      action: 'inventory',
+      date: toDateStr(new Date()),
+      snapshots: JSON.stringify([snap]),
+      timeStamp: new Date().toISOString(),
+    });
+    await loadProduction();
+    schedule = buildOptimalSchedule();
+    render();
+  }
+
+  async function saveStock() {
+    const snaps = {};
+    document.querySelectorAll('[data-stock-section]').forEach(inp => {
+      const sku = (inp.dataset.sku || '').trim(); // defense in depth — match read path
+      const section = inp.dataset.stockSection;
+      const n   = parseInt(inp.value, 10) || 0;
+      if (!sku) return;
+      if (!snaps[sku]) snaps[sku] = { sku, coldFerment: 0, frozen: 0, onHand: 0 };
+      if (section === 'shape')  snaps[sku].coldFerment = n;
+      if (section === 'frozen') snaps[sku].frozen      = n;
+      // onhand bucket — for lifecycle-less SKUs (cheese, bulk dip, future
+      // retail dips). Distinct from `frozen` (which is reserved for actually
+      // frozen pretzels) so the cheese row doesn't pollute pretzel forecasts.
+      if (section === 'onhand') snaps[sku].onHand      = n;
+    });
+    // Save ALL SKUs the user touched, including zeros — clearing an SKU to 0
+    // must propagate so getLatestInventory can overwrite older non-zero values.
+    const snapArr = Object.values(snaps);
+    const saveBtn = document.getElementById('stock-save');
+    if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = appLang === 'es' ? 'Guardando…' : 'Saving…'; }
+    // Capture the schedule BEFORE save so we can diff after rebuild.
+    // The diff toast is purely observational — it can't affect any state.
+    const prevSchedule = schedule;
+    try {
+      await appendLog(PRODUCTION_LOG, {
+        action: 'inventory', date: toDateStr(new Date()),
+        snapshots: JSON.stringify(snapArr), timeStamp: new Date().toISOString(),
+      });
+      await loadProduction();
+      schedule = buildOptimalSchedule();
+      render();
+      // Surface what changed across days. Wrapped so a toast bug never
+      // breaks the save flow itself.
+      try { showScheduleDiffToast(diffSchedules(prevSchedule, schedule)); }
+      catch (toastErr) { console.warn('schedule diff toast skipped:', toastErr); }
+    } catch (e) {
+      alert('Error saving: ' + e.message);
+      if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = t('save_stock'); }
+    }
+  }
+
+  // ─── SCHEDULE DIFF (observation only) ─────────────────────────────────────
+
+  /**
+   * Compare two schedule objects (output of buildOptimalSchedule) and
+   * return per-day deltas in batches.
+   *
+   * Pure function. Doesn't mutate either input. Doesn't read any module
+   * state. The output is consumed only by showScheduleDiffToast.
+   *
+   * @param {Object} prev
+   * @param {Object} next
+   * @returns {Array<{date: string, deltaShape: number, deltaBfp: number, newOverdue: number}>}
+   *          One entry per day where ANY delta is non-zero, sorted by date.
+   */
+  function diffSchedules(prev, next) {
+    const sumBatches = items => (items || []).reduce((s, d) => s + (Number(d.batches) || 0), 0);
+    const dates = new Set([
+      ...Object.keys(prev?.shape || {}),
+      ...Object.keys(prev?.bfp   || {}),
+      ...Object.keys(next?.shape || {}),
+      ...Object.keys(next?.bfp   || {}),
+    ]);
+    const prevOverdue = new Set((prev?.overdue || []).map(o => `${o.team}:${o.sku}`));
+    const nextOverdue = (next?.overdue || []).filter(o => !prevOverdue.has(`${o.team}:${o.sku}`));
+    const out = [];
+    [...dates].sort().forEach(d => {
+      const deltaShape = sumBatches(next?.shape?.[d]) - sumBatches(prev?.shape?.[d]);
+      const deltaBfp   = sumBatches(next?.bfp?.[d])   - sumBatches(prev?.bfp?.[d]);
+      if (Math.abs(deltaShape) >= 0.01 || Math.abs(deltaBfp) >= 0.01) {
+        out.push({ date: d, deltaShape, deltaBfp });
+      }
+    });
+    return { perDay: out, newOverdue: nextOverdue };
+  }
+
+  /**
+   * Render the schedule-diff banner. Auto-dismisses after ~6s. Click to
+   * dismiss. Pure DOM injection — no other state touched.
+   */
+  function showScheduleDiffToast({ perDay, newOverdue }) {
+    // Remove any prior toast before showing a new one
+    document.querySelectorAll('.schedule-diff-toast').forEach(n => n.remove());
+
+    const toast = document.createElement('div');
+    toast.className = 'schedule-diff-toast';
+    if (newOverdue.length > 0) toast.classList.add('has-overdue');
+    if (perDay.length === 0 && newOverdue.length === 0) toast.classList.add('unchanged');
+
+    const titleText = perDay.length === 0 && newOverdue.length === 0
+      ? (appLang === 'es' ? '✓ Inventario guardado · sin cambios al cronograma' : '✓ Stock saved · schedule unchanged')
+      : (appLang === 'es' ? '✓ Inventario guardado · cronograma actualizado'   : '✓ Stock saved · schedule updated');
+
+    let rowsHtml = '';
+    if (newOverdue.length > 0) {
+      const list = newOverdue.map(o => `<strong>${esc(o.sku)}</strong>`).join(', ');
+      const label = appLang === 'es'
+        ? `🚨 Nuevo atrasado: ${list}`
+        : `🚨 New overdue: ${list}`;
+      rowsHtml += `<div class="schedule-diff-toast-row"><span class="day"></span><span class="sub">${label}</span></div>`;
+    }
+    perDay.forEach(({ date, deltaShape, deltaBfp }) => {
+      const total = deltaShape + deltaBfp;
+      const dayLabel = fmtFull(parseDate(date));
+      const sign = total > 0 ? `+${Math.round(total)}` : `${Math.round(total)}`;
+      const cls  = total > 0 ? 'add' : (total < 0 ? 'sub' : 'same');
+      const teamSuffix = (deltaShape !== 0 && deltaBfp !== 0)
+        ? ` (shape ${deltaShape > 0 ? '+' : ''}${Math.round(deltaShape)}, bfp ${deltaBfp > 0 ? '+' : ''}${Math.round(deltaBfp)})`
+        : (deltaShape !== 0 ? ' shape' : ' bfp');
+      const batchWord = (Math.abs(total) === 1) ? 'batch' : 'batches';
+      rowsHtml += `<div class="schedule-diff-toast-row">
+        <span class="day">${esc(dayLabel)}</span>
+        <span class="${cls}">${sign} ${batchWord}${teamSuffix}</span>
+      </div>`;
+    });
+    if (perDay.length === 0 && newOverdue.length === 0) {
+      rowsHtml = `<div class="schedule-diff-toast-row"><span class="day"></span><span class="same">${appLang === 'es' ? 'Todos los días iguales.' : 'All days unchanged.'}</span></div>`;
+    }
+    const dismiss = appLang === 'es' ? 'Toca para cerrar' : 'Tap to dismiss';
+    toast.innerHTML = `
+      <div class="schedule-diff-toast-title">${titleText}</div>
+      ${rowsHtml}
+      <div class="schedule-diff-toast-dismiss">${dismiss}</div>`;
+
+    document.body.appendChild(toast);
+    const remove = () => toast.remove();
+    toast.addEventListener('click', remove);
+    const ttl = (perDay.length === 0 && newOverdue.length === 0) ? 2500 : 6000;
+    setTimeout(remove, ttl);
+  }
+
+  /**
+   * Stock audit modal — manager-only diagnostic. Walks the user through
+   * exactly how each SKU's current displayed inventory value is computed:
+   *   snapshot baseline  + shape_done  + bfp_done  − deliveries  − foh_done
+   *                                                                = displayed
+   * Plus a per-SKU list of deliveries that were SKIPPED from deduction
+   * along with the reason (status not confirmed, past-dated already in
+   * snapshot, etc.) so the manager can spot drift sources.
+   *
+   * Pure UI — reads from the same `getInventoryReportLocal()` the rest of
+   * the page consumes, mutates no state.
+   */
+  function showStockAuditModal() {
+    // Remove any prior audit modal (re-open replaces)
+    document.querySelectorAll('.stock-audit-overlay').forEach(n => n.remove());
+
+    const rpt = getInventoryReportLocal();
+    const snapshotTs = rpt.snapshot?.timestamp || '';
+    const snapshotDate = rpt.snapshot?.date || '';
+    const snapshotRaw = rpt.snapshot?.raw || { coldFerment: {}, frozen: {}, onHand: {} };
+    const effective = rpt.effective || { coldFerment: {}, frozen: {}, onHand: {} };
+    const flowShape = rpt.flowsSinceSnapshot?.shape || {};
+    const flowBfp   = rpt.flowsSinceSnapshot?.bfp   || {};
+    const flowFoh   = rpt.flowsSinceSnapshot?.foh   || {};
+    const flowDelv  = rpt.flowsSinceSnapshot?.delivered || {};
+    const explanations = rpt.deductionExplanations || [];
+
+    // Collect SKUs to display: any SKU present in snapshot, effective,
+    // or in any of the flows. Sort by display name.
+    const skuSet = new Set();
+    Object.keys(snapshotRaw.coldFerment || {}).forEach(k => skuSet.add(k));
+    Object.keys(snapshotRaw.frozen || {}).forEach(k => skuSet.add(k));
+    Object.keys(snapshotRaw.onHand || {}).forEach(k => skuSet.add(k));
+    Object.keys(effective.coldFerment || {}).forEach(k => skuSet.add(k));
+    Object.keys(effective.frozen || {}).forEach(k => skuSet.add(k));
+    Object.keys(effective.onHand || {}).forEach(k => skuSet.add(k));
+    Object.keys(flowShape).forEach(k => skuSet.add(k));
+    Object.keys(flowBfp).forEach(k => skuSet.add(k));
+    Object.keys(flowFoh).forEach(k => skuSet.add(k));
+    Object.keys(flowDelv).forEach(k => skuSet.add(k));
+    const skus = [...skuSet].sort();
+
+    // Pre-group skipped deliveries by SKU so we can show them in-context.
+    // Also group deducted deliveries' itemTrail for per-SKU rendering.
+    const deductedBySku = {};
+    const skippedAll = [];
+    explanations.forEach((exp) => {
+      if (exp.decision === 'deducted') {
+        (exp.items || []).forEach((it) => {
+          if (!deductedBySku[it.sku]) deductedBySku[it.sku] = [];
+          deductedBySku[it.sku].push({ ...it, customer: exp.customer, date: exp.date, deliveryId: exp.deliveryId, deleted: exp.deleted });
+        });
+      } else {
+        // Skipped: we don't know which SKUs it affected without parsing
+        // its lineItems again (skipped deliveries don't decompose). Show
+        // these at the top of the modal under a global "skipped" list,
+        // not per-SKU.
+        skippedAll.push(exp);
+      }
+    });
+
+    const fmtSnapTime = snapshotTs
+      ? new Date(snapshotTs).toLocaleString('en-US', { timeZone: 'America/Denver', dateStyle: 'medium', timeStyle: 'short' })
+      : '(no snapshot yet)';
+
+    const skuSections = skus.map((sku) => {
+      const snapCf = Number(snapshotRaw.coldFerment?.[sku] || 0);
+      const snapFr = Number(snapshotRaw.frozen?.[sku] || 0);
+      const snapOh = Number(snapshotRaw.onHand?.[sku] || 0);
+      const snapTotal = snapCf + snapFr + snapOh;
+      const effCf = Number(effective.coldFerment?.[sku] || 0);
+      const effFr = Number(effective.frozen?.[sku] || 0);
+      const effOh = Number(effective.onHand?.[sku] || 0);
+      const effTotal = effCf + effFr + effOh;
+
+      const shapeBatches = Number(flowShape[sku] || 0);
+      const bfpBatches   = Number(flowBfp[sku]   || 0);
+      const fohSheets    = Number(flowFoh[sku]   || 0);
+      const bs = getBatchSize(sku) || 0;
+      const ts2 = getTraySize(sku) || 0;
+      const shapeP = shapeBatches * bs;
+      const bfpP   = bfpBatches   * bs;
+      const fohP   = fohSheets    * ts2;
+
+      const deliveryRows = (deductedBySku[sku] || []).filter(d => (d.fromOh + d.fromCf + d.fromFr) > 0);
+      const deliveryTotal = deliveryRows.reduce((s, d) => s + d.fromOh + d.fromCf + d.fromFr, 0);
+
+      // Skip SKUs with no meaningful activity AND no snapshot
+      if (snapTotal === 0 && shapeP === 0 && bfpP === 0 && fohP === 0 && deliveryTotal === 0 && effTotal === 0) {
+        return '';
+      }
+
+      const rows = [];
+      rows.push(`<div class="stock-audit-row"><span class="label">${appLang === 'es' ? 'Inventario inicial' : 'Snapshot baseline'} (${esc(snapshotDate || '—')})</span><span>${snapTotal}p</span></div>`);
+      if (shapeP > 0) rows.push(`<div class="stock-audit-row"><span class="label">+ ${appLang === 'es' ? 'Formado' : 'Shape done'}</span><span class="add">+${shapeP}p (${shapeBatches} ${shapeBatches === 1 ? (appLang === 'es' ? 'tanda' : 'batch') : (appLang === 'es' ? 'tandas' : 'batches')})</span></div>`);
+      if (bfpP > 0) rows.push(`<div class="stock-audit-row"><span class="label">+ ${appLang === 'es' ? 'Horneado/Cong' : 'BFP done'}</span><span class="add">+${bfpP}p</span></div>`);
+      if (fohP > 0) rows.push(`<div class="stock-audit-row"><span class="label">− ${appLang === 'es' ? 'FOH usó' : 'FOH consumed'}</span><span class="sub">−${fohP}p (${fohSheets} ${fohSheets === 1 ? 'sheet' : 'sheets'})</span></div>`);
+      deliveryRows.forEach((dr) => {
+        const buckets = [];
+        if (dr.fromOh > 0) buckets.push(`${dr.fromOh}p on-hand`);
+        if (dr.fromCf > 0) buckets.push(`${dr.fromCf}p dough`);
+        if (dr.fromFr > 0) buckets.push(`${dr.fromFr}p frozen`);
+        const total = dr.fromOh + dr.fromCf + dr.fromFr;
+        const tag = dr.deleted ? ' <em style="color:#888">(deleted, kept for math)</em>' : '';
+        rows.push(`<div class="stock-audit-row"><span class="label">− ${esc(dr.customer || '?')} ${dr.date ? `(${esc(dr.date)})` : ''}${tag}</span><span class="sub">−${total}p · ${esc(buckets.join(' + '))}</span></div>`);
+      });
+      rows.push(`<div class="stock-audit-row total"><span>${appLang === 'es' ? 'Mostrado ahora' : 'Displayed now'}</span><span>${effTotal}p</span></div>`);
+
+      // Skipped deliveries for THIS sku: parse explanation lineItems
+      // looking for this SKU. Inline by extracting from exp.items
+      // (deducted only), so for skipped we'd need to re-parse — but we
+      // already stashed skippedAll at the top of the modal globally.
+      // Leave per-SKU section clean; skipped deliveries appear at the
+      // bottom of the modal.
+
+      return `<div class="stock-audit-sku">
+        <div class="stock-audit-sku-name">${esc(sku)}</div>
+        ${rows.join('')}
+      </div>`;
+    }).filter(Boolean).join('');
+
+    const skippedHtml = skippedAll.length === 0 ? '' : `
+      <div class="stock-audit-sku">
+        <div class="stock-audit-sku-name">${appLang === 'es' ? 'Entregas omitidas (no deducidas)' : 'Skipped deliveries (NOT deducted)'}</div>
+        <div class="stock-audit-skipped-title">${appLang === 'es' ? 'Estas entregas confirmadas/canceladas no afectaron el inventario:' : 'These confirmed/cancelled deliveries did not affect inventory:'}</div>
+        ${skippedAll.map((s) => {
+          const tag = s.deleted ? ' <em style="color:#888">(deleted)</em>' : '';
+          return `<div class="stock-audit-skipped-row">• <strong>${esc(s.customer)}</strong> (${esc(s.date || '—')}, ${esc(s.status)})${tag} — ${esc(s.reason)}</div>`;
+        }).join('')}
+      </div>`;
+
+    const overlay = document.createElement('div');
+    overlay.className = 'stock-audit-overlay';
+    overlay.innerHTML = `
+      <div class="stock-audit-modal" role="dialog" aria-labelledby="stock-audit-title">
+        <h3 id="stock-audit-title">${appLang === 'es' ? '🔍 Auditoría de inventario' : '🔍 Stock audit'}</h3>
+        <div class="stock-audit-meta">${appLang === 'es' ? 'Inventario guardado' : 'Snapshot saved'}: <strong>${esc(fmtSnapTime)}</strong></div>
+        ${skuSections || `<div class="stock-audit-empty">${appLang === 'es' ? 'Sin actividad de inventario.' : 'No inventory activity.'}</div>`}
+        ${skippedHtml}
+        <div class="stock-audit-footer">
+          <span style="color:#888; font-size:11px">${appLang === 'es' ? 'Haz clic fuera o pulsa Cerrar.' : 'Click outside or press Close.'}</span>
+          <button type="button" class="stock-audit-close">${appLang === 'es' ? 'Cerrar' : 'Close'}</button>
+        </div>
+      </div>`;
+
+    document.body.appendChild(overlay);
+    const close = () => overlay.remove();
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) close();
+    });
+    overlay.querySelector('.stock-audit-close').addEventListener('click', close);
+  }
+
+  // FOH dough-pull confirmation. Reuses the schedule-diff-toast CSS so no
+  // new styling surface needed. ~3s TTL — long enough to read, short
+  // enough to not pile up if FOH saves twice.
+  function showFohTransferToast(sheetsTotal) {
+    document.querySelectorAll('.schedule-diff-toast').forEach(n => n.remove());
+    const toast = document.createElement('div');
+    toast.className = 'schedule-diff-toast unchanged';
+    const sheetWord = appLang === 'es'
+      ? (sheetsTotal === 1 ? 'hoja transferida' : 'hojas transferidas')
+      : (sheetsTotal === 1 ? 'sheet transferred' : 'sheets transferred');
+    const title = appLang === 'es'
+      ? `✓ Guardado · ${sheetsTotal} ${sheetWord}`
+      : `✓ Saved · ${sheetsTotal} ${sheetWord}`;
+    const dismiss = appLang === 'es' ? 'Toca para cerrar' : 'Tap to dismiss';
+    toast.innerHTML = `
+      <div class="schedule-diff-toast-title">${title}</div>
+      <div class="schedule-diff-toast-dismiss">${dismiss}</div>`;
+    document.body.appendChild(toast);
+    const remove = () => toast.remove();
+    toast.addEventListener('click', remove);
+    setTimeout(remove, 3000);
+  }
+
+  // ─── INLINE LOGGER (TAP +/- ON SKU ROW) ───────────────────────────────────
+  // Each tap optimistically updates local state; a debounced timer pushes the
+  // delta to the production log so rapid taps coalesce into one network call.
+
+  function getMadePretzels(type, dateStr, sku) {
+    // Returns the pretzel count currently logged today for this SKU
+    const doneKey = type === 'shape' ? 'shapeDone' : 'bfpDone';
+    const arr = (productionState[dateStr] || {})[doneKey] || [];
+    const c = arr.find(x => x.sku === sku);
+    const batches = c ? Number(c.batches) || 0 : 0;
+    return batches * getBatchSize(sku);
+  }
+
+  function getCurrentPretzels(type, dateStr, sku) {
+    // Local state takes priority; falls back to server state
+    return loggedPretzels[type]?.[dateStr]?.[sku]
+      ?? getMadePretzels(type, dateStr, sku);
+  }
+
+  function getLastSavedPretzels(type, dateStr, sku) {
+    return lastSavedPretzels[type]?.[dateStr]?.[sku]
+      ?? getMadePretzels(type, dateStr, sku);
+  }
+
+  function setLocalLog(type, dateStr, sku, pretzels) {
+    if (!loggedPretzels[type])           loggedPretzels[type] = {};
+    if (!loggedPretzels[type][dateStr])  loggedPretzels[type][dateStr] = {};
+    loggedPretzels[type][dateStr][sku] = Math.max(0, pretzels);
+  }
+
+  /**
+   * Toggle a packed-case slot on the BFP pack list.
+   * Optimistic UI: flip the slot visually + update local packedCases state,
+   * then POST a `case_packed` log event. On error, the next loadProduction
+   * will re-sync from the server (or we revert the flip directly).
+   */
+  async function togglePackedCase(btn) {
+    const deliveryId = btn.dataset.deliveryId || '';
+    const sku        = btn.dataset.sku || '';
+    const caseSize   = Number(btn.dataset.caseSize) || 0;
+    const caseIndex  = Number(btn.dataset.caseIndex) || 0;
+    if (!deliveryId || !sku || caseIndex <= 0) return;
+
+    const currentlyPacked = btn.dataset.currentlyPacked === '1';
+    const newPacked = !currentlyPacked;
+
+    // Optimistic UI flip
+    btn.classList.toggle('packed', newPacked);
+    btn.textContent = newPacked ? '✓' : '';
+    btn.dataset.currentlyPacked = newPacked ? '1' : '0';
+
+    // Update local state so re-renders within the same session see the change
+    if (!packedCases[deliveryId]) packedCases[deliveryId] = {};
+    if (!packedCases[deliveryId][sku]) packedCases[deliveryId][sku] = {};
+    packedCases[deliveryId][sku][caseIndex] = {
+      packed: newPacked,
+      ts: new Date().toISOString(),
+    };
+
+    // Refresh the parent <li>'s "all packed" state — adds the green ✓ /
+    // dimming when every case in that delivery's SKU line is packed.
+    const li = btn.closest('li');
+    if (li) {
+      const slots = li.querySelectorAll('.pack-slot');
+      const allPacked = [...slots].every(s => s.classList.contains('packed'));
+      li.classList.toggle('all-packed', allPacked);
+    }
+
+    try {
+      await appendLog(PRODUCTION_LOG, {
+        action:     'case_packed',
+        deliveryId,
+        sku,
+        caseSize:   String(caseSize),
+        caseIndex:  String(caseIndex),
+        packed:     String(newPacked),
+        timeStamp:  new Date().toISOString(),
+      });
+    } catch (e) {
+      // Revert on error
+      btn.classList.toggle('packed', currentlyPacked);
+      btn.textContent = currentlyPacked ? '✓' : '';
+      btn.dataset.currentlyPacked = currentlyPacked ? '1' : '0';
+      packedCases[deliveryId][sku][caseIndex] = {
+        packed: currentlyPacked,
+        ts: new Date().toISOString(),
+      };
+      if (li) {
+        const slots = li.querySelectorAll('.pack-slot');
+        const allPacked = [...slots].every(s => s.classList.contains('packed'));
+        li.classList.toggle('all-packed', allPacked);
+      }
+      alert('Failed to log case pack — try again. ' + (e?.message || ''));
+    }
+  }
+
+  function bumpStepper(type, dateStr, sku, deltaSign) {
+    // deltaSign is +1 or -1 — actual increment is the SKU's stepDelta (batch or tray)
+    const stepDelta = getStepDelta(type, sku);
+    if (!stepDelta) return;
+    const cur  = getCurrentPretzels(type, dateStr, sku);
+    const next = Math.max(0, cur + (deltaSign * stepDelta));
+    if (next === cur) return;
+    setLocalLog(type, dateStr, sku, next);
+    // Update input value too so user sees the change
+    const inputEl = document.getElementById(`rli-${type}-${sku}`);
+    if (inputEl) inputEl.value = next;
+    updateStepperDom(type, dateStr, sku);
+    scheduleSave(type, dateStr, sku);
+  }
+
+  function setStepperValue(type, dateStr, sku, rawInput) {
+    // Direct typing: any non-negative integer
+    const next = Math.max(0, parseInt(rawInput, 10) || 0);
+    const cur  = getCurrentPretzels(type, dateStr, sku);
+    if (next === cur) return;
+    setLocalLog(type, dateStr, sku, next);
+    updateStepperDom(type, dateStr, sku, /* skipInput */ true);
+    scheduleSave(type, dateStr, sku);
+  }
+
+  function updateStepperDom(type, dateStr, sku, skipInput = false) {
+    const cur = getCurrentPretzels(type, dateStr, sku);
+    const bs  = getBatchSize(sku);
+    // Total need for display: pull from current schedule + completions
+    const items = schedule[type][dateStr] || [];
+    const sched = items.find(i => i.sku === sku);
+    const doneKey = type === 'shape' ? 'shapeDone' : 'bfpDone';
+    const completedRow = ((productionState[dateStr] || {})[doneKey] || []).find(c => c.sku === sku);
+    const schedBatches = sched ? sched.batches : 0;
+    const madeBatches  = completedRow ? (Number(completedRow.batches) || 0) : 0;
+    const origP = Math.round((schedBatches + madeBatches) * bs);
+    // Update the "/ N" suffix on both card variants:
+    //   manager view: <span class="row-log-of">/ N</span>
+    //   worker view:  <span class="of"> / N</span> inside .wmetric-value
+    const inputEl = document.getElementById(`rli-${type}-${sku}`);
+    const parent  = inputEl?.parentElement;
+    if (parent) {
+      const ofEl = parent.querySelector('.row-log-of, .of');
+      if (ofEl) ofEl.textContent = ofEl.classList.contains('row-log-of') ? `/ ${origP}` : ` / ${origP}`;
+    }
+    // Update input value (unless caller is the input itself, mid-keystroke)
+    if (!skipInput) {
+      const inp = inputEl;
+      if (inp && document.activeElement !== inp) inp.value = cur;
+    }
+    // Decrement button disabled when at zero
+    const decBtns = document.querySelectorAll(`[data-log-step][data-key="${type}|${dateStr}|${sku}"][data-delta="-1"]`);
+    decBtns.forEach(b => { b.disabled = cur <= 0; });
+    // Status indicator — only show "saving…" when a debounced save is pending.
+    // Epsilon tolerance: ignore sub-pretzel FP drift from chained operations.
+    const statusEl = document.getElementById(`rls-${type}-${sku}`);
+    if (statusEl) {
+      const isPending = saveTimers[`${type}|${dateStr}|${sku}`] != null;
+      const overBy = Math.round(cur - origP);
+      if (overBy > 0 && origP > 0) {
+        statusEl.className = 'row-log-status over';
+        statusEl.textContent = `+${overBy}`;
+      } else if (cur >= origP - 0.5 && origP > 0) {
+        statusEl.className = 'row-log-status done';
+        statusEl.textContent = '✅';
+      } else if (isPending) {
+        statusEl.className = 'row-log-status saving';
+        statusEl.textContent = appLang === 'es' ? 'guardando…' : 'saving…';
+      } else {
+        statusEl.className = 'row-log-status';
+        statusEl.textContent = '';
+      }
+    }
+  }
+
+  function scheduleSave(type, dateStr, sku) {
+    const key = `${type}|${dateStr}|${sku}`;
+    if (saveTimers[key]) clearTimeout(saveTimers[key]);
+    saveTimers[key] = setTimeout(() => {
+      saveTimers[key] = null;
+      saveStepperDelta(type, dateStr, sku);
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  async function saveStepperDelta(type, dateStr, sku) {
+    const bs = getBatchSize(sku);
+    if (!bs) return;
+    const sentP  = getCurrentPretzels(type, dateStr, sku); // value AT save time
+    const lastP  = getLastSavedPretzels(type, dateStr, sku);
+    const deltaP = sentP - lastP;
+    if (deltaP === 0) return;
+    const deltaBatches = deltaP / bs; // fractional OK (typed values may not align to batches)
+    const statusEl = document.getElementById(`rls-${type}-${sku}`);
+    if (statusEl) { statusEl.className = 'row-log-status saving'; statusEl.textContent = appLang === 'es' ? 'guardando…' : 'saving…'; }
+    try {
+      await appendLog(PRODUCTION_LOG, {
+        action:      type === 'shape' ? 'shape_done' : 'bfp_done',
+        date:        dateStr,
+        completions: JSON.stringify([{ sku, batches: deltaBatches }]),
+        workers:     getWorkers(type, dateStr),
+        timeStamp:   new Date().toISOString(),
+      });
+      // Always update lastSaved to what we sent — next save's delta is computed
+      // from this baseline regardless of further user input.
+      if (!lastSavedPretzels[type])           lastSavedPretzels[type] = {};
+      if (!lastSavedPretzels[type][dateStr])  lastSavedPretzels[type][dateStr] = {};
+      lastSavedPretzels[type][dateStr][sku] = sentP;
+      // Pull fresh server state and rebuild schedule (so other SKUs reflect changes)
+      await loadProduction();
+      schedule = buildOptimalSchedule();
+      // Only sync local with server if user hasn't typed since save started.
+      // If they have, leave their in-progress value alone — next debounced save
+      // will compute the delta against the now-up-to-date lastSaved (sentP).
+      const localNow   = loggedPretzels[type]?.[dateStr]?.[sku];
+      const userQuiet  = localNow === sentP;
+      if (userQuiet) {
+        const newServerP = getMadePretzels(type, dateStr, sku);
+        setLocalLog(type, dateStr, sku, newServerP);
+        lastSavedPretzels[type][dateStr][sku] = newServerP;
+      }
+      // If the user is mid-typing, skip full re-render to preserve focus.
+      const activeIsLogInput = document.activeElement?.matches?.('[data-log-input]');
+      if (activeIsLogInput) {
+        updateStepperDom(type, dateStr, sku, /* skipInput */ document.activeElement?.id === `rli-${type}-${sku}`);
+      } else {
+        render();
+      }
+      if (statusEl) {
+        statusEl.className = 'row-log-status saved';
+        statusEl.textContent = '✓';
+        setTimeout(() => updateStepperDom(type, dateStr, sku), 1500);
+      }
+    } catch (e) {
+      if (statusEl) { statusEl.className = 'row-log-status error'; statusEl.textContent = 'error'; }
+      console.error('Log save failed:', e);
+    }
+  }
+
+  // ─── RENDER WEEK VIEW ─────────────────────────────────────────────────────
+
+  function renderWeekView() {
+    const today    = new Date();
+    const todayStr = toDateStr(today);
+    const statusIcon = s => s === 'done' ? '✅' : s === 'partial' ? '⏳' : s === 'todo' ? '⬜' : '—';
+    let html = '';
+
+    for (let i = 0; i < SCHEDULE_LOOKAHEAD; i++) {
+      const d  = addDays(today, i);
+      const ds = toDateStr(d);
+
+      const sItems   = schedule.shape[ds] || [];
+      const bItems   = schedule.bfp[ds]   || [];
+      const sTotal   = sItems.reduce((s, x) => s + x.batches, 0);
+      const bTotal   = bItems.reduce((s, x) => s + x.batches, 0);
+      const sStatus  = getTeamStatus('shape', ds);
+      const bStatus  = getTeamStatus('bfp', ds);
+      const showShape = userRole === 'manager' || userRole === 'shape';
+      const showBfp   = userRole === 'manager' || userRole === 'bfp';
+      const isEmpty   = (showShape ? sTotal : 0) + (showBfp ? bTotal : 0) === 0;
+
+      if (i === 0) html += `<div class="week-section-lbl">${t('this_week')}</div>`;
+      else if (i === 7) html += `<div class="week-section-lbl">${t('next_week')}</div>`;
+
+      const dayLabel  = i === 0 ? t('today_label') : i === 1 ? t('tomorrow_label') : fmtDay(d);
+      const shapeText = sTotal > 0 ? `${statusIcon(sStatus)} ${t('shape_label')}: ${sTotal}` : `${statusIcon(sStatus)} ${t('shape_label')}`;
+      const bfpText   = bTotal > 0 ? `${statusIcon(bStatus)} ${t('bfp_label')}: ${bTotal}` : `${statusIcon(bStatus)} ${t('bfp_label')}`;
+
+      html += `<div class="week-row${ds === todayStr ? ' is-today' : ''}${isEmpty ? ' is-empty' : ''}"
+        data-goto="${esc(ds)}" role="button" tabindex="0">
+        <div class="week-row-date">
+          <div class="week-row-day">${esc(dayLabel)}</div>
+          <div class="week-row-sub">${esc(fmtShort(d))}${isEmpty ? ' — ' + t('no_prod_day') : ''}</div>
+        </div>
+        <div class="week-row-right">
+          ${showShape ? `<span class="week-team-line">${shapeText}</span>` : ''}
+          ${showBfp   ? `<span class="week-team-line">${bfpText}</span>`   : ''}
+          <span class="week-chevron">›</span>
+        </div>
+      </div>`;
+    }
+    return html || `<div class="no-prod">${t('no_prod_lookahead', { n: SCHEDULE_LOOKAHEAD })}</div>`;
+  }
+
+  // ─── UPDATE NAV BAR ───────────────────────────────────────────────────────
+
+  function updateNav() {
+    const todayStr = toDateStr(new Date());
+    const curStr   = toDateStr(currentDate);
+    const label    = document.getElementById('date-label');
+    const sub      = document.getElementById('date-sub');
+    const wt       = document.getElementById('week-toggle');
+
+    let labelText, subText, isToday = false, isWeek = false;
+    if (viewMode === 'week') {
+      labelText = t('week_view');
+      subText = t('next_n_days', { n: SCHEDULE_LOOKAHEAD });
+      isWeek = true;
+    } else {
+      const diff = Math.round((parseDate(curStr) - parseDate(todayStr)) / 86400000);
+      if (diff === 0)       { labelText = t('today_label');     isToday = true; }
+      else if (diff === 1)  { labelText = t('tomorrow_label');  }
+      else if (diff === -1) { labelText = t('yesterday_label'); }
+      else                  { labelText = fmtFull(currentDate); }
+      subText = diff === 0 ? fmtFull(currentDate)
+              : diff > 0 ? t('days_away', { n: diff }) : t('days_ago', { n: -diff });
+    }
+
+    // Manager nav
+    if (label && sub && wt) {
+      label.textContent = labelText;
+      label.classList.toggle('is-today', isToday);
+      sub.textContent   = subText;
+      wt.classList.toggle('active', isWeek);
+    }
+    // Worker header date row (mirror of the same data)
+    const wLbl = document.getElementById('worker-date-label');
+    const wSub = document.getElementById('worker-date-sub');
+    const wWk  = document.getElementById('worker-week-btn');
+    if (wLbl) { wLbl.textContent = labelText; wLbl.classList.toggle('is-today', isToday); }
+    if (wSub) { wSub.textContent = subText; }
+    if (wWk)  { wWk.classList.toggle('active', isWeek); }
+  }
+
+  // ─── MAIN RENDER ──────────────────────────────────────────────────────────
+
+  function render() {
+    updateNav();
+
+    // Consolidated overdue panel (one block, merged by SKU, pretzel-first display).
+    // Filtered by role — team views only see their own team's overdue items.
+    let overdueHtml = '';
+    if (schedule.overdue.length > 0) {
+      const mergeBySku = (items) => {
+        const m = {};
+        items.forEach(o => { m[o.sku] = (m[o.sku] || 0) + o.batches; });
+        return Object.entries(m).map(([sku, b]) => {
+          const bs = getBatchSize(sku);
+          const p  = Math.round(b * bs);
+          return `${esc(sku)} · <strong>${p}</strong> pretzel${p !== 1 ? 's' : ''} (${b} batch${b !== 1 ? 'es' : ''})`;
+        }).join(' · ');
+      };
+      const showShape  = userRole === 'manager' || userRole === 'shape';
+      const showBfp    = userRole === 'manager' || userRole === 'bfp';
+      const shapeOver  = showShape ? schedule.overdue.filter(o => o.team === 'shape') : [];
+      const bfpOver    = showBfp   ? schedule.overdue.filter(o => o.team === 'bfp')   : [];
+      const visibleSet = new Set([...shapeOver, ...bfpOver].map(o => `${o.team}:${o.sku}`));
+      const groupHtml  = (items, label) => items.length === 0 ? '' :
+        `<div style="margin-top:6px"><span style="font:700 12px 'Manrope',sans-serif;text-transform:uppercase;letter-spacing:0.5px">${label}:</span> ${mergeBySku(items)}</div>`;
+      if (visibleSet.size > 0) {
+        overdueHtml = `<div class="overdue-banner">
+          <div style="font:800 14px 'Manrope',sans-serif;margin-bottom:2px">${t('overdue_title', { n: visibleSet.size })}</div>
+          ${groupHtml(shapeOver, t('shape_label'))}
+          ${groupHtml(bfpOver, t('bfp_label'))}
+        </div>`;
+      }
+    }
+
+    // Unconfigured SKU warnings — manager only (configuring is an admin task)
+    const unconfigHtml = userRole === 'manager'
+      ? (schedule.unconfigured || []).map(sku =>
+          `<div class="alert-banner" style="display:flex;align-items:center;justify-content:space-between;gap:12px">
+            <span>${t('new_sku', { sku: esc(sku) })}</span>
+            <button class="btn-link" data-cfg-btn data-sku="${esc(sku)}" style="white-space:nowrap">${t('set_up')}</button>
+          </div>`
+        ).join('')
+      : '';
+
+    // Unconfirmed deliveries today
+    const todayStr = toDateStr(new Date());
+    const unconfirmed = allDeliveries.filter(d =>
+      d.date === todayStr && !['delivered','picked_up','cancelled'].includes(d.status)
+    );
+    const unconfirmedHtml = unconfirmed.length > 0
+      ? `<div class="alert-banner">${t('unconfirmed', { n: unconfirmed.length })}<a href="../delivery-planner/index.html">${t('go_to_planner')}</a></div>`
+      : '';
+
+    // Possible-duplicate deliveries — manager only (data-quality flag, not workflow)
+    let dupHtml = '';
+    if (userRole === 'manager') {
+      const dupGroups = {};
+      allDeliveries.forEach(d => {
+        if (['delivered','picked_up','cancelled'].includes(d.status)) return;
+        if (!d.date || d.date < todayStr) return;
+        const cust = d.customer || d.location || '?';
+        const key = `${d.date}|${cust}`;
+        if (!dupGroups[key]) dupGroups[key] = [];
+        dupGroups[key].push(d);
+      });
+      const dups = Object.entries(dupGroups).filter(([,arr]) => arr.length >= 2);
+      if (dups.length > 0) {
+        dupHtml = `<div class="alert-banner" style="background:#fff3cd;color:#856404">
+            ${t('dup_alert', { n: dups.length })}
+            ${dups.map(([key,arr]) => {
+              const [date, cust] = key.split('|');
+              return `<strong>${esc(cust)}</strong> · ${esc(date)} (${arr.length}×)`;
+            }).join(', ')} —
+            <a href="../delivery-planner/index.html">${t('review_planner')}</a>
+          </div>`;
+      }
+    }
+
+    // Aging-dough banner — manager only. Reads from getInventoryReportLocal() so the
+    // numbers match the stock tab's per-row aging indicator exactly.
+    let agingDoughHtml = '';
+    let overbakeHtml = '';
+    if (userRole === 'manager') {
+      const inventoryReport = getInventoryReportLocal();
+      const aging = inventoryReport.alerts.agingDough;
+      if (aging.length > 0) {
+        const items = aging.map(a => {
+          const bs = getBatchSize(a.sku) || 1;
+          const batches = (a.pretzels / bs).toFixed(1).replace(/\.0$/, '');
+          return `<strong>${esc(a.sku)}</strong> · ${a.pretzels}p (~${batches} batches) · ${a.ageDays}d old`;
+        }).join(' · ');
+        const hasCritical = aging.some(a => a.critical);
+        const bg = hasCritical ? '#FCEBEB' : '#fff3cd';
+        const fg = hasCritical ? 'var(--red)' : '#856404';
+        const icon = hasCritical ? '🔴' : '🟡';
+        const label = hasCritical
+          ? (appLang === 'es' ? `Masa pasada — descartar o usar hoy:` : `Aging dough past ${DOUGH_AGE_FAIL_DAYS} days — discard or use today:`)
+          : (appLang === 'es' ? 'Masa envejeciendo — usar pronto:'    : 'Aging dough — use soon:');
+        agingDoughHtml = `<div class="alert-banner" style="background:${bg};color:${fg}"><strong>${icon} ${label}</strong> ${items}</div>`;
+      }
+      // BFP overbake banner — fires when BFP attributed more pretzels
+      // than the cold-ferment snapshot said existed. Indicates the
+      // inventory snapshot is stale or under-counted. The schedule will
+      // silently shrink shape demand if uncorrected (phantom frozen
+      // covers shape).
+      const overbakes = inventoryReport.alerts.bfpOverbake || [];
+      if (overbakes.length > 0) {
+        // Group by SKU + sum phantom pretzels. One delivery per session
+        // could log many small overbakes; user wants the summary.
+        const bySku = {};
+        overbakes.forEach(o => {
+          if (!bySku[o.sku]) bySku[o.sku] = 0;
+          bySku[o.sku] += Number(o.phantomPretzels) || 0;
+        });
+        const items = Object.entries(bySku)
+          .map(([sku, phantom]) => `<strong>${esc(sku)}</strong> · ~${Math.round(phantom)}p`)
+          .join(' · ');
+        const label = appLang === 'es'
+          ? '⚠️ BFP horneó más de lo registrado — actualiza el inventario:'
+          : '⚠️ BFP attributed more dough than the snapshot tracked — update the inventory:';
+        overbakeHtml = `<div class="alert-banner" style="background:#fff3cd;color:#856404"><strong>${label}</strong> ${items}</div>`;
+      }
+    }
+
+    // Worker views see no banners (calmer UX). Per-card 🚨 tag still surfaces overdue work.
+    const alertHtml = userRole === 'manager'
+      ? (overdueHtml + agingDoughHtml + overbakeHtml + unconfigHtml + dupHtml + unconfirmedHtml)
+      : '';
+    document.getElementById('alert-area').innerHTML = alertHtml;
+
+    // Tab bar — manager + FOH (shape/BFP see only their own card; FOH still
+    // needs to switch between Dips and Stock).
+    const tabBar = document.getElementById('tab-bar');
+    const tabBarVisible = viewMode !== 'week'
+      && (userRole === 'manager' || userRole === 'foh');
+    tabBar.style.display = tabBarVisible ? 'flex' : 'none';
+    document.querySelectorAll('.tab-btn').forEach(btn =>
+      btn.classList.toggle('active', btn.dataset.tab === dayTab));
+
+    document.getElementById('main-view').innerHTML  =
+      viewMode === 'week' ? renderWeekView() : renderDayView();
+
+    bindActions();
+  }
+
+  // ─── BIND ACTIONS ─────────────────────────────────────────────────────────
+
+  function bindActions() {
+    document.querySelectorAll('[data-worker-dec]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const { type, date } = btn.dataset;
+        const cur = getWorkers(type, date);
+        if (cur <= 1) return;
+        saveWorkers(type, date, cur - 1);
+        schedule = buildOptimalSchedule();
+        render();
+      });
+    });
+    document.querySelectorAll('[data-worker-inc]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const { type, date } = btn.dataset;
+        saveWorkers(type, date, getWorkers(type, date) + 1);
+        schedule = buildOptimalSchedule();
+        render();
+      });
+    });
+    document.querySelectorAll('[data-log-step]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const [type, dateStr, sku] = btn.dataset.key.split('|');
+        const delta = parseInt(btn.dataset.delta, 10);
+        bumpStepper(type, dateStr, sku, delta);
+      });
+    });
+    document.querySelectorAll('[data-pack-toggle]').forEach(btn => {
+      btn.addEventListener('click', () => togglePackedCase(btn));
+    });
+    // Dips tab stepper — per-dip, single OR double batches, simpler than shape/bfp.
+    document.querySelectorAll('[data-dip-step]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const sku = btn.dataset.sku;
+        const size = btn.dataset.size || 'single';
+        const delta = parseInt(btn.dataset.delta, 10);
+        logDipDelta(sku, size, delta).catch(err => alert('Error logging dip: ' + err.message));
+      });
+    });
+    // Recent-batches undo on Dips cards — writes a negative cheese_done
+    // row on the original batch date, cancelling the credit. Confirms
+    // before sending so misclicks are reversible.
+    document.querySelectorAll('[data-dip-undo]').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        const sku = btn.dataset.sku;
+        const date = btn.dataset.date;
+        const size = btn.dataset.size || 'single';
+        const batches = Number(btn.dataset.batches) || 1;
+        const cfg = DIP_CONFIG[sku];
+        const units = (size === 'double' ? cfg?.doubleBatchSize : cfg?.singleBatchSize) || 0;
+        const msg = appLang === 'es'
+          ? `Deshacer ${batches} × ${size} (${batches * units} dips) en ${date}?`
+          : `Undo ${batches} × ${size} (${batches * units} dips) on ${date}?`;
+        if (!window.confirm(msg)) return;
+        try {
+          const completions = JSON.stringify([{ sku, batches: -batches, size }]);
+          await appendLog(PRODUCTION_LOG, {
+            action: 'cheese_done',
+            date,
+            completions,
+            timeStamp: new Date().toISOString(),
+          });
+          await loadProduction();
+          schedule = buildOptimalSchedule();
+          render();
+        } catch (err) {
+          alert('Error undoing batch: ' + err.message);
+        }
+      });
+    });
+    // Inline ON HAND editor on Dips cards. Click the metric value → swaps
+    // to a number input. Enter or blur commits via saveDipOnHand; Escape
+    // restores the original render.
+    document.querySelectorAll('[data-onhand-edit]').forEach(metricEl => {
+      metricEl.addEventListener('click', () => {
+        const sku = metricEl.dataset.onhandEdit;
+        const currentText = metricEl.querySelector('strong')?.textContent || '0';
+        const originalHtml = metricEl.innerHTML;
+        const input = document.createElement('input');
+        input.type = 'number';
+        input.min = '0';
+        input.value = currentText;
+        // Class is picked up by _isInputBusy so a softRefresh tick can't
+        // erase the input mid-type.
+        input.className = 'inline-onhand-edit';
+        input.style.cssText = 'width:80px;padding:4px 6px;border:1.5px solid var(--gray-2);border-radius:6px;font:700 18px "Manrope",sans-serif;text-align:center;color:var(--dark)';
+        metricEl.innerHTML = '';
+        metricEl.appendChild(input);
+        input.focus();
+        input.select();
+        let committed = false;
+        const commit = () => {
+          if (committed) return;
+          committed = true;
+          const val = input.value.trim();
+          if (val === '' || val === currentText) {
+            metricEl.innerHTML = originalHtml;
+            return;
+          }
+          saveDipOnHand(sku, val).catch(err => {
+            metricEl.innerHTML = originalHtml;
+            alert('Error saving on-hand: ' + err.message);
+          });
+        };
+        const cancel = () => {
+          if (committed) return;
+          committed = true;
+          metricEl.innerHTML = originalHtml;
+        };
+        input.addEventListener('blur', commit);
+        input.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter') { e.preventDefault(); commit(); }
+          else if (e.key === 'Escape') { e.preventDefault(); cancel(); }
+        });
+      });
+    });
+    // Backward-compat: handle any remaining data-cheese-step buttons.
+    document.querySelectorAll('[data-cheese-step]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const delta = parseInt(btn.dataset.delta, 10);
+        logCheeseDelta(delta).catch(err => alert('Error logging cheese: ' + err.message));
+      });
+    });
+    document.querySelectorAll('[data-log-input]').forEach(inp => {
+      const [type, dateStr, sku] = inp.dataset.key.split('|');
+      inp.addEventListener('focus', () => inp.select());
+      inp.addEventListener('input', () => setStepperValue(type, dateStr, sku, inp.value));
+    });
+    document.querySelectorAll('[data-extra-btn]').forEach(btn => {
+      btn.addEventListener('click', () => openExtraSheet(btn.dataset.type, btn.dataset.date));
+    });
+    document.querySelectorAll('[data-cfg-btn]').forEach(btn => {
+      btn.addEventListener('click', () => openCfgSheet(btn.dataset.sku));
+    });
+    // Worker view: details toggle + done-card-expand
+    document.querySelectorAll('[data-details-toggle]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const sku = btn.dataset.sku;
+        const type = userRole === 'bfp' ? 'bfp' : 'shape';
+        const panel = document.getElementById(`wdp-${type}-${sku}`);
+        if (panel) panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+      });
+    });
+    document.querySelectorAll('[data-expand-sku]').forEach(card => {
+      card.addEventListener('click', () => {
+        expandedDoneCards.add(card.dataset.expandSku);
+        render();
+      });
+    });
+    const stockSaveBtn = document.getElementById('stock-save');
+    if (stockSaveBtn) stockSaveBtn.addEventListener('click', saveStock);
+    const stockAuditBtn = document.getElementById('stock-audit');
+    if (stockAuditBtn) stockAuditBtn.addEventListener('click', showStockAuditModal);
+    // FOH dough-transfer save button (only present on FOH home view).
+    const fohTransferBtn = document.getElementById('foh-transfer-save');
+    if (fohTransferBtn) fohTransferBtn.addEventListener('click', saveFohTransfer);
+    // ↺ zero button: pre-fill the SKU's on-hand input to 0 without saving.
+    // Manager / FOH still has to click Save Stock Count to commit, so a
+    // misclick is easily fixed by editing the field back to the right value.
+    document.querySelectorAll('[data-stock-zero]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const sku = btn.dataset.zeroSku;
+        const inp = document.querySelector(`input[data-stock-section="onhand"][data-sku="${sku.replace(/"/g, '\\"')}"]`);
+        if (inp) {
+          inp.value = '0';
+          inp.focus();
+          inp.select();
+        }
+      });
+    });
+    // Stock tab → Box mappings list — click a row to re-open its config sheet.
+    document.querySelectorAll('[data-box-edit]').forEach(row => {
+      row.addEventListener('click', () => openCfgSheet(row.dataset.boxEdit));
+    });
+    document.querySelectorAll('[data-goto]').forEach(row => {
+      row.addEventListener('click', () => {
+        currentDate = parseDate(row.dataset.goto);
+        viewMode = 'day';
+        render();
+      });
+    });
+  }
+
+  // ─── EXTRA / UNSCHEDULED BATCH SHEET ─────────────────────────────────────
+
+  function updateExtraHint() {
+    const sku = document.getElementById('extra-sku-select').value;
+    const bs  = getBatchSize(sku);
+    const stepDelta = getStepDelta(extraType, sku);
+    const hintEl = document.getElementById('extra-hint');
+    if (!hintEl) return;
+    if (!sku || !bs) { hintEl.textContent = ''; return; }
+    const batches = bs > 0 ? (extraValuePretzels / bs).toFixed(2).replace(/\.?0+$/, '') : 0;
+    const unitLabel = extraType === 'bfp' && getTraySize(sku) > 0
+      ? t('tray_of', { n: stepDelta })
+      : t('batch_of', { n: bs });
+    const equivLabel = appLang === 'es'
+      ? `≈ ${batches} ${batches !== '1' ? 'tandas' : 'tanda'} · +/- = ${unitLabel}`
+      : `≈ ${batches} batch${batches !== '1' ? 'es' : ''} · +/- = ${unitLabel}`;
+    hintEl.textContent = equivLabel;
+  }
+
+  function openExtraSheet(type, dateStr) {
+    extraType  = type;
+    extraDate  = dateStr;
+    extraValuePretzels = 0;
+
+    const teamLabel = type === 'shape' ? t('shape_label') : t('bfp_label');
+    document.getElementById('extra-title').textContent =
+      `${teamLabel} — ${t('extra_title')}`;
+    document.getElementById('extra-sub').textContent =
+      `${dateStr} · ${t('extra_sub')}`;
+    document.getElementById('extra-val').value = '0';
+
+    // Populate SKU dropdown (includes in-app configured SKUs)
+    document.getElementById('extra-sku-select').innerHTML =
+      allProductionSkus().map(sku => `<option value="${esc(sku)}">${esc(sku)}</option>`).join('');
+
+    // Default to one step's worth so users see what + does
+    const sku = document.getElementById('extra-sku-select').value;
+    extraValuePretzels = getStepDelta(type, sku) || 0;
+    document.getElementById('extra-val').value = String(extraValuePretzels);
+    updateExtraHint();
+
+    document.getElementById('extra-overlay').classList.add('open');
+  }
+
+  async function saveExtra() {
+    const sku = document.getElementById('extra-sku-select').value;
+    if (!sku || extraValuePretzels <= 0) { alert(t('select_sku_qty') === 'select_sku_qty' ? 'Select a SKU and quantity.' : t('select_sku_qty')); return; }
+    const bs = getBatchSize(sku);
+    if (!bs) { alert('Batch size not configured for this SKU.'); return; }
+    const batchEquiv = extraValuePretzels / bs; // fractional ok
+    const promptMsg = appLang === 'es'
+      ? `¿Registrar ${extraValuePretzels} pretzels extra de ${sku} para ${extraDate}?`
+      : `Log ${extraValuePretzels} extra pretzels of ${sku} for ${extraDate}?`;
+    if (!confirm(promptMsg)) return;
+
+    const saveBtn = document.getElementById('extra-save');
+    saveBtn.disabled = true; saveBtn.textContent = appLang === 'es' ? 'Guardando…' : 'Saving…';
+    try {
+      await appendLog(PRODUCTION_LOG, {
+        action:      extraType === 'shape' ? 'shape_done' : 'bfp_done',
+        date:        extraDate,
+        completions: JSON.stringify([{ sku, batches: batchEquiv }]),
+        workers:     getWorkers(extraType, extraDate),
+        timeStamp:   new Date().toISOString(),
+      });
+      document.getElementById('extra-overlay').classList.remove('open');
+      await loadProduction();
+      schedule = buildOptimalSchedule();
+      render();
+    } catch (e) {
+      saveBtn.disabled = false; saveBtn.textContent = t('extra_save');
+      alert('Error saving: ' + e.message);
+    }
+  }
+
+  // ─── CONFIGURE SKU SHEET ─────────────────────────────────────────────────
+  // Lets you set batch size + type for any SKU that appears in delivery orders
+  // but isn't in the hardcoded BATCH_SIZES. Config saved to production log.
+
+  let cfgSku = null, cfgType = 'standard', cfgMode = 'config';
+
+  function setCfgMode(mode) {
+    cfgMode = mode;
+    document.querySelectorAll('.cfg-mode-btn').forEach(btn => {
+      const isActive = btn.dataset.cfgMode === mode;
+      btn.classList.toggle('active', isActive);
+      btn.style.background = isActive ? 'var(--white)' : 'none';
+      btn.style.color = isActive ? 'var(--dark)' : 'var(--gray-4)';
+      btn.style.boxShadow = isActive ? '0 1px 4px rgba(0,0,0,0.10)' : 'none';
+    });
+    document.getElementById('cfg-config-panel').style.display = mode === 'config' ? '' : 'none';
+    document.getElementById('cfg-alias-panel').style.display  = mode === 'alias'  ? '' : 'none';
+    document.getElementById('cfg-box-panel').style.display    = mode === 'box'    ? '' : 'none';
+  }
+
+  // Render one box-mapping row: SKU dropdown + multiplier input + remove btn.
+  // Existing rows seeded from skuConfig[cfgSku].expandsTo when re-opening
+  // the sheet for a previously-mapped box.
+  function renderCfgBoxRow(initialSku, initialMul) {
+    const row = document.createElement('div');
+    row.className = 'cfg-box-row';
+    row.style.cssText = 'display:grid;grid-template-columns:1fr 80px 36px;gap:6px;align-items:center';
+    const skuSelect = document.createElement('select');
+    skuSelect.className = 'cfg-box-sku extra-sku-select';
+    skuSelect.style.margin = '0';
+    skuSelect.innerHTML = '<option value="">Pick SKU…</option>'
+      + allSkus.filter(s => s !== cfgSku).map(s => `<option value="${esc(s)}">${esc(s)}</option>`).join('');
+    if (initialSku) skuSelect.value = initialSku;
+    const mulInput = document.createElement('input');
+    mulInput.type = 'number';
+    mulInput.min = '1';
+    mulInput.placeholder = 'qty';
+    mulInput.className = 'cfg-box-mul';
+    mulInput.style.cssText = 'padding:10px;border:1.5px solid var(--gray-2);border-radius:8px;width:100%;box-sizing:border-box';
+    if (initialMul) mulInput.value = String(initialMul);
+    const removeBtn = document.createElement('button');
+    removeBtn.type = 'button';
+    removeBtn.textContent = '×';
+    removeBtn.style.cssText = 'background:none;border:1px solid var(--gray-2);border-radius:8px;padding:8px;font-size:18px;color:var(--gray-4);cursor:pointer';
+    removeBtn.addEventListener('click', () => row.remove());
+    row.appendChild(skuSelect);
+    row.appendChild(mulInput);
+    row.appendChild(removeBtn);
+    document.getElementById('cfg-box-rows').appendChild(row);
+    return row;
+  }
+
+  function openCfgSheet(sku) {
+    cfgSku = sku;
+    cfgType = skuConfig[sku]?.type || 'standard';
+    document.getElementById('cfg-sku-display').textContent = sku;
+    document.getElementById('cfg-batch-size').value = skuConfig[sku]?.batchSize || '';
+    document.getElementById('cfg-tray-size').value  = skuConfig[sku]?.traySize  || '';
+    document.getElementById('cfg-case-size').value  = skuConfig[sku]?.caseSize  || '';
+    document.querySelectorAll('.cfg-type-btn').forEach(btn =>
+      btn.classList.toggle('selected', btn.dataset.cfgType === cfgType));
+
+    // Populate alias dropdown with all canonical SKUs from skus.json
+    const target = document.getElementById('cfg-alias-target');
+    target.innerHTML = allSkus
+      .filter(s => s !== sku) // can't alias to self
+      .map(s => `<option value="${esc(s)}">${esc(s)}</option>`).join('');
+
+    // Seed box-mapping rows from existing skuConfig.expandsTo. If empty,
+    // start with one blank row so the manager has something to fill in.
+    const boxRowsContainer = document.getElementById('cfg-box-rows');
+    boxRowsContainer.innerHTML = '';
+    const existing = skuConfig[sku]?.expandsTo || [];
+    if (existing.length > 0) {
+      existing.forEach((e) => renderCfgBoxRow(e.sku, e.multiplier));
+    } else {
+      renderCfgBoxRow('', '');
+    }
+
+    // Default to box mode if the SKU name starts with "Catering:" — likely a
+    // box, and that's almost certainly what the manager opened the sheet for.
+    // Otherwise default to the existing config tab.
+    const looksLikeBox = /^catering:/i.test(sku);
+    setCfgMode(looksLikeBox ? 'box' : 'config');
+    document.getElementById('cfg-overlay').classList.add('open');
+  }
+
+  async function saveCfg() {
+    const saveBtn = document.getElementById('cfg-save');
+    saveBtn.disabled = true; saveBtn.textContent = appLang === 'es' ? 'Guardando…' : 'Saving…';
+    try {
+      if (cfgMode === 'alias') {
+        const target = document.getElementById('cfg-alias-target').value;
+        if (!target) { alert('Pick a target SKU first'); throw new Error('No target'); }
+        await appendLog(PRODUCTION_LOG, {
+          action: 'sku_alias', from: cfgSku, to: target,
+          timeStamp: new Date().toISOString(),
+        });
+      } else if (cfgMode === 'box') {
+        // Read all rows in the box-mapping panel; each row contributes one
+        // entry to expandsTo if both fields are filled. Empty rows ignored.
+        const rows = [...document.querySelectorAll('#cfg-box-rows .cfg-box-row')];
+        const expandsTo = rows.map((r) => {
+          const sku = r.querySelector('.cfg-box-sku').value.trim();
+          const multiplier = parseInt(r.querySelector('.cfg-box-mul').value, 10) || 0;
+          return sku && multiplier > 0 ? { sku, multiplier } : null;
+        }).filter(Boolean);
+        if (expandsTo.length === 0) {
+          alert('Add at least one SKU + quantity (or use "Map to existing" if you just want to alias).');
+          throw new Error('No expansions');
+        }
+        await appendLog(PRODUCTION_LOG, {
+          action: 'sku_config', sku: cfgSku,
+          batchSize: '0', traySize: '0', caseSize: '0',
+          type: 'box',
+          expandsTo: JSON.stringify(expandsTo),
+          timeStamp: new Date().toISOString(),
+        });
+      } else {
+        const batchSize = parseInt(document.getElementById('cfg-batch-size').value, 10);
+        if (!batchSize || batchSize < 1) { alert('Enter a batch size first'); throw new Error('No size'); }
+        const traySize = parseInt(document.getElementById('cfg-tray-size').value, 10) || 0;
+        const caseSize = parseInt(document.getElementById('cfg-case-size').value, 10) || 0;
+        await appendLog(PRODUCTION_LOG, {
+          action: 'sku_config', sku: cfgSku,
+          batchSize: String(batchSize),
+          traySize:  String(traySize),
+          caseSize:  String(caseSize),
+          type: cfgType,
+          timeStamp: new Date().toISOString(),
+        });
+      }
+      document.getElementById('cfg-overlay').classList.remove('open');
+      await loadProduction();
+      // Box-mapping changes affect the resolved delivery line items, so we
+      // must re-resolve before rebuilding the schedule. Pretzel/SKU config
+      // changes only affect downstream — schedule rebuild covers them.
+      resolveDeliveriesNow();
+      schedule = buildOptimalSchedule();
+      render();
+    } catch (e) {
+      if (!['No target', 'No size', 'No expansions'].includes(e.message)) alert('Error saving: ' + e.message);
+    } finally {
+      saveBtn.disabled = false; saveBtn.textContent = 'Save';
+    }
+  }
+
+  // ─── DATA LOADING ─────────────────────────────────────────────────────────
+
+  // Re-resolve deliveries from raw logs using the latest skuConfig (for
+  // catering box expansion). Called after both deliveries + production are
+  // loaded, since loadDeliveries and loadProduction run in parallel and
+  // skuConfig isn't known until loadProduction completes.
+  function resolveDeliveriesNow() {
+    allDeliveries = resolveDeliveries(deliveryLogs, {
+      shapeOnlyEnabled: SHAPE_ONLY_ENABLED,
+      skuConfig,
+    });
+  }
+
+  async function loadDeliveries() {
+    const logs = await fetchLog(DELIVERY_LOG);
+    deliveryLogs = Array.isArray(logs) ? logs : [];
+    // First-pass resolution with whatever skuConfig is currently known
+    // (might be empty if loadProduction hasn't completed yet — that's fine,
+    // resolveDeliveriesNow() runs again at the end of init/refresh).
+    resolveDeliveriesNow();
+  }
+
+  async function loadProduction() {
+    const logs = await fetchLog(PRODUCTION_LOG);
+    productionLogs = Array.isArray(logs) ? logs : [];
+    // Shared resolver returns the full bundle — unpack into module-scope state.
+    const resolved = resolveProductionLogs(productionLogs);
+    productionState   = resolved.state;
+    skuConfig         = resolved.skuConfig;
+    skuAliases        = resolved.skuAliases;
+    latestInventoryTs = resolved.latestInventoryTs;
+    packedCases       = resolved.packedCases || {};
+  }
+
+  async function loadSkus() {
+    try {
+      const r = await fetch('../delivery-planner/skus.json');
+      allSkus = await r.json();
+    } catch { allSkus = Object.keys(BATCH_SIZES); } // fallback to hardcoded list
+  }
+
+  // Pull per-dip FOH walk-in rates from the worker (last 28 days of Square
+  // orders → daily average per dip). Best-effort: if the fetch fails the
+  // schedulers fall back to delivery-only demand for cheese (0 demand for
+  // retail dips, so they show no upcoming batches until the next refresh).
+  async function loadDipConsumption() {
+    try {
+      const r = await fetch(DIP_CONSUMPTION_URL);
+      if (!r.ok) return;
+      const data = await r.json();
+      const next = {};
+      Object.entries(data.dips || {}).forEach(([sku, info]) => {
+        next[sku] = Number(info.dailyAvg) || 0;
+      });
+      dipDailyAvgs = next;
+      cheeseFohDailyAvg = next['3oz cheese dip'] || 0;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('dip-consumption fetch failed:', e);
+    }
+  }
+  // Backward-compat alias — keep so all four Promise.all sites keep working.
+  // Phase 3d migrates the call sites; remove this in Phase 4 cleanup.
+  const loadCheeseConsumption = loadDipConsumption;
+
+  // ─── NAV WIRING ───────────────────────────────────────────────────────────
+
+  document.getElementById('nav-prev').addEventListener('click', () => {
+    if (viewMode === 'week') { viewMode = 'day'; }
+    else { currentDate = addDays(currentDate, -1); }
+    render();
   });
-  // 400ms debounce — same as barcode-lookup page
-  document.getElementById('barcode-input').addEventListener('input', () => {
-    clearTimeout(scanDebounceTimer);
-    scanDebounceTimer = setTimeout(() => {
-      if (document.getElementById('barcode-input').value.trim()) scanIngredient();
-    }, 400);
+  document.getElementById('nav-next').addEventListener('click', () => {
+    if (viewMode === 'week') return;
+    currentDate = addDays(currentDate, 1);
+    render();
+  });
+  document.getElementById('date-display').addEventListener('click', () => {
+    currentDate = new Date();
+    viewMode = 'day';
+    render();
+  });
+  document.getElementById('week-toggle').addEventListener('click', () => {
+    viewMode = viewMode === 'week' ? 'day' : 'week';
+    render();
+  });
+  // Worker header nav buttons: same actions as manager nav
+  const wPrev = document.getElementById('worker-prev');
+  const wNext = document.getElementById('worker-next');
+  const wDate = document.getElementById('worker-date-btn');
+  const wWeek = document.getElementById('worker-week-btn');
+  if (wPrev) wPrev.addEventListener('click', () => {
+    if (viewMode === 'week') { viewMode = 'day'; }
+    else { currentDate = addDays(currentDate, -1); }
+    render();
+  });
+  if (wNext) wNext.addEventListener('click', () => {
+    if (viewMode === 'week') return;
+    currentDate = addDays(currentDate, 1);
+    render();
+  });
+  if (wDate) wDate.addEventListener('click', () => {
+    currentDate = new Date();
+    viewMode = 'day';
+    render();
+  });
+  if (wWeek) wWeek.addEventListener('click', () => {
+    viewMode = viewMode === 'week' ? 'day' : 'week';
+    render();
+  });
+  document.getElementById('refresh-btn').addEventListener('click', async () => {
+    const btn = document.getElementById('refresh-btn');
+    btn.disabled = true; btn.textContent = '…';
+    try {
+      await Promise.all([loadDeliveries(), loadProduction(), loadSkus(), loadCheeseConsumption()]); resolveDeliveriesNow();
+      schedule = buildOptimalSchedule();
+      render();
+    } finally {
+      btn.disabled = false; btn.textContent = '↻';
+    }
   });
 
-  // History filters — live re-render on any change
-  ['filter-batch','filter-barcode','filter-date-from','filter-date-to','filter-product'].forEach((id) => {
-    document.getElementById(id).addEventListener('input', renderHistory);
-    document.getElementById(id).addEventListener('change', renderHistory);
-  });
-  document.getElementById('filter-clear').addEventListener('click', () => {
-    ['filter-batch','filter-barcode','filter-date-from','filter-date-to'].forEach((id) => { document.getElementById(id).value = ''; });
-    document.getElementById('filter-product').value = '';
-    renderHistory();
+  // Language toggle — flip and re-render. Persist to localStorage.
+  function syncLangBtn() {
+    const setText = (id, text) => { const el = document.getElementById(id); if (el) el.textContent = text; };
+    const setHTML = (id, html) => { const el = document.getElementById(id); if (el) el.innerHTML  = html; };
+
+    const lb = document.getElementById('lang-btn');
+    if (lb) lb.textContent = appLang === 'en' ? 'ES' : 'EN';
+
+    // Worker header — set role name + active-lang highlight (date is set by updateNav)
+    if (userRole !== 'manager') {
+      const teamLabel = userRole === 'shape' ? t('header_shape_team') : t('header_bfp_team');
+      const emoji     = userRole === 'shape' ? '🥨' : '🔥';
+      setHTML('worker-header-name', `${emoji} ${esc(teamLabel)}`);
+      const esEl = document.getElementById('worker-lang-es');
+      const enEl = document.getElementById('worker-lang-en');
+      if (esEl) esEl.className = appLang === 'es' ? 'active-lang' : '';
+      if (enEl) enEl.className = appLang === 'en' ? 'active-lang' : '';
+      const wb = document.getElementById('worker-week-btn');
+      if (wb) wb.textContent = appLang === 'es' ? 'Sem' : 'Week';
+    }
+
+    // Tab bar
+    const tShape = document.querySelector('.tab-btn[data-tab="shape"]');
+    const tBfp   = document.querySelector('.tab-btn[data-tab="bfp"]');
+    const tStock = document.querySelector('.tab-btn[data-tab="stock"]');
+    if (tShape) tShape.textContent = '🥨 ' + t('shape_tab');
+    if (tBfp)   tBfp.textContent   = '🔥 ' + t('bfp_tab');
+    if (tStock) tStock.textContent = '📦 ' + t('stock_tab');
+
+    const wt = document.getElementById('week-toggle');
+    if (wt) wt.textContent = appLang === 'es' ? 'Sem' : 'Week';
+
+    // Configure SKU sheet
+    setText('cfg-title-text', t('cfg_title'));
+    setText('cfg-newtab',     t('cfg_new_tab'));
+    setText('cfg-aliastab',   t('cfg_alias_tab'));
+    setText('cfg-lbl-batch',  t('cfg_per_batch'));
+    setHTML('cfg-lbl-tray',   `${t('cfg_per_tray')} <span style="font-weight:400;color:var(--gray-3)">${t('cfg_per_tray_sub')}</span>`);
+    setHTML('cfg-lbl-case',   `${t('cfg_per_case')} <span style="font-weight:400;color:var(--gray-3)">${t('cfg_per_case_sub')}</span>`);
+    setText('cfg-lbl-type',   t('cfg_type'));
+    setText('cfg-btn-std',    t('cfg_standard'));
+    setText('cfg-btn-coat',   t('cfg_coating'));
+    setText('cfg-btn-foh',    t('cfg_foh'));
+    setText('cfg-alias-help', t('cfg_alias_help'));
+    setText('cfg-alias-lbl',  t('cfg_alias_label'));
+    setText('cfg-save',       t('save'));
+    setText('cfg-cancel',     t('cancel'));
+
+    // Extra batch sheet
+    setText('extra-title',       t('extra_title'));
+    setText('extra-sub',         t('extra_sub'));
+    setText('extra-batches-lbl', t('extra_batches'));
+    setText('extra-save',        t('extra_save'));
+    setText('extra-cancel',      t('cancel'));
+  }
+  syncLangBtn();
+  function flipLang() {
+    appLang = appLang === 'en' ? 'es' : 'en';
+    try { localStorage.setItem('prod-lang', appLang); } catch {}
+    syncLangBtn();
+    if (userRole === 'shape')      document.title = appLang === 'es' ? 'Formar · Producción' : 'Shape · Production';
+    else if (userRole === 'bfp')   document.title = appLang === 'es' ? 'HCE · Producción'    : 'BFP · Production';
+    else                            document.title = appLang === 'es' ? 'Producción' : 'Production';
+    schedule = buildOptimalSchedule();
+    render();
+  }
+  document.getElementById('lang-btn').addEventListener('click', flipLang);
+  const wLang = document.getElementById('worker-lang-btn');
+  if (wLang) wLang.addEventListener('click', flipLang);
+  const wRef = document.getElementById('worker-refresh-btn');
+  if (wRef) wRef.addEventListener('click', async () => {
+    wRef.disabled = true; wRef.textContent = '…';
+    try {
+      await Promise.all([loadDeliveries(), loadProduction(), loadSkus(), loadCheeseConsumption()]); resolveDeliveriesNow();
+      schedule = buildOptimalSchedule();
+      render();
+    } finally {
+      wRef.disabled = false; wRef.textContent = '↻';
+    }
   });
 
-  // Language toggle
-  document.getElementById('lang-en').addEventListener('click', () => { lang = 'en'; localStorage.setItem('prod-lang', lang); applyStrings(); renderHistory(); if (activeBatch) showScanView(); });
-  document.getElementById('lang-es').addEventListener('click', () => { lang = 'es'; localStorage.setItem('prod-lang', lang); applyStrings(); renderHistory(); if (activeBatch) showScanView(); });
+  // Auto-refresh — visibility regain + soft 60s interval. Both gated by
+  // active input focus + pending save (so we don't clobber typing).
+  // .inline-onhand-edit is the dynamic input from the Dips-tab ON HAND
+  // editor; without it softRefresh would erase the input mid-type. Same
+  // story for [data-foh-transfer-sheets] on the FOH home page — without
+  // it, FOH could be partway through typing "5" when the 60s interval
+  // fires and rebuilds the dough section back to 0.
+  const _isInputBusy = () =>
+    document.activeElement?.matches?.('[data-log-input], [data-stock-section], [data-log-step], #extra-val, .inline-onhand-edit, [data-foh-transfer-sheets]')
+    || Object.keys(saveTimers || {}).some(k => saveTimers[k] != null);
 
-  // Initial render
-  applyStrings();
-  loadAll();
+  // Track when the current worker session started so we don't toast diffs
+  // accumulated before they sat down (first refresh after page load is a
+  // sync, not an "update").
+  let _workerDiffArmed = false;
+
+  async function softRefresh() {
+    if (_isInputBusy()) return;
+    // Snapshot prev schedule for the worker-view diff toast. Manager view
+    // already sees diffs on saveStock; soft-refreshes there are silent.
+    const prevSched = (_isWorkerView && _workerDiffArmed) ? schedule : null;
+    try {
+      await Promise.all([loadDeliveries(), loadProduction(), loadSkus(), loadCheeseConsumption()]); resolveDeliveriesNow();
+      schedule = buildOptimalSchedule();
+      // Skip render if user just started typing during the network call
+      if (!_isInputBusy()) render();
+      // Surface team-relevant schedule shifts so the dough/BFP team can see
+      // what changed instead of "wait, my number went from 3 to 4 mid-shift".
+      if (prevSched) {
+        try {
+          const diff = filterDiffForRole(diffSchedules(prevSched, schedule), userRole);
+          if (diff.perDay.length > 0 || diff.newOverdue.length > 0) {
+            showWorkerRefreshDiffToast(diff);
+          }
+        } catch (toastErr) { console.warn('worker refresh diff skipped:', toastErr); }
+      }
+      _workerDiffArmed = _isWorkerView; // arm AFTER first successful refresh
+    } catch (_) { /* network blip — next interval will retry */ }
+  }
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') softRefresh();
+  });
+  setInterval(softRefresh, 60_000);
+
+  /**
+   * Filter a schedule diff to entries that matter to a single team.
+   * Shape worker sees only deltaShape; BFP worker sees only deltaBfp;
+   * manager would see everything (but doesn't get this toast — saveStock
+   * already covers them).
+   */
+  function filterDiffForRole(diff, role) {
+    const teamKey = role === 'shape' ? 'deltaShape' : 'deltaBfp';
+    return {
+      perDay: (diff.perDay || []).filter(d => Math.abs(d[teamKey] || 0) >= 0.01),
+      newOverdue: (diff.newOverdue || []).filter(o => o.team === role),
+    };
+  }
+
+  /**
+   * Soft "schedule changed" toast for the worker view's auto-refresh.
+   * Different framing from showScheduleDiffToast (which is tied to manager
+   * stock saves). Single-team perspective — only the worker's own batches.
+   */
+  function showWorkerRefreshDiffToast({ perDay, newOverdue }) {
+    document.querySelectorAll('.schedule-diff-toast').forEach(n => n.remove());
+    const toast = document.createElement('div');
+    toast.className = 'schedule-diff-toast worker-refresh';
+    if (newOverdue.length > 0) toast.classList.add('has-overdue');
+
+    const titleText = appLang === 'es'
+      ? '✏️ Cronograma actualizado'
+      : '✏️ Schedule updated';
+
+    const teamKey = userRole === 'shape' ? 'deltaShape' : 'deltaBfp';
+    let rowsHtml = '';
+    if (newOverdue.length > 0) {
+      const list = newOverdue.map(o => `<strong>${esc(o.sku)}</strong>`).join(', ');
+      const label = appLang === 'es' ? `🚨 Nuevo atrasado: ${list}` : `🚨 New overdue: ${list}`;
+      rowsHtml += `<div class="schedule-diff-toast-row"><span class="day"></span><span class="sub">${label}</span></div>`;
+    }
+    perDay.forEach((entry) => {
+      const delta = entry[teamKey] || 0;
+      if (Math.abs(delta) < 0.01) return;
+      const dayLabel = fmtFull(parseDate(entry.date));
+      const rounded = Math.round(delta);
+      const sign = rounded > 0 ? `+${rounded}` : `${rounded}`;
+      const cls  = rounded > 0 ? 'add' : 'sub';
+      const word = (Math.abs(rounded) === 1)
+        ? (appLang === 'es' ? 'tanda' : 'batch')
+        : (appLang === 'es' ? 'tandas' : 'batches');
+      rowsHtml += `<div class="schedule-diff-toast-row">
+        <span class="day">${esc(dayLabel)}</span>
+        <span class="${cls}">${sign} ${word}</span>
+      </div>`;
+    });
+    const dismiss = appLang === 'es' ? 'Toca para cerrar' : 'Tap to dismiss';
+    toast.innerHTML = `
+      <div class="schedule-diff-toast-title">${titleText}</div>
+      ${rowsHtml}
+      <div class="schedule-diff-toast-dismiss">${dismiss}</div>`;
+
+    document.body.appendChild(toast);
+    const remove = () => toast.remove();
+    toast.addEventListener('click', remove);
+    setTimeout(remove, 8000);
+  }
+
+  // Extra sheet
+  document.getElementById('extra-save').addEventListener('click', saveExtra);
+  document.getElementById('extra-cancel').addEventListener('click', () =>
+    document.getElementById('extra-overlay').classList.remove('open'));
+  document.getElementById('extra-overlay').addEventListener('click', e => {
+    if (e.target === document.getElementById('extra-overlay'))
+      document.getElementById('extra-overlay').classList.remove('open');
+  });
+  document.getElementById('extra-dec').addEventListener('click', () => {
+    const sku = document.getElementById('extra-sku-select').value;
+    const step = getStepDelta(extraType, sku);
+    if (!step) return;
+    extraValuePretzels = Math.max(0, extraValuePretzels - step);
+    document.getElementById('extra-val').value = String(extraValuePretzels);
+    updateExtraHint();
+  });
+  document.getElementById('extra-inc').addEventListener('click', () => {
+    const sku = document.getElementById('extra-sku-select').value;
+    const step = getStepDelta(extraType, sku);
+    if (!step) return;
+    extraValuePretzels = extraValuePretzels + step;
+    document.getElementById('extra-val').value = String(extraValuePretzels);
+    updateExtraHint();
+  });
+  document.getElementById('extra-val').addEventListener('input', () => {
+    extraValuePretzels = Math.max(0, parseInt(document.getElementById('extra-val').value, 10) || 0);
+    updateExtraHint();
+  });
+  document.getElementById('extra-val').addEventListener('focus', () => {
+    document.getElementById('extra-val').select();
+  });
+  // When SKU changes, reset the value to one step (so the user sees a sensible default)
+  document.getElementById('extra-sku-select').addEventListener('change', () => {
+    const sku = document.getElementById('extra-sku-select').value;
+    extraValuePretzels = getStepDelta(extraType, sku) || 0;
+    document.getElementById('extra-val').value = String(extraValuePretzels);
+    updateExtraHint();
+  });
+
+  // Configure SKU sheet
+  document.getElementById('cfg-save').addEventListener('click', saveCfg);
+  document.getElementById('cfg-cancel').addEventListener('click', () =>
+    document.getElementById('cfg-overlay').classList.remove('open'));
+  document.getElementById('cfg-box-add-row').addEventListener('click', () => renderCfgBoxRow('', ''));
+  document.getElementById('cfg-overlay').addEventListener('click', e => {
+    if (e.target === document.getElementById('cfg-overlay'))
+      document.getElementById('cfg-overlay').classList.remove('open');
+  });
+  document.querySelectorAll('.cfg-type-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      cfgType = btn.dataset.cfgType;
+      document.querySelectorAll('.cfg-type-btn').forEach(b =>
+        b.classList.toggle('selected', b === btn));
+    });
+  });
+  document.querySelectorAll('.cfg-mode-btn').forEach(btn => {
+    btn.addEventListener('click', () => setCfgMode(btn.dataset.cfgMode));
+  });
+
+  // Tab buttons
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => { dayTab = btn.dataset.tab; render(); });
+  });
+
+  // ─── SELF-TEST HARNESS ───────────────────────────────────────────────────
+  // Runs on `?selftest=1`. Builds synthetic items in the same shape buildWorkerItems
+  // produces, then verifies the day-total math (workload = need + made) plus
+  // bucket / spare / over derivations. Prints a pass/fail summary to a banner
+  // at the top of the page.
+  function runSelfTests() {
+    const tests = [];
+    const fmtBs = (n) => n; // batch counts are integers in tests
+
+    // Helper: synthesize an item the way buildWorkerItems would (workload-based).
+    const mkItem = ({ sku = 'test', need, made, bs = 48, isOverdue = false }) => {
+      const totalBatches = need + made;
+      const origP = Math.round(totalBatches * bs);
+      const madeP = Math.round(made * bs);
+      let bucket;
+      if (madeP >= origP - 0.5 && origP > 0) bucket = 'done';
+      else if (made > 0)                      bucket = 'progress';
+      else if (isOverdue)                     bucket = 'overdue';
+      else                                    bucket = 'pending';
+      return { sku, needBatches: need, madeBatches: made, totalBatches, origP, madeP, bucket };
+    };
+
+    // Helper: aggregate the way renderTeamCard does.
+    const aggregate = (items, capacity) => {
+      const totalOrig  = items.reduce((s, d) => s + d.totalBatches, 0);
+      const totalMade  = items.reduce((s, d) => s + d.madeBatches, 0);
+      const totalOrigP = items.reduce((s, d) => s + d.origP, 0);
+      const totalMadeP = items.reduce((s, d) => s + d.madeP, 0);
+      const isOver = totalOrig > capacity + 0.5;
+      const spare  = Math.max(0, capacity - Math.ceil(totalOrig));
+      return { totalOrig, totalMade, totalOrigP, totalMadeP, isOver, spare };
+    };
+
+    const expect = (label, actual, expected) => {
+      const pass = JSON.stringify(actual) === JSON.stringify(expected);
+      tests.push({ label, pass, actual, expected });
+    };
+
+    // T1 — Empty
+    {
+      const a = aggregate([], 15);
+      expect('T1 empty: total=0', a.totalOrig, 0);
+      expect('T1 empty: spare=cap', a.spare, 15);
+      expect('T1 empty: not over', a.isOver, false);
+    }
+    // T2 — Untouched mustDo
+    {
+      const items = [mkItem({ need: 3, made: 0 })];
+      const a = aggregate(items, 15);
+      expect('T2 untouched: total=3', a.totalOrig, 3);
+      expect('T2 untouched: spare=12', a.spare, 12);
+      expect('T2 untouched: bucket=pending', items[0].bucket, 'pending');
+    }
+    // T3 — Done
+    {
+      const items = [mkItem({ need: 0, made: 3 })];
+      const a = aggregate(items, 15);
+      expect('T3 done: total=3', a.totalOrig, 3);
+      expect('T3 done: spare=12', a.spare, 12);
+      expect('T3 done: bucket=done', items[0].bucket, 'done');
+    }
+    // T4 — Mid-progress (the user's exact case in spirit)
+    {
+      const items = [mkItem({ need: 3, made: 2 })];
+      const a = aggregate(items, 15);
+      expect('T4 mid: total=5 (workload, not max=3)', a.totalOrig, 5);
+      expect('T4 mid: spare=10', a.spare, 10);
+      expect('T4 mid: bucket=progress', items[0].bucket, 'progress');
+    }
+    // T5 — Over capacity
+    {
+      const items = [mkItem({ need: 10, made: 0 })];
+      const a = aggregate(items, 5);
+      expect('T5 over: total=10', a.totalOrig, 10);
+      expect('T5 over: isOver=true', a.isOver, true);
+      expect('T5 over: spare=0', a.spare, 0);
+    }
+    // T6 — Mid-progress + other card maxes capacity
+    {
+      const items = [mkItem({ need: 3, made: 2, sku: 'A' }), mkItem({ need: 10, made: 0, sku: 'B' })];
+      const a = aggregate(items, 15);
+      expect('T6 maxed: total=15', a.totalOrig, 15);
+      expect('T6 maxed: spare=0', a.spare, 0);
+      expect('T6 maxed: not over', a.isOver, false);
+    }
+    // T7 — User's reported scenario
+    {
+      const items = [
+        mkItem({ need: 1, made: 0, sku: '6.5oz plain', bs: 72 }),
+        mkItem({ need: 1, made: 0, sku: '10oz plain', bs: 48 }),
+        mkItem({ need: 4, made: 0, sku: 'plain bombs', bs: 72 }),
+        mkItem({ need: 3, made: 2, sku: '4oz twist plain', bs: 108 }),
+        mkItem({ need: 2, made: 0, sku: '4oz twist bbk', bs: 108 }),
+        mkItem({ need: 1, made: 0, sku: '4oz twist spicy bee', bs: 108 }),
+        mkItem({ need: 1, made: 0, sku: '6.5oz Bootlegger', bs: 72 }),
+      ];
+      const a = aggregate(items, 15);
+      expect('T7 user-scenario: total=15 (was 13 with max-based math)', a.totalOrig, 15);
+      expect('T7 user-scenario: spare=0 (was 2 with max-based math)', a.spare, 0);
+      expect('T7 user-scenario: not over', a.isOver, false);
+    }
+    // T8 — Done detection edge: madeP exactly equals origP
+    {
+      const items = [mkItem({ need: 0, made: 5, bs: 100 })];
+      expect('T8 exact done: bucket=done', items[0].bucket, 'done');
+    }
+    // T9 — Almost done (user expects to know more is needed)
+    {
+      const items = [mkItem({ need: 1, made: 4, bs: 100 })];
+      expect('T9 almost-done: bucket=progress (need=1>0)', items[0].bucket, 'progress');
+      expect('T9 almost-done: total=5 not 4', items[0].totalBatches, 5);
+    }
+    // T10 — Logging never grows the visible target inappropriately
+    {
+      // Imagine: schedule places need=3, team logs +1 → need decreases to 2,
+      // made=1. Workload=3 (same).
+      const before = mkItem({ need: 3, made: 0 });
+      const after  = mkItem({ need: 2, made: 1 });
+      expect('T10 stable target: total before = after', before.totalBatches, after.totalBatches);
+    }
+
+    // Render results banner
+    const passed = tests.filter(t => t.pass).length;
+    const failed = tests.length - passed;
+    const banner = document.createElement('div');
+    banner.style.cssText = `position:fixed;top:0;left:0;right:0;z-index:9999;
+      padding:14px 20px;font:700 14px 'Manrope',sans-serif;
+      background:${failed === 0 ? '#d4edda' : '#f8d7da'};
+      color:${failed === 0 ? '#155724' : '#721c24'};
+      border-bottom:2px solid ${failed === 0 ? '#4a4' : '#c44'};`;
+    banner.innerHTML = `<div>${failed === 0 ? '✓' : '✗'} Self-test: ${passed}/${tests.length} passed</div>` +
+      tests.filter(t => !t.pass).map(t =>
+        `<div style="font:500 12px 'Manrope',monospace;margin-top:4px">FAIL — ${t.label} · expected ${JSON.stringify(t.expected)} · got ${JSON.stringify(t.actual)}</div>`
+      ).join('');
+    document.body.appendChild(banner);
+    // Also dump to console for CI / scripted checks
+    // eslint-disable-next-line no-console
+    console.log('Self-test results:', { passed, failed, tests });
+  }
+
+  // ─── BOOT ─────────────────────────────────────────────────────────────────
+
+  (async () => {
+    try {
+      await Promise.all([loadDeliveries(), loadProduction(), loadSkus(), loadCheeseConsumption()]); resolveDeliveriesNow();
+      schedule = buildOptimalSchedule();
+      render();
+      // Self-test mode: ?selftest=1 — synthesizes items and verifies the
+      // day-total / spare / bucket math without depending on live data.
+      if (_urlSearch.get('selftest') === '1') runSelfTests();
+    } catch (e) {
+      document.getElementById('main-view').innerHTML = `
+        <div class="load-error">
+          ⚠️ Could not load data<br>
+          <span style="font:400 13px 'Manrope',sans-serif">${esc(e.message)}</span><br><br>
+          <button onclick="window.location.reload()"
+            style="padding:12px 28px;background:var(--red);color:#fff;border:none;border-radius:8px;font:700 15px 'Manrope',sans-serif;cursor:pointer;min-height:48px">
+            Retry
+          </button>
+        </div>`;
+    }
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
PR 35 accidentally replaced `static/production/index.html` with the new batch tracking page. This restores the original 5,242-line production scheduling page from the commit immediately before PR 35 merged.

## Preview
https://feature-restore-production-page--website--dangpretz.aem.page/static/production/

## Test plan
- [ ] `/static/production/` loads the original production scheduling page (not the batch tracking page)
- [ ] `/static/batch-tracking/` still loads the batch tracking page

🤖 Generated with [Claude Code](https://claude.com/claude-code)