### PR TITLE
Connect recipes to ingredients via gram-based conversion

### DIFF
--- a/static/inventory-forecast/index.html
+++ b/static/inventory-forecast/index.html
@@ -339,9 +339,14 @@
     function fmt2(n) { return isNaN(n) ? '—' : (Math.round(n * 100) / 100).toString(); }
     function parsePackSize(ps) {
       const parts = (ps || '').split('/');
-      if (parts.length < 3) return { innerUnitsPerCase: 1, innerUnitLabel: ps || 'unit' };
-      const c = parseFloat(parts[0]);
-      return { innerUnitsPerCase: isNaN(c) ? 1 : c, innerUnitLabel: `${parts[1]} ${parts[2]}` };
+      if (parts.length < 3) return { innerUnitsPerCase: 1, innerUnitLabel: ps || 'unit', gramsPerInnerUnit: null };
+      const c    = parseFloat(parts[0]);
+      const qty  = parseFloat(parts[1]);
+      const unit = parts[2].trim().toUpperCase();
+      let gramsPerInnerUnit = null;
+      if (unit === 'LB') gramsPerInnerUnit = qty * 453.592;
+      else if (unit === 'OZ') gramsPerInnerUnit = qty * 28.3495;
+      return { innerUnitsPerCase: isNaN(c) ? 1 : c, innerUnitLabel: `${parts[1]} ${parts[2]}`, gramsPerInnerUnit };
     }
     function todayStr() { return new Date().toISOString().slice(0, 10); }
     function addDays(dateStr, n) {
@@ -429,8 +434,9 @@
 
     // ── Build recipe maps ────────────────────────────────────────────────────
     function buildRecipeMaps(recipeLogs) {
-      const scaleMap  = {};  // sku → { pretzelsPerTray, traysPerBatch }
-      const recipeMap = {};  // sku → { productId → quantityPerBatch }
+      const scaleMap   = {};  // sku → { pretzelsPerTray, traysPerBatch }
+      const recipeMap  = {};  // sku → { productId → gramsPerBatch }
+      const densityMap = {};  // productId → gramsPerInnerUnit (for GAL products)
       for (const r of recipeLogs) {
         if (r.action === 'sku_scale') {
           const ppt = Number(r.pretzelsPerTray);
@@ -439,17 +445,21 @@
             scaleMap[r.sku] = { pretzelsPerTray: ppt, traysPerBatch: tpb };
           }
         }
-        if (r.action === 'recipe') {
+        if (r.action === 'recipe_v2') {
           if (!recipeMap[r.sku]) recipeMap[r.sku] = {};
-          const v = Number(r.quantityPerBatch);
+          const v = Number(r.gramsPerBatch);
           if (!isNaN(v)) recipeMap[r.sku][r.productId] = v;
         }
+        if (r.action === 'ingredient_density') {
+          const v = Number(r.gramsPerInnerUnit);
+          if (!isNaN(v) && v > 0) densityMap[r.productId] = v;
+        }
       }
-      return { scaleMap, recipeMap };
+      return { scaleMap, recipeMap, densityMap };
     }
 
     // ── Compute forecast ─────────────────────────────────────────────────────
-    function computeForecast(deliveries, recipeMap, scaleMap, inventoryMap) {
+    function computeForecast(deliveries, recipeMap, scaleMap, inventoryMap, densityMap = {}) {
       const today = todayStr();
       const end   = addDays(today, 6);
 
@@ -493,10 +503,15 @@
           const recipe = recipeMap[sku];
           if (!recipe) continue;
 
-          for (const [productId, qtyPerBatch] of Object.entries(recipe)) {
+          for (const [productId, gramsPerBatch] of Object.entries(recipe)) {
             if (!forecastMap.has(productId)) continue;
             const row = forecastMap.get(productId);
-            const usage = batchesNeeded * qtyPerBatch;
+            // Convert grams → inner units using pack size or density override
+            const { gramsPerInnerUnit } = parsePackSize(row.packSize);
+            const gpu = gramsPerInnerUnit || densityMap[productId] || 0;
+            if (!gpu) continue; // no conversion available (GAL without density set)
+            const innerUnitsPerBatch = gramsPerBatch / gpu;
+            const usage = batchesNeeded * innerUnitsPerBatch;
             row.expectedUsage += usage;
             row.projectedRemaining = row.stock - row.expectedUsage;
             row.hasRecipe = true;
@@ -513,6 +528,7 @@
     let inventoryMap  = new Map();
     let scaleMap      = {};
     let recipeMap     = {};
+    let densityMap    = {};
     let allDeliveryLogs  = [];
     let allReceivingLogs = [];
     let allInventoryLogs = [];
@@ -543,11 +559,11 @@
         allInventoryLogs = iLogs;
 
         buildDynamicProducts(rLogs);
-        ({ scaleMap, recipeMap } = buildRecipeMaps(rcLogs));
+        ({ scaleMap, recipeMap, densityMap } = buildRecipeMaps(rcLogs));
         inventoryMap = computeInventory(rLogs, iLogs);
 
         const deliveries = resolveDeliveries(dLogs);
-        forecastMap = computeForecast(deliveries, recipeMap, scaleMap, inventoryMap);
+        forecastMap = computeForecast(deliveries, recipeMap, scaleMap, inventoryMap, densityMap);
 
         updateWindowLabel();
         renderForecastTable();
@@ -801,7 +817,7 @@
             if (inventoryMap.has(productId)) inventoryMap.get(productId).par = val;
             // Recompute forecast so status badges & sort order update immediately
             const deliveries = resolveDeliveries(allDeliveryLogs);
-            forecastMap = computeForecast(deliveries, recipeMap, scaleMap, inventoryMap);
+            forecastMap = computeForecast(deliveries, recipeMap, scaleMap, inventoryMap, densityMap);
             renderForecastTable();
             showToast('PAR updated', 'success');
           } catch (err) {
@@ -865,7 +881,7 @@
               note:      'inline stock set',
             });
             if (inventoryMap.has(productId)) inventoryMap.get(productId).stock = newVal;
-            forecastMap = computeForecast(resolveDeliveries(allDeliveryLogs), recipeMap, scaleMap, inventoryMap);
+            forecastMap = computeForecast(resolveDeliveries(allDeliveryLogs), recipeMap, scaleMap, inventoryMap, densityMap);
             renderForecastTable();
             showToast(`Stock set to ${newVal}`, 'success');
           } catch (err) {

--- a/static/recipes/index.html
+++ b/static/recipes/index.html
@@ -82,13 +82,24 @@
     .recipe-qty-derived { font: 400 12px 'Manrope', sans-serif; color: #555; text-align: right; min-width: 54px; display: inline-block; }
     .ing-unit { font: 400 11px 'Manrope', sans-serif; color: #555; white-space: nowrap; }
     .purchase-units { font: 600 12px 'Manrope', sans-serif; color: #C41E1E; white-space: nowrap; }
-    .ing-row-ea { opacity: 0.45; }
     .density-row { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
     .density-label { font: 400 10px 'Manrope', sans-serif; color: #666; white-space: nowrap; }
     .density-input { width: 70px; font: 400 12px 'Manrope', sans-serif; padding: 3px 6px; border: 1.5px solid #555; border-radius: 4px; background: #2a2a2a; color: #aaa; outline: none; text-align: right; -moz-appearance: textfield; }
     .density-input:focus { border-color: #C41E1E; }
     .density-input::-webkit-outer-spin-button,
     .density-input::-webkit-inner-spin-button { -webkit-appearance: none; }
+    .btn-remove-ing { background: none; border: none; cursor: pointer; color: #555; font-size: 16px; padding: 2px 6px; border-radius: 4px; line-height: 1; vertical-align: middle; }
+    .btn-remove-ing:hover { color: #e55; background: rgba(255,80,80,.1); }
+    .ingredient-add-wrap { padding: 10px 0 2px; }
+    .ingredient-search-wrap { position: relative; }
+    .ingredient-search { width: 100%; font: 400 13px 'Manrope',sans-serif; padding: 9px 12px; border: 1.5px dashed #444; border-radius: 6px; background: #2a2a2a; color: #ccc; outline: none; transition: border-color .2s; }
+    .ingredient-search:focus { border-color: #C41E1E; border-style: solid; }
+    .ingredient-search::placeholder { color: #555; }
+    .ingredient-dropdown { position: absolute; top: calc(100% + 4px); left: 0; right: 0; background: #2a2a2a; border: 1.5px solid #444; border-radius: 6px; max-height: 220px; overflow-y: auto; z-index: 50; box-shadow: 0 4px 16px rgba(0,0,0,.4); }
+    .ingredient-option { display: flex; justify-content: space-between; align-items: baseline; padding: 9px 14px; cursor: pointer; gap: 12px; }
+    .ingredient-option:hover { background: #3a3a3a; }
+    .ing-opt-name { font: 400 13px 'Manrope',sans-serif; color: #ccc; }
+    .ing-opt-pack { font: 400 11px 'Manrope',sans-serif; color: #555; white-space: nowrap; }
     .sku-save-row { display: flex; align-items: center; gap: 10px; }
     .sku-save-btn { padding: 9px 20px; font: 700 13px 'Manrope', sans-serif; background: #C41E1E; color: #fff; border: none; border-radius: 6px; cursor: pointer; transition: background .2s; }
     .sku-save-btn:hover:not(:disabled) { background: #a01818; }
@@ -125,10 +136,10 @@
       .sku-grid { grid-template-columns: 1fr; }
       .scale-row { grid-template-columns: 1fr 1fr; }
       .scale-row .auto-col { display: none; }
-      .recipe-ing-table th:nth-child(3),
-      .recipe-ing-table td:nth-child(3),
       .recipe-ing-table th:nth-child(4),
-      .recipe-ing-table td:nth-child(4) { display: none; }
+      .recipe-ing-table td:nth-child(4),
+      .recipe-ing-table th:nth-child(5),
+      .recipe-ing-table td:nth-child(5) { display: none; }
       .summary-ing-table th:nth-child(3),
       .summary-ing-table td:nth-child(3),
       .summary-ing-table th:nth-child(4),
@@ -301,6 +312,29 @@
       grid.querySelectorAll('.sku-card').forEach(wireSkuCard);
     }
 
+    function buildIngRowHtml(p, gramsVal, ppt, tpb) {
+      const { innerUnitLabel, unit, gramsPerInnerUnit } = parsePackSize(p.packSize);
+      const isGal = unit === 'GAL';
+      const gpu   = gramsPerInnerUnit || densityMap[p.id] || 0;
+      const ppb   = (ppt && tpb) ? ppt * tpb : 0;
+      const gv    = gramsVal !== '' ? parseFloat(gramsVal) : NaN;
+      const perTray = (!isNaN(gv) && tpb) ? fmt2(gv / tpb) : '—';
+      const perPret = (!isNaN(gv) && ppb) ? fmt2(gv / ppb) : '—';
+      const purchase = gpu ? fmtPurchaseUnits(gv, gpu, innerUnitLabel) : (isGal ? '<em style="color:#888;font-size:11px">set density ↓</em>' : '—');
+      const densityHtml = isGal
+        ? `<div class="density-row"><label class="density-label">g per ${innerUnitLabel}:</label><input type="number" class="density-input" data-product-id="${escapeHtml(p.id)}" value="${densityMap[p.id] || ''}" placeholder="e.g. 3785" min="1" step="1"></div>`
+        : '';
+      return `<tr class="ing-row" data-product-id="${escapeHtml(p.id)}">
+          <td><button class="btn-remove-ing" title="Remove">×</button></td>
+          <td><span class="ing-name">${escapeHtml(p.name)}</span>${densityHtml}</td>
+          <td><input type="number" class="recipe-qty-input" data-product-id="${escapeHtml(p.id)}" value="${gramsVal}" placeholder="—" min="0" step="0.1"></td>
+          <td><span class="recipe-qty-derived per-tray">${perTray}</span></td>
+          <td><span class="recipe-qty-derived per-pretzel">${perPret}</span></td>
+          <td><span class="purchase-units">${purchase}</span></td>
+          <td><span class="ing-unit">${escapeHtml(innerUnitLabel)}</span></td>
+        </tr>`;
+    }
+
     function buildSkuCard(sku) {
       const scale = scaleMap[sku] || {};
       const ppt = scale.pretzelsPerTray || '';
@@ -310,27 +344,11 @@
       const recipe = recipeMap[sku] || {};
       const hasAny = Object.keys(recipe).length > 0 || ppt || tpb;
 
-      const ingRows = PRODUCTS.map((p) => {
-        const { innerUnitLabel, unit, gramsPerInnerUnit } = parsePackSize(p.packSize);
-        const isEa  = unit === 'EA';
-        const isGal = unit === 'GAL';
-        const gpu   = gramsPerInnerUnit || densityMap[p.id] || 0;
-        const perBatch = recipe[p.id] != null ? recipe[p.id] : '';
-        const perTray  = (perBatch !== '' && tpb) ? fmt2(perBatch / tpb) : '';
-        const perPret  = (perBatch !== '' && ppt && tpb) ? fmt2(perBatch / (ppt * tpb)) : '';
-        const purchase = isEa ? '—' : (gpu ? fmtPurchaseUnits(perBatch, gpu, innerUnitLabel) : (isGal ? '<em style="color:#888;font-size:11px">set density ↓</em>' : '—'));
-        const densityInput = isGal
-          ? `<div class="density-row"><label class="density-label">g per ${innerUnitLabel}:</label><input type="number" class="density-input" data-product-id="${escapeHtml(p.id)}" value="${densityMap[p.id] || ''}" placeholder="e.g. 3785" min="1" step="1"></div>`
-          : '';
-        return `<tr class="ing-row${isEa ? ' ing-row-ea' : ''}">
-          <td><span class="ing-name">${escapeHtml(p.name)}</span>${densityInput}</td>
-          <td>${isEa ? '<span class="ing-unit">—</span>' : `<input type="number" class="recipe-qty-input" data-product-id="${escapeHtml(p.id)}" value="${perBatch}" placeholder="—" min="0" step="0.1">`}</td>
-          <td><span class="recipe-qty-derived per-tray">${isEa ? '—' : (perTray || '—')}</span></td>
-          <td><span class="recipe-qty-derived per-pretzel">${isEa ? '—' : (perPret || '—')}</span></td>
-          <td><span class="purchase-units">${purchase}</span></td>
-          <td><span class="ing-unit">${escapeHtml(innerUnitLabel)}</span></td>
-        </tr>`;
-      }).join('');
+      // Only render rows for ingredients already in the recipe
+      const ingRows = PRODUCTS
+        .filter((p) => recipe[p.id] != null)
+        .map((p) => buildIngRowHtml(p, recipe[p.id] != null ? recipe[p.id] : '', ppt, tpb))
+        .join('');
 
       return `<div class="sku-card${hasAny ? ' expanded' : ''}" data-sku="${escapeHtml(sku)}">
         <div class="sku-card-header">
@@ -357,6 +375,7 @@
           </div>
           <table class="recipe-ing-table">
             <thead><tr>
+              <th></th>
               <th>Ingredient</th>
               <th>g / Batch</th>
               <th>g / Tray</th>
@@ -364,8 +383,14 @@
               <th>Purchase Units</th>
               <th>Pack</th>
             </tr></thead>
-            <tbody>${ingRows}</tbody>
+            <tbody class="recipe-ing-body">${ingRows}</tbody>
           </table>
+          <div class="ingredient-add-wrap">
+            <div class="ingredient-search-wrap">
+              <input type="text" class="ingredient-search" placeholder="Add ingredient…" autocomplete="off" spellcheck="false">
+              <div class="ingredient-dropdown" hidden></div>
+            </div>
+          </div>
           <div class="sku-save-row">
             <button class="sku-save-btn">Save Recipe</button>
             <span class="sku-save-status"></span>
@@ -375,10 +400,18 @@
     }
 
     function wireSkuCard(card) {
-      const sku = card.dataset.sku;
-      const pptInput  = card.querySelector('.ppt-input');
-      const tpbInput  = card.querySelector('.tpb-input');
+      const sku        = card.dataset.sku;
+      const pptInput   = card.querySelector('.ppt-input');
+      const tpbInput   = card.querySelector('.tpb-input');
       const ppbDisplay = card.querySelector('.ppb-display');
+      const tbody      = card.querySelector('.recipe-ing-body');
+      const searchInput = card.querySelector('.ingredient-search');
+      const dropdown    = card.querySelector('.ingredient-dropdown');
+
+      // Track which products are already in the card
+      const addedIds = new Set(
+        [...card.querySelectorAll('.recipe-qty-input')].map((i) => i.dataset.productId),
+      );
 
       function updateDerived() {
         const ppt = parseFloat(pptInput.value) || 0;
@@ -387,10 +420,10 @@
         if (ppbDisplay) ppbDisplay.value = ppb ? String(ppb) : '';
 
         card.querySelectorAll('.recipe-qty-input').forEach((inp) => {
-          const val = parseFloat(inp.value);
+          const val       = parseFloat(inp.value);
           const productId = inp.dataset.productId;
           const product   = PRODUCTS.find((p) => p.id === productId);
-          const row = inp.closest('tr');
+          const row       = inp.closest('tr');
           const perTrayEl    = row.querySelector('.per-tray');
           const perPretzelEl = row.querySelector('.per-pretzel');
           const purchaseEl   = row.querySelector('.purchase-units');
@@ -409,27 +442,83 @@
         });
       }
 
+      function wireRow(tr) {
+        const productId = tr.dataset.productId;
+        const qtyInp = tr.querySelector('.recipe-qty-input');
+        if (qtyInp) qtyInp.addEventListener('input', updateDerived);
+
+        const densInp = tr.querySelector('.density-input');
+        if (densInp) {
+          densInp.addEventListener('input', () => {
+            const pid = densInp.dataset.productId;
+            const gpu = parseFloat(densInp.value) || 0;
+            densityMap[pid] = gpu;
+            const product = PRODUCTS.find((p) => p.id === pid);
+            if (!product) return;
+            const { innerUnitLabel } = parsePackSize(product.packSize);
+            const purchaseEl = tr.querySelector('.purchase-units');
+            if (purchaseEl) {
+              const grams = parseFloat(qtyInp ? qtyInp.value : '');
+              purchaseEl.innerHTML = gpu ? fmtPurchaseUnits(grams, gpu, innerUnitLabel) : '<em style="color:#888;font-size:11px">set density ↓</em>';
+            }
+          });
+        }
+
+        const removeBtn = tr.querySelector('.btn-remove-ing');
+        if (removeBtn) {
+          removeBtn.addEventListener('click', () => {
+            addedIds.delete(productId);
+            tr.remove();
+            if (document.activeElement === searchInput) renderDropdown(searchInput.value);
+          });
+        }
+      }
+
+      function addIngredientRow(product, gramsVal = '') {
+        const ppt = parseFloat(pptInput.value) || 0;
+        const tpb = parseFloat(tpbInput.value) || 0;
+        tbody.insertAdjacentHTML('beforeend', buildIngRowHtml(product, gramsVal, ppt, tpb));
+        const tr = tbody.lastElementChild;
+        wireRow(tr);
+        addedIds.add(product.id);
+        const inp = tr.querySelector('.recipe-qty-input');
+        if (inp) inp.focus();
+      }
+
+      function renderDropdown(query) {
+        const q = query.trim().toLowerCase();
+        if (!q) { dropdown.hidden = true; return; }
+        const matches = PRODUCTS.filter((p) => {
+          const { unit } = parsePackSize(p.packSize);
+          return unit !== 'EA' && !addedIds.has(p.id) && p.name.toLowerCase().includes(q);
+        });
+        if (!matches.length) { dropdown.hidden = true; return; }
+        dropdown.innerHTML = matches.map((p) => `<div class="ingredient-option" data-product-id="${escapeHtml(p.id)}">
+            <span class="ing-opt-name">${escapeHtml(p.name)}</span>
+            <span class="ing-opt-pack">${escapeHtml(p.packSize)}</span>
+          </div>`).join('');
+        dropdown.hidden = false;
+        dropdown.querySelectorAll('.ingredient-option').forEach((opt) => {
+          opt.addEventListener('mousedown', (e) => {
+            e.preventDefault();
+            const product = PRODUCTS.find((p) => p.id === opt.dataset.productId);
+            if (product) { addIngredientRow(product); }
+            dropdown.hidden = true;
+            searchInput.value = '';
+          });
+        });
+      }
+
       pptInput.addEventListener('input', updateDerived);
       tpbInput.addEventListener('input', updateDerived);
-      card.querySelectorAll('.recipe-qty-input').forEach((inp) => inp.addEventListener('input', updateDerived));
 
-      // Density inputs (GAL products) — update purchase units live
-      card.querySelectorAll('.density-input').forEach((inp) => {
-        inp.addEventListener('input', () => {
-          const productId = inp.dataset.productId;
-          const gpu = parseFloat(inp.value) || 0;
-          densityMap[productId] = gpu;
-          const product = PRODUCTS.find((p) => p.id === productId);
-          if (!product) return;
-          const { innerUnitLabel } = parsePackSize(product.packSize);
-          const qtyInp = card.querySelector(`.recipe-qty-input[data-product-id="${productId}"]`);
-          const purchaseEl = inp.closest('tr').querySelector('.purchase-units');
-          if (purchaseEl) {
-            const grams = parseFloat(qtyInp?.value);
-            purchaseEl.innerHTML = gpu ? fmtPurchaseUnits(grams, gpu, innerUnitLabel) : '<em style="color:#888;font-size:11px">set density ↓</em>';
-          }
-        });
+      searchInput.addEventListener('input', () => renderDropdown(searchInput.value));
+      searchInput.addEventListener('blur', () => {
+        setTimeout(() => { dropdown.hidden = true; searchInput.value = ''; }, 150);
       });
+
+      // Wire existing rows
+      tbody.querySelectorAll('tr.ing-row').forEach(wireRow);
 
       card.querySelector('.sku-save-btn').addEventListener('click', async () => {
         const saveBtn    = card.querySelector('.sku-save-btn');
@@ -461,7 +550,6 @@
           }
         });
 
-        // Save density overrides for GAL products
         card.querySelectorAll('.density-input').forEach((inp) => {
           const productId = inp.dataset.productId;
           const val = parseFloat(inp.value);
@@ -476,7 +564,6 @@
 
         try {
           await Promise.all(writes);
-          // Update in-memory maps
           if (!isNaN(ppt) && ppt > 0 && !isNaN(tpb) && tpb > 0) scaleMap[sku] = { pretzelsPerTray: ppt, traysPerBatch: tpb };
           if (!recipeMap[sku]) recipeMap[sku] = {};
           card.querySelectorAll('.recipe-qty-input').forEach((inp) => {

--- a/static/recipes/index.html
+++ b/static/recipes/index.html
@@ -81,6 +81,14 @@
     .recipe-qty-input::-webkit-inner-spin-button { -webkit-appearance: none; }
     .recipe-qty-derived { font: 400 12px 'Manrope', sans-serif; color: #555; text-align: right; min-width: 54px; display: inline-block; }
     .ing-unit { font: 400 11px 'Manrope', sans-serif; color: #555; white-space: nowrap; }
+    .purchase-units { font: 600 12px 'Manrope', sans-serif; color: #C41E1E; white-space: nowrap; }
+    .ing-row-ea { opacity: 0.45; }
+    .density-row { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
+    .density-label { font: 400 10px 'Manrope', sans-serif; color: #666; white-space: nowrap; }
+    .density-input { width: 70px; font: 400 12px 'Manrope', sans-serif; padding: 3px 6px; border: 1.5px solid #555; border-radius: 4px; background: #2a2a2a; color: #aaa; outline: none; text-align: right; -moz-appearance: textfield; }
+    .density-input:focus { border-color: #C41E1E; }
+    .density-input::-webkit-outer-spin-button,
+    .density-input::-webkit-inner-spin-button { -webkit-appearance: none; }
     .sku-save-row { display: flex; align-items: center; gap: 10px; }
     .sku-save-btn { padding: 9px 20px; font: 700 13px 'Manrope', sans-serif; background: #C41E1E; color: #fff; border: none; border-radius: 6px; cursor: pointer; transition: background .2s; }
     .sku-save-btn:hover:not(:disabled) { background: #a01818; }
@@ -240,17 +248,32 @@
     function fmt2(n) { return isNaN(n) ? '—' : (Math.round(n * 100) / 100).toString(); }
     function parsePackSize(ps) {
       const parts = (ps || '').split('/');
-      if (parts.length < 3) return { innerUnitLabel: ps || 'unit' };
-      return { innerUnitLabel: `${parts[1]} ${parts[2]}` };
+      if (parts.length < 3) return { innerUnitLabel: ps || 'unit', unit: '', gramsPerInnerUnit: null };
+      const qty  = parseFloat(parts[1]);
+      const unit = parts[2].trim().toUpperCase();
+      let gramsPerInnerUnit = null;
+      if (unit === 'LB') gramsPerInnerUnit = qty * 453.592;
+      else if (unit === 'OZ') gramsPerInnerUnit = qty * 28.3495;
+      // GAL: density must be supplied per-product; EA: not applicable
+      return { innerUnitLabel: `${parts[1]} ${parts[2]}`, unit, gramsPerInnerUnit };
     }
 
+    // Convert grams → "X.XXX × N UNIT" label for cross-check display
+    function fmtPurchaseUnits(grams, gpu, innerUnitLabel) {
+      if (!gpu || isNaN(grams) || grams === '') return '—';
+      return `${fmt3(grams / gpu)} × ${innerUnitLabel}`;
+    }
+    function fmt3(n) { return isNaN(n) ? '—' : (Math.round(n * 1000) / 1000).toFixed(3); }
+
     // ── Recipe maps ──────────────────────────────────────────────────────────
-    let scaleMap  = {}; // { sku: { pretzelsPerTray, traysPerBatch } }
-    let recipeMap = {}; // { sku: { productId: quantityPerBatch } }
+    let scaleMap   = {}; // { sku: { pretzelsPerTray, traysPerBatch } }
+    let recipeMap  = {}; // { sku: { productId: gramsPerBatch } }
+    let densityMap = {}; // { productId: gramsPerInnerUnit } — for GAL products
 
     function buildRecipeMaps(logs) {
-      scaleMap  = {};
-      recipeMap = {};
+      scaleMap   = {};
+      recipeMap  = {};
+      densityMap = {};
       for (const r of logs) {
         if (r.action === 'sku_scale' && r.sku) {
           scaleMap[r.sku] = {
@@ -258,9 +281,12 @@
             traysPerBatch:   parseFloat(r.traysPerBatch)   || 0,
           };
         }
-        if (r.action === 'recipe' && r.sku && r.productId) {
+        if (r.action === 'recipe_v2' && r.sku && r.productId) {
           if (!recipeMap[r.sku]) recipeMap[r.sku] = {};
-          recipeMap[r.sku][r.productId] = parseFloat(r.quantityPerBatch) ?? 0;
+          recipeMap[r.sku][r.productId] = parseFloat(r.gramsPerBatch) ?? 0;
+        }
+        if (r.action === 'ingredient_density' && r.productId) {
+          densityMap[r.productId] = parseFloat(r.gramsPerInnerUnit) || 0;
         }
       }
     }
@@ -285,15 +311,23 @@
       const hasAny = Object.keys(recipe).length > 0 || ppt || tpb;
 
       const ingRows = PRODUCTS.map((p) => {
-        const { innerUnitLabel } = parsePackSize(p.packSize);
+        const { innerUnitLabel, unit, gramsPerInnerUnit } = parsePackSize(p.packSize);
+        const isEa  = unit === 'EA';
+        const isGal = unit === 'GAL';
+        const gpu   = gramsPerInnerUnit || densityMap[p.id] || 0;
         const perBatch = recipe[p.id] != null ? recipe[p.id] : '';
         const perTray  = (perBatch !== '' && tpb) ? fmt2(perBatch / tpb) : '';
         const perPret  = (perBatch !== '' && ppt && tpb) ? fmt2(perBatch / (ppt * tpb)) : '';
-        return `<tr>
-          <td><span class="ing-name">${escapeHtml(p.name)}</span></td>
-          <td><input type="number" class="recipe-qty-input" data-product-id="${escapeHtml(p.id)}" value="${perBatch}" placeholder="—" min="0" step="0.001"></td>
-          <td><span class="recipe-qty-derived per-tray">${perTray || '—'}</span></td>
-          <td><span class="recipe-qty-derived per-pretzel">${perPret || '—'}</span></td>
+        const purchase = isEa ? '—' : (gpu ? fmtPurchaseUnits(perBatch, gpu, innerUnitLabel) : (isGal ? '<em style="color:#888;font-size:11px">set density ↓</em>' : '—'));
+        const densityInput = isGal
+          ? `<div class="density-row"><label class="density-label">g per ${innerUnitLabel}:</label><input type="number" class="density-input" data-product-id="${escapeHtml(p.id)}" value="${densityMap[p.id] || ''}" placeholder="e.g. 3785" min="1" step="1"></div>`
+          : '';
+        return `<tr class="ing-row${isEa ? ' ing-row-ea' : ''}">
+          <td><span class="ing-name">${escapeHtml(p.name)}</span>${densityInput}</td>
+          <td>${isEa ? '<span class="ing-unit">—</span>' : `<input type="number" class="recipe-qty-input" data-product-id="${escapeHtml(p.id)}" value="${perBatch}" placeholder="—" min="0" step="0.1">`}</td>
+          <td><span class="recipe-qty-derived per-tray">${isEa ? '—' : (perTray || '—')}</span></td>
+          <td><span class="recipe-qty-derived per-pretzel">${isEa ? '—' : (perPret || '—')}</span></td>
+          <td><span class="purchase-units">${purchase}</span></td>
           <td><span class="ing-unit">${escapeHtml(innerUnitLabel)}</span></td>
         </tr>`;
       }).join('');
@@ -324,10 +358,11 @@
           <table class="recipe-ing-table">
             <thead><tr>
               <th>Ingredient</th>
-              <th>Per Batch</th>
-              <th>Per Tray</th>
-              <th>Per Pretzel</th>
-              <th>Unit</th>
+              <th>g / Batch</th>
+              <th>g / Tray</th>
+              <th>g / Pretzel</th>
+              <th>Purchase Units</th>
+              <th>Pack</th>
             </tr></thead>
             <tbody>${ingRows}</tbody>
           </table>
@@ -353,9 +388,12 @@
 
         card.querySelectorAll('.recipe-qty-input').forEach((inp) => {
           const val = parseFloat(inp.value);
+          const productId = inp.dataset.productId;
+          const product   = PRODUCTS.find((p) => p.id === productId);
           const row = inp.closest('tr');
           const perTrayEl    = row.querySelector('.per-tray');
           const perPretzelEl = row.querySelector('.per-pretzel');
+          const purchaseEl   = row.querySelector('.purchase-units');
           if (!isNaN(val)) {
             if (perTrayEl)    perTrayEl.textContent    = tpb ? fmt2(val / tpb) : '—';
             if (perPretzelEl) perPretzelEl.textContent = ppb ? fmt2(val / ppb)  : '—';
@@ -363,12 +401,35 @@
             if (perTrayEl)    perTrayEl.textContent    = '—';
             if (perPretzelEl) perPretzelEl.textContent = '—';
           }
+          if (purchaseEl && product) {
+            const { innerUnitLabel, gramsPerInnerUnit } = parsePackSize(product.packSize);
+            const gpu = gramsPerInnerUnit || densityMap[productId] || 0;
+            purchaseEl.innerHTML = gpu ? fmtPurchaseUnits(val, gpu, innerUnitLabel) : '<em style="color:#888;font-size:11px">set density ↓</em>';
+          }
         });
       }
 
       pptInput.addEventListener('input', updateDerived);
       tpbInput.addEventListener('input', updateDerived);
       card.querySelectorAll('.recipe-qty-input').forEach((inp) => inp.addEventListener('input', updateDerived));
+
+      // Density inputs (GAL products) — update purchase units live
+      card.querySelectorAll('.density-input').forEach((inp) => {
+        inp.addEventListener('input', () => {
+          const productId = inp.dataset.productId;
+          const gpu = parseFloat(inp.value) || 0;
+          densityMap[productId] = gpu;
+          const product = PRODUCTS.find((p) => p.id === productId);
+          if (!product) return;
+          const { innerUnitLabel } = parsePackSize(product.packSize);
+          const qtyInp = card.querySelector(`.recipe-qty-input[data-product-id="${productId}"]`);
+          const purchaseEl = inp.closest('tr').querySelector('.purchase-units');
+          if (purchaseEl) {
+            const grams = parseFloat(qtyInp?.value);
+            purchaseEl.innerHTML = gpu ? fmtPurchaseUnits(grams, gpu, innerUnitLabel) : '<em style="color:#888;font-size:11px">set density ↓</em>';
+          }
+        });
+      });
 
       card.querySelector('.sku-save-btn').addEventListener('click', async () => {
         const saveBtn    = card.querySelector('.sku-save-btn');
@@ -395,7 +456,18 @@
           const val = parseFloat(inp.value);
           if (!isNaN(val) && val >= 0) {
             writes.push(appendLog(RECIPES_PATH, {
-              action: 'recipe', sku, productId, quantityPerBatch: String(val), timeStamp: now, updatedBy: '',
+              action: 'recipe_v2', sku, productId, gramsPerBatch: String(val), timeStamp: now, updatedBy: '',
+            }));
+          }
+        });
+
+        // Save density overrides for GAL products
+        card.querySelectorAll('.density-input').forEach((inp) => {
+          const productId = inp.dataset.productId;
+          const val = parseFloat(inp.value);
+          if (!isNaN(val) && val > 0) {
+            writes.push(appendLog(RECIPES_PATH, {
+              action: 'ingredient_density', productId, gramsPerInnerUnit: String(val), timeStamp: now, updatedBy: '',
             }));
           }
         });
@@ -410,6 +482,10 @@
           card.querySelectorAll('.recipe-qty-input').forEach((inp) => {
             const val = parseFloat(inp.value);
             if (!isNaN(val) && val >= 0) recipeMap[sku][inp.dataset.productId] = val;
+          });
+          card.querySelectorAll('.density-input').forEach((inp) => {
+            const val = parseFloat(inp.value);
+            if (!isNaN(val) && val > 0) densityMap[inp.dataset.productId] = val;
           });
           const metaEl = card.querySelector('.sku-card-meta');
           if (metaEl && scaleMap[sku]) {
@@ -452,15 +528,18 @@
         const usedIngredients = PRODUCTS.filter((p) => recipe[p.id] != null && recipe[p.id] > 0);
 
         const ingRows = usedIngredients.map((p) => {
-          const { innerUnitLabel } = parsePackSize(p.packSize);
+          const { innerUnitLabel, gramsPerInnerUnit } = parsePackSize(p.packSize);
+          const gpu      = gramsPerInnerUnit || densityMap[p.id] || 0;
           const perBatch = recipe[p.id];
           const perTray  = (perBatch != null && scale.traysPerBatch)   ? fmt2(perBatch / scale.traysPerBatch) : '—';
           const perPret  = (perBatch != null && ppb && ppb !== '—')    ? fmt2(perBatch / ppb) : '—';
+          const purchase = gpu ? fmtPurchaseUnits(perBatch, gpu, innerUnitLabel) : '—';
           return `<tr>
             <td>${escapeHtml(p.name)}</td>
-            <td class="num">${fmt2(perBatch)}</td>
-            <td class="num">${perTray}</td>
-            <td class="num">${perPret}</td>
+            <td class="num">${fmt2(perBatch)}g</td>
+            <td class="num">${perTray}${perTray !== '—' ? 'g' : ''}</td>
+            <td class="num">${perPret}${perPret !== '—' ? 'g' : ''}</td>
+            <td class="num">${purchase}</td>
             <td class="unit">${escapeHtml(innerUnitLabel)}</td>
           </tr>`;
         }).join('');
@@ -483,10 +562,11 @@
             <table class="summary-ing-table">
               <thead><tr>
                 <th>Ingredient</th>
-                <th style="text-align:right">Per Batch</th>
-                <th style="text-align:right">Per Tray</th>
-                <th style="text-align:right">Per Pretzel</th>
-                <th>Unit</th>
+                <th style="text-align:right">g / Batch</th>
+                <th style="text-align:right">g / Tray</th>
+                <th style="text-align:right">g / Pretzel</th>
+                <th style="text-align:right">Purchase Units</th>
+                <th>Pack</th>
               </tr></thead>
               <tbody>${ingRows}</tbody>
             </table>` : noIngredientsNote}


### PR DESCRIPTION
## Summary

Recipes are now entered in **grams** and automatically converted to purchase/delivery units for cross-checking and forecasting.

### Recipes page
- All recipe quantity inputs changed to grams
- New **Purchase Units** column shows the derived delivery quantity live as you type — e.g. `0.220 × 50 LB` for flour, `1.103 × 1 LB` for butter — so staff can verify by eye
- g/Tray and g/Pretzel columns still update live
- **LB and OZ** ingredients auto-convert from pack size (no setup needed)
- **GAL** products (Mustard, Mayo, Cream, Ranch) show a one-time "g per unit" density input per ingredient — enter once, saved permanently
- **EA** items (Gloves, Liners) are greyed out — gram conversion not applicable
- Saves as new `action:'recipe_v2'` log entries with `gramsPerBatch`

### Inventory Forecast
- Reads `recipe_v2` (grams) and `ingredient_density` from recipes log
- `computeForecast` converts grams → inner units before comparing to stock levels
- GAL ingredients only appear in forecast once their density is set

## Preview
https://feature-recipes-grams-conversion--website--dangpretz.aem.page/static/recipes/

## Test plan
- [ ] Open a SKU card → ingredient inputs show "g / Batch" header
- [ ] Enter gram quantity → Purchase Units column shows `X.XXX × N LB` immediately
- [ ] g/Tray and g/Pretzel update live as grams are typed
- [ ] Save → toast appears, values persist on reload
- [ ] For a GAL ingredient (e.g. Ranch): density input appears below the name
- [ ] Enter density for Ranch → Purchase Units column populates
- [ ] EA rows (Gloves, Liners) are greyed out with no gram input
- [ ] Forecast page: ingredients with recipes show non-zero Expected Use after entering grams + density for GAL

🤖 Generated with [Claude Code](https://claude.com/claude-code)