### PR TITLE
Fix rep email not saving to log

### DIFF
--- a/static/sales/index.html
+++ b/static/sales/index.html
@@ -2308,9 +2308,8 @@ function renderSettings() {
     document.querySelectorAll('[data-save-rep]').forEach(btn => {
       btn.addEventListener('click', async () => {
         const id = btn.dataset.saveRep;
-        const card = btn.closest('[style*="border"]');
-        const name = card?.querySelector(`.rep-name-input[data-rep-id="${id}"]`)?.value.trim();
-        const email = card?.querySelector(`.rep-email-input[data-rep-id="${id}"]`)?.value.trim().toLowerCase() || '';
+        const name = document.querySelector(`.rep-name-input[data-rep-id="${id}"]`)?.value.trim();
+        const email = document.querySelector(`.rep-email-input[data-rep-id="${id}"]`)?.value.trim().toLowerCase() || '';
         if (!name) { toast('Rep name is required.'); return; }
         const rep = STATE.repRegistry.find(r => r.id === id);
         const entry = { action: 'set_rep', id, label: name, email, pwdHash: rep?.pwdHash || '', timeStamp: new Date().toISOString() };


### PR DESCRIPTION
## Summary
- Fixes a bug where saving a rep's info in Settings → Sales Team would silently drop their email, writing an empty string to the log
- The `closest('[style*="border"]')` DOM traversal could return `null` if the inline style was resolved differently, causing both the name and email inputs to read as `undefined`
- Replaced with `document.querySelector('.rep-email-input[data-rep-id="…"]')` which is unique and always reliable

## How to fix the affected rep
After this is merged, the admin should go to **Settings → Sales Team**, re-enter the rep's email, and click **Save**. This writes a new `set_rep` log entry with the correct email. The rep can then log in by email on any device.

## Test plan
- [ ] Admin opens Settings → Sales Team, sets a name and email for a rep, clicks Save → toast appears
- [ ] Rep can log in by email on a different device (fresh localStorage)
- [ ] Saving with a blank email still works (stores empty string, rep uses password-only login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)