### PR TITLE
fix(recipes): single-column SKU card layout

### DIFF
--- a/static/recipes/index.html
+++ b/static/recipes/index.html
@@ -47,7 +47,7 @@
     /* ════════════════════════════════════
        SKU CARDS
     ════════════════════════════════════ */
-    .sku-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 16px; }
+    .sku-grid { display: flex; flex-direction: column; gap: 16px; }
 
     .sku-card { background: #2e2e2e; border-radius: 10px; overflow: hidden; }
     .sku-card-header { display: flex; align-items: center; justify-content: space-between; padding: 14px 18px; cursor: pointer; user-select: none; border-bottom: 1px solid transparent; transition: border-color .2s; }
@@ -136,7 +136,6 @@
 
     /* ── Mobile ── */
     @media (max-width: 640px) {
-      .sku-grid { grid-template-columns: 1fr; }
       .scale-row { grid-template-columns: 1fr 1fr; }
       .scale-row .auto-col { display: none; }
       .summary-ing-table th:nth-child(3),


### PR DESCRIPTION
## Summary
- `.sku-grid` was using `repeat(auto-fill, minmax(340px, 1fr))`, which packed ~3 cards per row on a wide screen
- Replaced with `display: flex; flex-direction: column` so each SKU card is always full-width, one per row
- Removed the now-redundant `grid-template-columns: 1fr` mobile override

## Test URL
https://feature-recipes-grams-conversion--website--dangpretz.aem.page/static/recipes/

## Test plan
- [ ] Recipes page shows one SKU card per row at all screen widths
- [ ] Cards still expand/collapse correctly
- [ ] Ingredient blocks, search, and save all work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)