### PR TITLE
fix: update Honey Mustard pairing on signage screen 3

### DIFF
--- a/v2/signage/menu.html
+++ b/v2/signage/menu.html
@@ -652,7 +652,7 @@
         <div class="card-b__row card-b__row--3col card-b__row--dip">
           <span class="card-b__label">Honey Mustard</span>
           <span class="card-b__sub">Stone ground classic. Sweet and tangy.</span>
-          <span class="card-b__pairs"><small>Pairs With</small>Saint &middot; For The Kids</span>
+          <span class="card-b__pairs"><small>Pairs With</small>Devil's Delight &middot; Salty</span>
         </div>
         <div class="card-b__row card-b__row--3col card-b__row--dip">
           <span class="card-b__label">Hot Ranch</span>


### PR DESCRIPTION
## Summary
- Honey Mustard "Pairs With" on screen 3 showed **Saint · For The Kids**
- Updated to **Devil's Delight · Salty**

## Test plan
- [ ] Visit https://fix-honey-mustard-pairs-with--website--dangpretz.aem.page/v2/signage/menu.html?screen=3 and confirm the Honey Mustard row reads "Devil's Delight · Salty" under Pairs With

🤖 Generated with [Claude Code](https://claude.com/claude-code)