### PR TITLE
Filter all dip SKUs from shape/BFP schedule

### DIFF
--- a/static/production/index.html
+++ b/static/production/index.html
@@ -1862,7 +1862,7 @@
             let key = sku.trim();
             if (skuAliases[key]) key = skuAliases[key]; // resolve old → canonical name
             if (isFOH(key)) { fohSeen.add(key); return; }
-            if (key === CHEESE_KEY) return; // cheese has its own pipeline (Cheese tab); shape/BFP teams don't make it
+            if (DIP_CONFIG[key]) return; // dips have their own pipeline (Dips tab); shape/BFP teams don't make them
             if (!skuMap[key]) skuMap[key] = { shapePretzels: 0, bfpPretzels: 0, orders: [] };
             const q = Number(quantity) || 0;
             skuMap[key].shapePretzels += q;


### PR DESCRIPTION
## Summary
- `buildOptimalSchedule` was only filtering `CHEESE_KEY` (`3oz cheese dip`) from the shape/BFP pool; the other four `DIP_CONFIG` SKUs (`hot ranch dip`, `sweet cream dip`, `house mustard dip`, `honey mustard dip`) were passing through and appearing on the shape team card
- Changed the filter from `if (key === CHEESE_KEY)` to `if (DIP_CONFIG[key])` so all five dip SKUs share the same exclusion path

## Test URLs
- Before: https://main--website--dangpretz.hlx.page/static/production/index.html
- After: https://fix-dips-shape-filter--website--dangpretz.hlx.page/static/production/index.html

## Test plan
- [ ] Open shape tab — none of the dip SKUs (cheese dip, hot ranch, sweet cream, house mustard, honey mustard) appear
- [ ] Open BFP tab — same, no dip SKUs
- [ ] Open Dips tab — all dip SKUs still appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)