### PR TITLE
fix: always show FOH Placeholder in customer dropdown

### DIFF
--- a/static/delivery-planner/index.html
+++ b/static/delivery-planner/index.html
@@ -1507,6 +1507,8 @@
       // Keep placeholder + new-customer option, remove existing customer options
       [...select.options].filter((o) => o.value !== '' && o.value !== '__new__').forEach((o) => o.remove());
       const normalized = new Map();
+      // Always include FOH Placeholder so shape-only batches can be assigned without prior history
+      normalized.set('foh placeholder', 'FOH Placeholder');
       if (Array.isArray(deliveries)) {
         deliveries.forEach((row) => {
           const name = normalizeCustomer(row.customer || row.location || '');


### PR DESCRIPTION
## Summary
The customer dropdown is built from delivery history, so "FOH Placeholder" (the special customer name that flags shape-only batches) only appeared after at least one delivery had used it. Added it as a pinned entry in `updateCustomerSelect()` so it's always present.

One line change — no other behaviour affected.

Replaces #55 (branch name was too long for AEM preview URL).

## Test plan
- [ ] Open the New Order form at https://fix-foh-customer--website--dangpretz.aem.page/static/delivery-planner/index.html
- [ ] "FOH Placeholder" appears in the customer dropdown even with no prior delivery history
- [ ] Selecting it and saving creates a shape-only order (skips BFP coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)