### PR TITLE
fix: show dip stock as ready on delivery planner

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -1134,6 +1134,22 @@ export function attributeDeliveryCoverage({
   const frozenLeft = { ...inventoryReport.effective.frozen };
   const doughLeft = { ...inventoryReport.effective.coldFerment };
 
+  // onHand items are immediately ready (inventory snapshots / manual stock counts).
+  // Include them in frozenLeft so they register as "ready" coverage.
+  for (const [k, v] of Object.entries(inventoryReport.effective.onHand || {})) {
+    if (v > 0) frozenLeft[k] = (frozenLeft[k] || 0) + v;
+  }
+  // Dip SKUs have no BFP step — cheese_done credits coldFerment (refrigerated)
+  // but the product is immediately ready. Move dip coldFerment into frozenLeft
+  // so coverage shows "ready" rather than "baking".
+  for (const dipKey of Object.keys(DIP_CONFIG)) {
+    const cf = doughLeft[dipKey] || 0;
+    if (cf > 0) {
+      frozenLeft[dipKey] = (frozenLeft[dipKey] || 0) + cf;
+      doughLeft[dipKey] = 0;
+    }
+  }
+
   const coverage = new Map();
 
   sortedDeliveries.forEach((delivery) => {


### PR DESCRIPTION
## Summary
- `attributeDeliveryCoverage()` in `scripts/inventory.js` was ignoring `effective.onHand` entirely — manual stock counts entered via the Stock tab were invisible to the coverage display
- Dip `coldFerment` (populated by `cheese_done` log entries) was being mapped to "baking" status even though dips have no BFP step — once made, they're immediately ready
- Fix includes `onHand` in `frozenLeft` and moves all `DIP_CONFIG` SKU `coldFerment` into `frozenLeft` so cheese dip and all dip SKUs show "ready" once batches are logged

## What's unchanged
- Pretzel SKUs: their `coldFerment` (raw dough) stays in `doughLeft` and still shows "baking" — no behavior change
- This is a pure display function — no log writes, no data modification, fully reversible
- All `effective.*` values from `getInventoryReport()` are consumed unchanged; only how they map to display status is corrected

## Test plan
- [ ] Log a `cheese_done` batch on the production page → delivery planner shows the dip order as "ready"
- [ ] Enter an on-hand count in the Stock tab → delivery planner reflects that coverage
- [ ] Pretzel orders still show "baking" when only dough exists, "ready" when frozen — no regression
- [ ] All 5 dip SKUs (`3oz cheese dip`, `hot ranch dip`, `sweet cream dip`, `house mustard dip`, `honey mustard dip`) now reflect correct coverage

**Test URL:** https://fix-dip-stock-coverage--website--dangpretz.aem.page/static/delivery-planner/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)