### PR TITLE
Fix Amazon Silk browser chrome on signage screens

### DIFF
--- a/v2/signage/menu.html
+++ b/v2/signage/menu.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="refresh" content="600">
 <title>Dangerous Pretzel Co. — Digital Menu</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -706,7 +705,7 @@
     </div>
   </section>
 
-  <a class="relaunch" href="./index.html" aria-label="Re-launch screen picker">&#x2630;</a>
+  <a class="relaunch" href="./index.html" tabindex="-1" aria-label="Re-launch screen picker">&#x2630;</a>
 
   <script>
     // Screen switcher: ?screen=1 / 2 / 3
@@ -716,6 +715,10 @@
       const cls = (n === 1 || n === 2 || n === 3) ? 's' + n : 's1';
       document.body.classList.add(cls);
     })();
+
+    // Auto-refresh every 10 min using location.replace() to avoid
+    // triggering Amazon Silk's browser chrome (meta refresh causes full navigation)
+    setTimeout(function () { location.replace(location.href); }, 600000);
   </script>
 </body>
 </html>

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -2085,7 +2085,7 @@ export default {
                 type: 'FIXED_AMOUNT',
               };
               // eslint-disable-next-line no-console -- worker diagnostics
-              console.log(`[catering-checkout] Promo token validated: $${validateData.discount_cents/100} off for customer ${validateData.customer_id || 'unknown'}`);
+              console.log(`[catering-checkout] Promo token validated: $${validateData.discount_cents / 100} off for customer ${validateData.customer_id || 'unknown'}`);
             } else {
               // eslint-disable-next-line no-console -- worker diagnostics
               console.warn(`[catering-checkout] Promo token rejected: ${validateData.reason || 'unknown'}`);


### PR DESCRIPTION
## Summary
Two changes to stop Amazon Silk from pulling up its browser toolbar on the Fire TV signage displays:

1. **Replace `<meta http-equiv="refresh">` with `setTimeout + location.replace()`** — meta refresh is a full browser navigation event which always triggers Silk's address bar. `location.replace()` rewrites the current history entry in place, which is much less likely to cause the chrome to appear.

2. **Add `tabindex="-1"` to the hidden relaunch link** — the nearly-invisible `<a>` link in the corner is still focusable. Fire TV's D-pad navigation cycles through all focusable elements, and Silk shows its toolbar whenever a link gains focus. Removing it from the tab order prevents this.

No visual changes — CSS, content, and layout are identical to before.

## Preview
https://feature-signage-silk-fixes--website--dangpretz.aem.page/static/inventory/

## Test plan
- [ ] Leave signage screen running for 10+ minutes — page refreshes without browser chrome appearing
- [ ] Navigate with Fire TV remote D-pad — toolbar does not appear
- [ ] All three screens display identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)