### PR TITLE
fix: align Suds & Sodas descriptions via CSS subgrid

### DIFF
--- a/v2/signage/menu.html
+++ b/v2/signage/menu.html
@@ -296,10 +296,20 @@
     font: var(--weight-heavy) 1.77vw/1.05 var(--font);
   }
 
-  /* Suds & Sodas rows: vertically centered; left column sizes to widest label */
-  .card-b--dark .card-b__row--3col {
-    align-items: center;
+  /* Suds & Sodas: parent grid defines the columns so all rows share the same
+     max-content width for the label column. Each row uses subgrid to inherit
+     those tracks, keeping descriptions aligned regardless of label length. */
+  .card-b--dark {
+    display: grid;
     grid-template-columns: max-content 1fr auto;
+    column-gap: var(--space-4);
+    row-gap: var(--space-2);
+  }
+  .card-b--dark .card-b__row--3col {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: subgrid;
+    align-items: center;
   }
 
   /* ═══ Pills ═══ */


### PR DESCRIPTION
## Problem
The previous `max-content` fix was applied to each row individually. Since every row is its own grid, each row calculated its first column width independently — "Draft Beer" got a narrower column than "Cans & Bottles", so its description text started further left and didn't line up.

## Fix
Move the grid definition to the parent `.card-b--dark` container with `grid-template-columns: max-content 1fr auto`. Each row then gets `grid-column: 1 / -1` + `grid-template-columns: subgrid` to inherit the parent's column tracks. The widest label ("Cans & Bottles") sets the first-column width for all three rows, so all descriptions start at exactly the same position.

## Test plan
- [ ] Visit https://fix-signage-suds-column-alignment--website--dangpretz.aem.page/v2/signage/menu.html?screen=3
- [ ] All three Suds & Sodas descriptions are left-aligned at the same x-position
- [ ] Left column is as narrow as the widest label ("Cans & Bottles"), not a fixed 12.5vw
- [ ] Rows remain vertically centered and dividers between rows are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)