### PR TITLE
fix: cache-bust inventory.js and skus.json after new SKU additions

### DIFF
--- a/static/delivery-planner/index.html
+++ b/static/delivery-planner/index.html
@@ -957,7 +957,7 @@
       isShapeOnlyDelivery,
       expandBoxLineItems,
       caseSizeOptionsFor,
-    } from '../../scripts/inventory.js?v=2026-05-21-dip-coverage-fix';
+    } from '../../scripts/inventory.js?v=2026-05-22-new-skus';
 
     // Shape-only catering + box expansion. ENABLED BY DEFAULT — kept in
     // sync with production app via the same localStorage key.
@@ -1262,7 +1262,7 @@
     }
 
     async function loadSkus() {
-      const res = await fetch('skus.json');
+      const res = await fetch('skus.json?v=2026-05-22-new-skus');
       skus = await res.json();
     }
 

--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1125,7 +1125,7 @@
     getInventoryReport, attributeDeliveryCoverage,
     scheduleCheese, scheduleDip,
     isShapeOnlyDelivery,
-  } from '../../scripts/inventory.js?v=2026-05-21-dip-coverage-fix';
+  } from '../../scripts/inventory.js?v=2026-05-22-new-skus';
 
   // Shape-only catering + box expansion. ENABLED BY DEFAULT — catering
   // boxes (Catering: ...) and FOH Placeholder deliveries skip BFP and
@@ -4747,7 +4747,7 @@
 
   async function loadSkus() {
     try {
-      const r = await fetch('../delivery-planner/skus.json');
+      const r = await fetch('../delivery-planner/skus.json?v=2026-05-22-new-skus');
       allSkus = await r.json();
     } catch { allSkus = Object.keys(BATCH_SIZES); } // fallback to hardcoded list
   }


### PR DESCRIPTION
## Problem
PR #58 added `6.5oz bootlegger` and `6.5oz pepperoni` to `inventory.js` and `skus.json`, but both live pages were still showing the old SKU lists. The AEM CDN had cached both files under their old URLs.

## Changes
Three one-line cache-bust fixes:

| File | Change |
|------|--------|
| `static/production/index.html` | `inventory.js?v=` → `2026-05-22-new-skus` |
| `static/delivery-planner/index.html` | `inventory.js?v=` → `2026-05-22-new-skus` |
| `static/delivery-planner/index.html` | `fetch('skus.json')` → `fetch('skus.json?v=2026-05-22-new-skus')` |
| `static/production/index.html` | `fetch('../delivery-planner/skus.json')` → `fetch('../delivery-planner/skus.json?v=2026-05-22-new-skus')` |

## Test plan
- [ ] Production page Stock tab shows `6.5oz bootlegger` and `6.5oz pepperoni` — https://fix-new-sku-cache-bust--website--dangpretz.aem.page/static/production/index.html
- [ ] Delivery planner New Order SKU dropdown includes both new SKUs — https://fix-new-sku-cache-bust--website--dangpretz.aem.page/static/delivery-planner/index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)