### PR TITLE
Remove auto-refresh timer from signage menu

### DIFF
--- a/v2/signage/menu.html
+++ b/v2/signage/menu.html
@@ -716,9 +716,6 @@
       document.body.classList.add(cls);
     })();
 
-    // Auto-refresh every 10 min using location.replace() to avoid
-    // triggering Amazon Silk's browser chrome (meta refresh causes full navigation)
-    setTimeout(function () { location.replace(location.href); }, 600000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Removes the 10-minute auto-refresh timer entirely. Any form of page reload (meta refresh or JavaScript) triggers Amazon Silk's browser chrome on Fire TV. Since the menu content only changes on deployment, manual refresh of the Fire TV browsers when deploying is sufficient.

## Preview
https://feature-remove-signage-autoreload--website--dangpretz.aem.page/static/inventory/

## Test plan
- [ ] Leave signage screens running — browser chrome no longer appears after 10 minutes
- [ ] All three screens display identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)