### PR TITLE
fix: vertically center dip and suds rows on signage screen 3

### DIFF
--- a/v2/signage/menu.html
+++ b/v2/signage/menu.html
@@ -284,15 +284,22 @@
     text-transform: uppercase;
   }
 
-  /* Dip rows: smaller name, more padding, stronger divider */
+  /* Dip rows: smaller name, more padding, stronger divider, vertically centered */
   .card-b--cream .card-b__row--dip {
     padding: var(--space-3) 0;
+    align-items: center;
   }
   .card-b--cream .card-b__row--dip + .card-b__row--dip {
     border-top: 1px solid rgba(26, 26, 26, 0.12);
   }
   .card-b--cream .card-b__row--dip .card-b__label {
     font: var(--weight-heavy) 1.77vw/1.05 var(--font);
+  }
+
+  /* Suds & Sodas rows: vertically centered; left column sizes to widest label */
+  .card-b--dark .card-b__row--3col {
+    align-items: center;
+    grid-template-columns: max-content 1fr auto;
   }
 
   /* ═══ Pills ═══ */


### PR DESCRIPTION
## Summary
Two CSS-only changes to `v2/signage/menu.html`, screen 3 only:

**Dips section**
- Added `align-items: center` to `.card-b--cream .card-b__row--dip` so the dip name, description, and "Pairs With" column all share the same vertical midpoint

**Suds & Sodas section**
- Added `align-items: center` to `.card-b--dark .card-b__row--3col` for the same vertical centering
- Changed left column from fixed `12.5vw` to `max-content` so it sizes to the widest label ("Non-Alcoholic"), and the middle description column compresses to fill the remaining space naturally

No other screens or sections are affected.

## Test plan
- [ ] Visit https://fix-signage-screen3-alignment--website--dangpretz.aem.page/v2/signage/menu.html?screen=3
- [ ] Dips: all three columns (name / description / Pairs With) are vertically centered on each row
- [ ] Suds & Sodas: all three columns vertically centered; left label column aligns tightly to the longest label

🤖 Generated with [Claude Code](https://claude.com/claude-code)