### PR TITLE
Resilient confirm delivery — retry indefinitely on poor connection

### DIFF
--- a/scripts/sheet-logger.js
+++ b/scripts/sheet-logger.js
@@ -17,7 +17,7 @@ export async function fetchLog(logpath) {
 // Throws on non-2xx so callers' try/catch can react. The prior silent-
 // success-only behavior meant network blips were invisible — saveStock
 // would log "Saved!" toast even when the row never landed in the sheet.
-export async function appendLog(logpath, message) {
+export async function appendLog(logpath, message, { signal } = {}) {
   const params = new URLSearchParams();
   Object.keys(message).forEach((key) => {
     params.append(key, message[key]);
@@ -27,6 +27,7 @@ export async function appendLog(logpath, message) {
   try {
     resp = await fetch(`${SHEET_LOGGER}${logpath}?${params.toString()}`, {
       method: 'POST',
+      signal, // AbortSignal for per-attempt timeouts; undefined when not passed → no change
     });
   } catch (networkErr) {
     throw new Error(`appendLog ${logpath} network error: ${networkErr.message}`);

--- a/static/delivery-planner/index.html
+++ b/static/delivery-planner/index.html
@@ -2275,14 +2275,42 @@
         signatureData: useSignature && !sigPad.isEmpty() ? sigPad.toDataURL() : '',
         confirmNote: note, confirmTimestamp: new Date().toISOString(), timeStamp: new Date().toISOString(),
       };
-      let retries = 3;
-      while (retries > 0) {
-        try { await appendLog(LOG_PATH, data); break; }
-        catch (err) { retries--; if (retries === 0) { errEl.textContent = 'Failed to save. Try again.'; errEl.hidden = false; btn.disabled = false; btn.textContent = 'Confirm Delivery'; return; } await new Promise((r) => setTimeout(r, 1000)); }
+      // Indefinite retry with per-attempt abort timeout + exponential backoff.
+      // Each attempt gets 10 s before being aborted; on failure the user sees
+      // a live countdown ("No connection — retrying in 8s…") and we wait before
+      // trying again. Backoff: 2 s → 4 s → 8 s → 16 s → 30 s (then holds).
+      const TIMEOUT_MS = 10_000;
+      const BACKOFF_MS = [2000, 4000, 8000, 16000, 30000];
+      let attempt = 0;
+      while (true) { // eslint-disable-line no-constant-condition
+        btn.textContent = attempt === 0 ? 'Saving…' : 'Retrying…';
+        errEl.hidden = true;
+        try {
+          const ctrl  = new AbortController();
+          const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+          await appendLog(LOG_PATH, data, { signal: ctrl.signal });
+          clearTimeout(timer);
+          break; // ✅ success
+        } catch (_) {
+          const delay = BACKOFF_MS[Math.min(attempt, BACKOFF_MS.length - 1)];
+          attempt++;
+          let secs = Math.round(delay / 1000);
+          errEl.textContent = `No connection — retrying in ${secs}s…`;
+          errEl.hidden = false;
+          await new Promise((resolve) => {
+            const iv = setInterval(() => {
+              secs--;
+              if (secs > 0) errEl.textContent = `No connection — retrying in ${secs}s…`;
+              else { clearInterval(iv); resolve(); }
+            }, 1000);
+            setTimeout(resolve, delay);
+          });
+        }
       }
       btn.disabled = false; btn.textContent = 'Confirm Delivery';
       document.getElementById('confirm-overlay').classList.remove('open');
       confirmDeliveryId = null;
+      errEl.hidden = true;
       showNotification('✅ Delivery confirmed!');
       await loadRecords();
     });


### PR DESCRIPTION
## Summary
Fixes the confirm modal freezing on "Saving…" when internet is poor.

**Root cause:** `appendLog()` had no fetch timeout, so a slow/dead connection hung the browser for up to 10 minutes. The existing 3-retry loop was useless because each attempt could individually hang for that long.

**Fix — 2 files, 34 lines added / 5 removed:**

- **`scripts/sheet-logger.js`**: `appendLog()` now accepts an optional `{ signal }` parameter and passes it to `fetch()`. Fully backward-compatible — all other pages pass nothing and behave identically to today.
- **`static/delivery-planner/index.html`**: The confirm submit handler now:
  - Gives each attempt a **10-second abort timeout** via `AbortController` (fast failure instead of hanging)
  - On failure, shows a live countdown: `"No connection — retrying in 8s…"` (ticks every second)
  - Retries **indefinitely** with exponential backoff: 2 s → 4 s → 8 s → 16 s → 30 s
  - Keeps the modal open with signature, name, and note preserved throughout
  - Breaks out of the loop only on success

## AEM Preview
https://feat-confirm-retry--website--dangpretz.aem.page/static/delivery-planner/index.html

## Test plan
- [ ] Good connection: "Saving…" → modal closes → "✅ Delivery confirmed!" (same as today, ~1 s)
- [ ] Throttled/slow connection: attempt times out after 10 s → countdown appears → retries → succeeds when connection recovers
- [ ] Cancel during retry: modal closes; if connection returns the save completes silently in background
- [ ] All other pages using `appendLog` (production, inventory, etc.): no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)