### PR TITLE
fix: default 2 workers per team, 6 batches per worker cap

### DIFF
--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1283,7 +1283,7 @@
   // ─── BUSINESS RULES ───────────────────────────────────────────────────────
   // Edit these to match operational reality. Each is a single source of truth
   // for the rule it represents — no other place hardcodes these numbers.
-  const BATCHES_PER_WORKER  = 5;   // batches per worker per day (cap)
+  const BATCHES_PER_WORKER  = 6;   // batches per worker per day (cap)
   const SHAPE_MIN_LEAD      = 2;   // shape must happen at least N days before delivery
   const SHAPE_MAX_LEAD      = 7;   // shape can happen up to N days before delivery
   const BFP_MIN_LEAD        = 1;   // BFP must happen at least N days before delivery
@@ -1721,7 +1721,7 @@
   const getWorkers = (type, date) => {
     const fromLog = (productionState[date] || {})[type === 'shape' ? 'shapeWorkers' : 'bfpWorkers'];
     if (fromLog && fromLog > 0) return Math.max(1, fromLog);
-    return Math.max(1, parseInt(localStorage.getItem(`prod-${type}-workers-${date}`), 10) || 1);
+    return Math.max(1, parseInt(localStorage.getItem(`prod-${type}-workers-${date}`), 10) || 2);
   };
   // saveWorkers updates THREE things:
   //   1. productionState in-memory  (so the next getWorkers/render() call sees


### PR DESCRIPTION
## Changes
- **Default workers**: raised from `1` → `2` for both shape and BFP when no saved value exists (line 1724)
- **Batch cap**: `BATCHES_PER_WORKER` raised from `5` → `6` (line 1286), updating daily capacity used by the scheduler and worker day meter

## Test plan
- [ ] Visit https://fix-production-worker-defaults--website--dangpretz.aem.page/static/production/index.html on a fresh device (no localStorage) — worker count should show 2 for both tabs
- [ ] Daily batch cap per worker reflects 6 (2 workers × 6 = 12 batch cap displayed)
- [ ] Saving a different worker count still persists and overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)