### PR TITLE
ci: preview before publish in AEM deploy step

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,8 +17,12 @@ jobs:
       run: |
         find static -name "*.html" | while read FILE; do
           AEM_PATH="/${FILE}"
+          echo "Previewing ${AEM_PATH}…"
+          PRE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "https://admin.hlx.page/preview/dangpretz/website/main${AEM_PATH}")
+          echo "  preview → HTTP ${PRE}"
           echo "Publishing ${AEM_PATH}…"
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+          PUB=$(curl -s -o /dev/null -w "%{http_code}" \
             -X POST "https://admin.hlx.page/publish/dangpretz/website/main${AEM_PATH}")
-          echo "  → HTTP ${STATUS}"
+          echo "  publish → HTTP ${PUB}"
         done


### PR DESCRIPTION
## Summary
- The AEM `admin.hlx.page/publish` endpoint returns 404 if the content hasn't been registered via a preview call first
- Updated the CI deploy step to POST to `/preview/…` before `/publish/…` for each HTML file
- This should fix the issue where merging to main runs CI successfully but the live site doesn't update

## Test URL
https://feature-recipes-grams-conversion--website--dangpretz.aem.page/static/recipes/

## Test plan
- [ ] Merge this PR → CI run completes
- [ ] Check CI logs — preview and publish steps should return 2xx instead of 404
- [ ] Confirm `https://main--website--dangpretz.aem.live/static/recipes/` reflects the latest changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)