### PR TITLE
Fix worker count: BFP Sunday stepper + allow shape=0

### DIFF
--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -598,9 +598,11 @@ export function resolveProductionLogs(logs) {
       return;
     }
     if (action === 'workers_config') {
-      const n = Math.max(1, Number(row.workers) || 1);
-      if (row.type === 'shape') s.shapeWorkers = n;
-      else if (row.type === 'bfp') s.bfpWorkers = n;
+      const n      = Number(row.workers);
+      const minVal = row.type === 'shape' ? 0 : 1;
+      const v      = isNaN(n) ? minVal : Math.max(minVal, n);
+      if (row.type === 'shape') s.shapeWorkers = v;
+      else if (row.type === 'bfp') s.bfpWorkers = v;
     }
   });
 

--- a/scripts/inventory.js
+++ b/scripts/inventory.js
@@ -598,9 +598,9 @@ export function resolveProductionLogs(logs) {
       return;
     }
     if (action === 'workers_config') {
-      const n      = Number(row.workers);
+      const n = Number(row.workers);
       const minVal = row.type === 'shape' ? 0 : 1;
-      const v      = isNaN(n) ? minVal : Math.max(minVal, n);
+      const v = Number.isNaN(n) ? minVal : Math.max(minVal, n);
       if (row.type === 'shape') s.shapeWorkers = v;
       else if (row.type === 'bfp') s.bfpWorkers = v;
     }

--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1736,9 +1736,12 @@
   // devices (manager + Shape tablet + BFP tablet) see the same daily capacity.
   // Falls back to per-device localStorage (legacy + offline edits).
   const getWorkers = (type, date) => {
-    const fromLog = (productionState[date] || {})[type === 'shape' ? 'shapeWorkers' : 'bfpWorkers'];
-    if (fromLog && fromLog > 0) return Math.max(1, fromLog);
-    return Math.max(1, parseInt(localStorage.getItem(`prod-${type}-workers-${date}`), 10) || 2);
+    const key     = type === 'shape' ? 'shapeWorkers' : 'bfpWorkers';
+    const fromLog = (productionState[date] || {})[key];
+    const minVal  = type === 'shape' ? 0 : 1;
+    if (fromLog != null && !isNaN(fromLog)) return Math.max(minVal, Number(fromLog));
+    const stored = parseInt(localStorage.getItem(`prod-${type}-workers-${date}`), 10);
+    return Math.max(minVal, isNaN(stored) ? 2 : stored);
   };
   // saveWorkers updates THREE things:
   //   1. productionState in-memory  (so the next getWorkers/render() call sees
@@ -1748,7 +1751,7 @@
   //   2. localStorage              (per-device fallback + offline)
   //   3. production log            (synced across devices, fire-and-forget)
   const saveWorkers = (type, date, n) => {
-    const v = Math.max(1, n);
+    const v = Math.max(type === 'shape' ? 0 : 1, n);
     if (!productionState[date]) productionState[date] = {};
     productionState[date][type === 'shape' ? 'shapeWorkers' : 'bfpWorkers'] = v;
     localStorage.setItem(`prod-${type}-workers-${date}`, String(v));
@@ -2785,22 +2788,25 @@
     const hasBfp   = (schedule.bfp[dateStr]   || []).length > 0
                   || (dayState.bfpDone   || []).length > 0;
 
-    if (!hasShape && !hasBfp) {
-      return `<div class="no-prod">${t('nothing_today')}<br>
-        <span style="font-size:13px;color:var(--gray-3)">${t('no_prod_extra')}</span>
-      </div>`;
-    }
     const teamHas = type === 'shape' ? hasShape : hasBfp;
-    if (!teamHas) {
-      const teamLabel  = type === 'shape' ? t('shape_label') : t('bfp_label');
-      const otherLabel = type === 'shape' ? t('bfp_label')   : t('shape_label');
-      const hint = userRole === 'manager'
-        ? `<span style="font-size:13px;color:var(--gray-3)">${t('check_other', { team: otherLabel })}</span>`
-        : `<span style="font-size:13px;color:var(--gray-3)">${t('all_clear')}</span>`;
-      return `<div class="no-prod" style="padding:32px 20px">${t('nothing_for', { team: teamLabel })}<br>${hint}</div>`;
+
+    if (userRole !== 'manager') {
+      // Worker views — keep existing "nothing today" behaviour when their team has no work
+      if (!hasShape && !hasBfp) {
+        return `<div class="no-prod">${t('nothing_today')}<br>
+          <span style="font-size:13px;color:var(--gray-3)">${t('no_prod_extra')}</span>
+        </div>`;
+      }
+      if (!teamHas) {
+        const teamLabel = type === 'shape' ? t('shape_label') : t('bfp_label');
+        return `<div class="no-prod" style="padding:32px 20px">${t('nothing_for', { team: teamLabel })}<br>
+          <span style="font-size:13px;color:var(--gray-3)">${t('all_clear')}</span></div>`;
+      }
+      return renderWorkerDayView(type, dateStr);
     }
-    // Worker view: status-grouped sections + day meter; manager view: existing card
-    if (userRole !== 'manager') return renderWorkerDayView(type, dateStr);
+    // Manager: always render the team card — it handles empty items internally and
+    // always shows the workers stepper. This lets managers set worker counts even on
+    // days with no scheduled batches (e.g. BFP on Sunday).
     return renderTeamCard(type, dateStr);
   }
 
@@ -4320,8 +4326,9 @@
     document.querySelectorAll('[data-worker-dec]').forEach(btn => {
       btn.addEventListener('click', () => {
         const { type, date } = btn.dataset;
-        const cur = getWorkers(type, date);
-        if (cur <= 1) return;
+        const cur    = getWorkers(type, date);
+        const minVal = type === 'shape' ? 0 : 1;
+        if (cur <= minVal) return;
         saveWorkers(type, date, cur - 1);
         schedule = buildOptimalSchedule();
         render();


### PR DESCRIPTION
## Summary
- **BFP Sunday**: Manager navigating to the BFP tab on a day with no scheduled batches (e.g. Sunday) now sees the team card with the workers stepper, instead of a "nothing for BFP today" dead-end. Root cause: `renderDayView` returned early before calling `renderTeamCard` whenever `hasBfp = false`.
- **Shape 0 workers**: The `−` button on the shape team card can now count down to 0. All three guards (`getWorkers`, `saveWorkers`, decrement handler) now use type-aware minimums: shape=0, bfp=1. The stepper stays visible at 0 workers. `inventory.js` log reader updated to match.

Test URLs:
- Before: https://main--website--dangpretz.hlx.page/static/production/index.html
- After: https://fix-worker-counts--website--dangpretz.hlx.page/static/production/index.html

## Test plan
- [ ] Open production page as manager, navigate to a future Sunday → BFP tab shows workers stepper (not "nothing for BFP today")
- [ ] Tap `−` on BFP workers → stops at 1
- [ ] Tap `−` on Shape workers → counts down past 1 to 0; stepper card stays visible; `−` disables at 0
- [ ] Set shape to 0, reload → stepper shows 0 (persisted via localStorage + log)
- [ ] `?role=bfp` worker view on a day with no BFP orders → still shows "all clear" (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)