### PR TITLE
fix: bump inventory.js cache-bust version to load dip coverage fix

### DIFF
--- a/static/delivery-planner/index.html
+++ b/static/delivery-planner/index.html
@@ -957,7 +957,7 @@
       isShapeOnlyDelivery,
       expandBoxLineItems,
       caseSizeOptionsFor,
-    } from '../../scripts/inventory.js?v=2026-05-12-drift-fixes-plus-audit';
+    } from '../../scripts/inventory.js?v=2026-05-21-dip-coverage-fix';
 
     // Shape-only catering + box expansion. ENABLED BY DEFAULT — kept in
     // sync with production app via the same localStorage key.

--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1125,7 +1125,7 @@
     getInventoryReport, attributeDeliveryCoverage,
     scheduleCheese, scheduleDip,
     isShapeOnlyDelivery,
-  } from '../../scripts/inventory.js?v=2026-05-12-drift-fixes-plus-audit';
+  } from '../../scripts/inventory.js?v=2026-05-21-dip-coverage-fix';
 
   // Shape-only catering + box expansion. ENABLED BY DEFAULT — catering
   // boxes (Catering: ...) and FOH Placeholder deliveries skip BFP and


### PR DESCRIPTION
## Summary
- `scripts/inventory.js` was imported with `?v=2026-05-12-drift-fixes-plus-audit` in both the delivery planner and production pages
- AEM's CDN caches by full URL, so the dip stock fix from PR #48 was never served — browsers kept getting the old May 12 version
- Bumps the version string to `?v=2026-05-21-dip-coverage-fix` so the CDN fetches the updated file

## Pages changed
- `static/delivery-planner/index.html`
- `static/production/index.html`

## Test plan
- [ ] After merge, hard-refresh the delivery planner — cheese dip orders should now show correct stock coverage (ready/partial) when 300 on-hand is set on the production page
- [ ] Production page Stock tab still loads and saves correctly

**Test URL:** https://fix-inventory-cache-bust--website--dangpretz.aem.page/static/delivery-planner/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)